### PR TITLE
docs(app): affirm /screenalytics as canonical admin label

### DIFF
--- a/apps/web/src/components/admin/ScreenalyticsPickerPage.tsx
+++ b/apps/web/src/components/admin/ScreenalyticsPickerPage.tsx
@@ -131,7 +131,8 @@ export default function ScreenalyticsPickerPage() {
           <h1 className="text-3xl font-bold text-zinc-900">Screenalytics</h1>
           <p className="mt-1 text-sm text-zinc-600">
             Pick a show, then jump into its admin workspace for screen-time and related review flows. This picker lives
-            in TRR-APP and is separate from the retiring legacy screenalytics repo UI.
+            in TRR-APP, remains the canonical admin label for this workflow, and is separate from the retired legacy
+            screenalytics repo UI.
           </p>
         </div>
 

--- a/apps/web/src/lib/admin/admin-navigation.ts
+++ b/apps/web/src/lib/admin/admin-navigation.ts
@@ -38,7 +38,7 @@ export const ADMIN_NAV_ITEMS: readonly AdminNavItem[] = [
     title: "Screenalytics",
     href: "/screenalytics" as Route,
     description:
-      "TRR-APP admin entry for screen-time workflows. Pick a show here, then continue into its /<show> workspace.",
+      "Canonical TRR-APP admin entry for screen-time workflows. Pick a show here, then continue into its /<show> workspace.",
     badge: "Screen",
     activeMatchPrefixes: ["/screenalytics", "/screenlaytics", "/admin/screenalytics", "/admin/screenlaytics", "/admin/trr-shows"],
   },


### PR DESCRIPTION
## Summary
- affirm `/screenalytics` as the canonical TRR-owned admin label
- tighten copy in the admin navigation and picker page
- keep routes and compatibility aliases unchanged

## Validation
- `pnpm -C apps/web exec vitest run tests/admin-navigation.test.ts tests/admin-route-audit.test.ts tests/admin-ia-section.test.tsx`
- `pnpm -C apps/web run lint`
- `NEXT_PUBLIC_FIREBASE_API_KEY=test NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=test.firebaseapp.com NEXT_PUBLIC_FIREBASE_PROJECT_ID=test NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=test.appspot.com NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=123456 NEXT_PUBLIC_FIREBASE_APP_ID=1:123456:web:test pnpm -C apps/web exec next build --webpack`

## Notes
- local `pnpm -C apps/web run test:ci` is not clean on a fresh `origin/main` worktree due unrelated existing failures in broad social-profile and system-health test surfaces outside this change set
- this PR intentionally does not rename `/screenalytics` or remove compatibility aliases