### PR TITLE
feat(admin): Instagram comments tab + per-post Scrape Comments button

### DIFF
--- a/apps/web/src/app/admin/social/[platform]/[handle]/comments/page.tsx
+++ b/apps/web/src/app/admin/social/[platform]/[handle]/comments/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+
+type PageProps = {
+  params: Promise<{ platform: string; handle: string }>;
+};
+
+/**
+ * Legacy comments page (P0-1b). The canonical route is `/social/.../comments`.
+ * This redirect exists so inbound links from the `/admin/social/` tree keep
+ * working until the broader admin URL migration happens.
+ */
+export default async function LegacyAdminSocialAccountProfileCommentsPage({ params }: PageProps) {
+  const resolved = await params;
+  redirect(
+    `/social/${encodeURIComponent(resolved.platform)}/${encodeURIComponent(resolved.handle)}/comments`,
+  );
+}

--- a/apps/web/src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx
+++ b/apps/web/src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx
@@ -180,6 +180,9 @@ import {
 } from "./refresh-progress";
 
 const GETTY_RESULTS_PER_PAGE = 60;
+const CREDITS_READ_MAX_ATTEMPTS = 2;
+const CREDITS_READ_FALLBACK_RETRY_MS = 250;
+const CREDITS_READ_MAX_RETRY_MS = 1_000;
 
 function estimateGettyPageTotal(siteImageTotal: number | null | undefined): number {
   if (typeof siteImageTotal !== "number" || !Number.isFinite(siteImageTotal) || siteImageTotal <= 0) {
@@ -1142,6 +1145,46 @@ const isSignalAbortedWithoutReasonError = (error: unknown): boolean => {
 const isAdminRequestTimeoutError = (error: unknown): boolean =>
   error instanceof AdminRequestError &&
   (error.code === "REQUEST_TIMEOUT" || error.status === 408);
+
+const isRetryableCreditsReadError = (error: unknown): error is AdminRequestError =>
+  error instanceof AdminRequestError &&
+  (isAdminRequestTimeoutError(error) ||
+    (error.retryable &&
+      (error.code === "DATABASE_SERVICE_UNAVAILABLE" ||
+        error.reason === "pool_capacity" ||
+        error.reason === "session_pool_capacity" ||
+        error.reason === "queue_pressure")));
+
+const resolveCreditsRetryDelayMs = (error: AdminRequestError): number => {
+  const retryAfterMs =
+    typeof error.retryAfterMs === "number" && Number.isFinite(error.retryAfterMs)
+      ? error.retryAfterMs
+      : CREDITS_READ_FALLBACK_RETRY_MS;
+  return Math.max(1, Math.min(retryAfterMs, CREDITS_READ_MAX_RETRY_MS));
+};
+
+const waitForCreditsRetry = async (
+  retryDelayMs: number,
+  signal?: AbortSignal,
+): Promise<void> =>
+  await new Promise<void>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      signal?.removeEventListener("abort", handleAbort);
+      resolve();
+    }, retryDelayMs);
+
+    const handleAbort = () => {
+      clearTimeout(timeoutId);
+      signal?.removeEventListener("abort", handleAbort);
+      reject(createNamedError("AbortError", "Credits retry aborted"));
+    };
+
+    if (signal?.aborted) {
+      handleAbort();
+      return;
+    }
+    signal?.addEventListener("abort", handleAbort, { once: true });
+  });
 
 const createNamedError = (name: string, message: string): Error => {
   const error = new Error(message);
@@ -3552,6 +3595,7 @@ export default function PersonProfilePage() {
   const photosNextOffsetRef = useRef(photosNextOffset);
   const photosRequestKeyRef = useRef<string | null>(null);
   const photosInFlightRef = useRef<Promise<TrrPersonPhoto[]> | null>(null);
+  const creditsBootstrapRequestKeyRef = useRef<string | null>(null);
   const secondaryReadQueueRef = useRef<Array<() => void>>([]);
   const secondaryReadsInFlightRef = useRef(0);
   const showBrokenPhotoRefetchInitializedRef = useRef(false);
@@ -4446,6 +4490,7 @@ export default function PersonProfilePage() {
   }, [personRouteState.tab]);
 
   useEffect(() => {
+    setPrimaryGalleryReady(false);
     setBravoVideos([]);
     setBravoVideosLoaded(false);
     setBravoVideosError(null);
@@ -4482,8 +4527,11 @@ export default function PersonProfilePage() {
     setFandomLoading(false);
     setCredits([]);
     setShowScopedCredits(null);
+    setCreditsByShow([]);
     setCreditsError(null);
     setCreditsLoading(false);
+    creditsBootstrapRequestKeyRef.current = null;
+    showBrokenPhotoRefetchInitializedRef.current = false;
   }, [personId, showIdForApi]);
 
   useEffect(
@@ -5312,12 +5360,29 @@ export default function PersonProfilePage() {
     runSecondaryRead,
   });
 
-  usePersonProfileLoad({
+  const { personProfileReady } = usePersonProfileLoad({
     hasAccess,
     personId,
     fetchPerson,
     setLoading,
   });
+  const showRouteIdentifiersReady = !showIdParam || looksLikeUuid(showIdParam) || Boolean(showIdForApi);
+  const personBootstrapPhase = useMemo(() => {
+    if (!hasAccess) return "unauthorized";
+    if (!personRouteParam) return "missing_person";
+    if (!personId) return "resolving_person_slug";
+    if (!showRouteIdentifiersReady) return "resolving_show_slug";
+    if (!personProfileReady || !person) return "loading_person";
+    if (!primaryGalleryReady) return "loading_gallery";
+    return "ready";
+  }, [hasAccess, person, personId, personProfileReady, personRouteParam, primaryGalleryReady, showRouteIdentifiersReady]);
+  const personBootstrapReady =
+    Boolean(personId) && showRouteIdentifiersReady && personProfileReady && Boolean(person) && primaryGalleryReady;
+  const buildPersonPageReadDiagnosticMessage = useCallback(
+    (message: string) =>
+      `${message} [bootstrap=${personBootstrapPhase} tab=${activeTab} person=${personId || personRouteParam || "missing"} show=${showIdForApi ?? showIdParam ?? "none"}]`,
+    [activeTab, personBootstrapPhase, personId, personRouteParam, showIdForApi, showIdParam],
+  );
 
   const fetchBestActivePersonPipelineOperation = useCallback(
     async (operationTypes?: readonly PersonPipelineOperationType[]) => {
@@ -5832,62 +5897,102 @@ export default function PersonProfilePage() {
     });
     try {
       setCreditsLoading(true);
+      setCreditsError(null);
       const headers = await getAuthHeaders();
       const params = new URLSearchParams();
       params.set("limit", "500");
       if (showIdForApi) {
         params.set("showId", showIdForApi);
       }
-      const data = await adminGetJson<{
-        credits?: TrrPersonCredit[];
-        show_scope?: PersonCreditShowScope;
-        credits_by_show?: PersonCreditsByShow[];
-      }>(`/api/admin/trr-api/people/${personId}/credits?${params.toString()}`, {
-        headers,
-        externalSignal: signal,
-        requestRole: "secondary",
-        dedupeKey: `person:${personId}:credits:${params.toString()}`,
-      });
-      if (signal?.aborted) return;
-      setCredits(Array.isArray(data.credits) ? data.credits : []);
-      setShowScopedCredits(
-        data.show_scope && typeof data.show_scope === "object"
-          ? (data.show_scope as PersonCreditShowScope)
-          : null
-      );
-      setCreditsByShow(Array.isArray(data.credits_by_show) ? data.credits_by_show : []);
-      setCreditsError(null);
-      logAdminPageReadDiagnostic({
-        pageFamily: "people-gallery",
-        resource: "credits",
-        requestRole: "secondary",
-        phase: "success",
-        durationMs: Date.now() - startedAt,
-        payloadBytes: measurePayloadBytes({
-          credits: Array.isArray(data.credits) ? data.credits : [],
-          show_scope: data.show_scope ?? null,
-          credits_by_show: Array.isArray(data.credits_by_show) ? data.credits_by_show : [],
-        }),
-      });
-    } catch (err) {
-      if (signal?.aborted || isAbortError(err) || isSignalAbortedWithoutReasonError(err)) return;
-      setCredits([]);
-      setShowScopedCredits(null);
-      setCreditsByShow([]);
-      setCreditsError(err instanceof Error ? err.message : "Failed to fetch credits");
-      logAdminPageReadDiagnostic({
-        pageFamily: "people-gallery",
-        resource: "credits",
-        requestRole: "secondary",
-        phase: "error",
-        durationMs: Date.now() - startedAt,
-        message: err instanceof Error ? err.message : "Failed to fetch credits",
-      });
-      console.error("Failed to fetch credits:", err);
+
+      for (let attempt = 1; attempt <= CREDITS_READ_MAX_ATTEMPTS; attempt += 1) {
+        try {
+          const data = await adminGetJson<{
+            credits?: TrrPersonCredit[];
+            show_scope?: PersonCreditShowScope;
+            credits_by_show?: PersonCreditsByShow[];
+          }>(`/api/admin/trr-api/people/${personId}/credits?${params.toString()}`, {
+            headers,
+            externalSignal: signal,
+            requestRole: "secondary",
+            dedupeKey: `person:${personId}:credits:${params.toString()}`,
+          });
+          if (signal?.aborted) return;
+          setCredits(Array.isArray(data.credits) ? data.credits : []);
+          setShowScopedCredits(
+            data.show_scope && typeof data.show_scope === "object"
+              ? (data.show_scope as PersonCreditShowScope)
+              : null
+          );
+          setCreditsByShow(Array.isArray(data.credits_by_show) ? data.credits_by_show : []);
+          setCreditsError(null);
+          logAdminPageReadDiagnostic({
+            pageFamily: "people-gallery",
+            resource: "credits",
+            requestRole: "secondary",
+            phase: "success",
+            durationMs: Date.now() - startedAt,
+            payloadBytes: measurePayloadBytes({
+              credits: Array.isArray(data.credits) ? data.credits : [],
+              show_scope: data.show_scope ?? null,
+              credits_by_show: Array.isArray(data.credits_by_show) ? data.credits_by_show : [],
+            }),
+          });
+          return;
+        } catch (err) {
+          if (signal?.aborted || isAbortError(err) || isSignalAbortedWithoutReasonError(err)) return;
+          if (isRetryableCreditsReadError(err) && attempt < CREDITS_READ_MAX_ATTEMPTS) {
+            setCredits([]);
+            setShowScopedCredits(null);
+            setCreditsByShow([]);
+            logAdminPageReadDiagnostic({
+              pageFamily: "people-gallery",
+              resource: "credits",
+              requestRole: "secondary",
+              phase: "error",
+              durationMs: Date.now() - startedAt,
+              message: buildPersonPageReadDiagnosticMessage(
+                `Retrying transient credits read failure (attempt ${attempt}/${CREDITS_READ_MAX_ATTEMPTS}): ${err.message}`,
+              ),
+            });
+            try {
+              await waitForCreditsRetry(resolveCreditsRetryDelayMs(err), signal);
+            } catch (retryErr) {
+              if (
+                signal?.aborted ||
+                isAbortError(retryErr) ||
+                isSignalAbortedWithoutReasonError(retryErr) ||
+                (retryErr instanceof Error && retryErr.name === "AbortError")
+              ) {
+                return;
+              }
+              throw retryErr;
+            }
+            continue;
+          }
+
+          setCredits([]);
+          setShowScopedCredits(null);
+          setCreditsByShow([]);
+          setCreditsError(err instanceof Error ? err.message : "Failed to fetch credits");
+          logAdminPageReadDiagnostic({
+            pageFamily: "people-gallery",
+            resource: "credits",
+            requestRole: "secondary",
+            phase: "error",
+            durationMs: Date.now() - startedAt,
+            message: buildPersonPageReadDiagnosticMessage(
+              err instanceof Error ? err.message : "Failed to fetch credits",
+            ),
+          });
+          console.error("Failed to fetch credits:", err);
+          return;
+        }
+      }
     } finally {
       setCreditsLoading(false);
     }
-  }, [personId, getAuthHeaders, showIdForApi]);
+  }, [buildPersonPageReadDiagnosticMessage, getAuthHeaders, personId, showIdForApi]);
 
   // Fetch cover photo
   const fetchCoverPhoto = useCallback(async (options?: { signal?: AbortSignal }) => {
@@ -9854,8 +9959,7 @@ export default function PersonProfilePage() {
   useEffect(() => {
     if (!hasAccess) return;
     if (!personId) return;
-    setPrimaryGalleryReady(false);
-    showBrokenPhotoRefetchInitializedRef.current = false;
+    if (!person) return;
     let cancelled = false;
     const controller = new AbortController();
     const { signal } = controller;
@@ -9873,6 +9977,15 @@ export default function PersonProfilePage() {
         });
       } catch (err) {
         if (signal.aborted) return;
+        logAdminPageReadDiagnostic({
+          pageFamily: "people-gallery",
+          resource: "bootstrap-gallery",
+          requestRole: "primary",
+          phase: "error",
+          message: buildPersonPageReadDiagnosticMessage(
+            err instanceof Error ? err.message : "Failed to load person gallery bootstrap",
+          ),
+        });
         console.error("Failed to load person page data:", err);
       } finally {
         if (!cancelled && !signal.aborted) {
@@ -9887,11 +10000,14 @@ export default function PersonProfilePage() {
       controller.abort();
       secondaryReadQueueRef.current = [];
     };
-  }, [hasAccess, fetchCoverPhoto, fetchPhotos, personId, runSecondaryRead]);
+  }, [buildPersonPageReadDiagnosticMessage, hasAccess, fetchCoverPhoto, fetchPhotos, person, personId, runSecondaryRead]);
 
   useEffect(() => {
     if (activeTab !== "credits") return;
-    if (!hasAccess || !personId || creditsLoading || credits.length > 0) return;
+    if (!hasAccess || !personBootstrapReady || credits.length > 0) return;
+    const creditsRequestKey = `${personId}:${showIdForApi ?? showIdParam ?? "none"}`;
+    if (creditsBootstrapRequestKeyRef.current === creditsRequestKey) return;
+    creditsBootstrapRequestKeyRef.current = creditsRequestKey;
     const controller = new AbortController();
     void runSecondaryRead(async () => {
       await fetchCredits({ signal: controller.signal });
@@ -9899,11 +10015,21 @@ export default function PersonProfilePage() {
     return () => {
       controller.abort();
     };
-  }, [activeTab, credits.length, creditsLoading, fetchCredits, hasAccess, personId, runSecondaryRead]);
+  }, [
+    activeTab,
+    credits.length,
+    fetchCredits,
+    hasAccess,
+    personBootstrapReady,
+    personId,
+    runSecondaryRead,
+    showIdForApi,
+    showIdParam,
+  ]);
 
   useEffect(() => {
     if (activeTab !== "videos") return;
-    if (!showIdForApi || bravoVideosLoaded) return;
+    if (!personBootstrapReady || !showIdForApi || bravoVideosLoaded) return;
     const controller = new AbortController();
     void runSecondaryRead(async () => {
       await fetchBravoVideos({ signal: controller.signal });
@@ -9911,7 +10037,7 @@ export default function PersonProfilePage() {
     return () => {
       controller.abort();
     };
-  }, [activeTab, bravoVideosLoaded, fetchBravoVideos, runSecondaryRead, showIdForApi]);
+  }, [activeTab, bravoVideosLoaded, fetchBravoVideos, personBootstrapReady, runSecondaryRead, showIdForApi]);
 
   useEffect(() => {
     if (!hasAccess || !personId) return;
@@ -9950,7 +10076,7 @@ export default function PersonProfilePage() {
 
   useEffect(() => {
     if (activeTab !== "news") return;
-    if (!showIdForApi || !personId) return;
+    if (!personBootstrapReady || !showIdForApi || !personId) return;
     const controller = new AbortController();
     void runSecondaryRead(async () => {
       await loadUnifiedNews();
@@ -9958,11 +10084,11 @@ export default function PersonProfilePage() {
     return () => {
       controller.abort();
     };
-  }, [activeTab, loadUnifiedNews, personId, runSecondaryRead, showIdForApi]);
+  }, [activeTab, loadUnifiedNews, personBootstrapReady, personId, runSecondaryRead, showIdForApi]);
 
   useEffect(() => {
     if (activeTab !== "fandom") return;
-    if (!hasAccess || fandomLoaded) return;
+    if (!hasAccess || !personBootstrapReady || fandomLoaded) return;
     const controller = new AbortController();
     void runSecondaryRead(async () => {
       await fetchFandomData({ signal: controller.signal });
@@ -9970,7 +10096,7 @@ export default function PersonProfilePage() {
     return () => {
       controller.abort();
     };
-  }, [activeTab, fandomLoaded, fetchFandomData, hasAccess, runSecondaryRead]);
+  }, [activeTab, fandomLoaded, fetchFandomData, hasAccess, personBootstrapReady, runSecondaryRead]);
 
   const newsSourceOptions = useMemo(
     () => newsFacets.sources,

--- a/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/comments/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/comments/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/server/auth";
+import {
+  fetchSocialBackendJson,
+  socialProxyErrorResponse,
+} from "@/lib/server/trr-api/social-admin-proxy";
+
+export const dynamic = "force-dynamic";
+
+type RouteContext = {
+  params: Promise<{ platform: string; handle: string }>;
+};
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  try {
+    await requireAdmin(request);
+    const { platform, handle } = await context.params;
+    const queryString = request.nextUrl.searchParams.toString();
+    const data = await fetchSocialBackendJson(
+      `/profiles/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/comments`,
+      {
+        queryString,
+        fallbackError: "Failed to fetch social account comments",
+        retries: 0,
+        timeoutMs: 30_000,
+      },
+    );
+    return NextResponse.json(data);
+  } catch (error) {
+    return socialProxyErrorResponse(error, "[api] Failed to fetch social account comments");
+  }
+}

--- a/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/comments/runs/[runId]/progress/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/comments/runs/[runId]/progress/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/server/auth";
+import {
+  fetchSocialBackendJson,
+  socialProxyErrorResponse,
+} from "@/lib/server/trr-api/social-admin-proxy";
+
+export const dynamic = "force-dynamic";
+
+type RouteContext = {
+  params: Promise<{ platform: string; handle: string; runId: string }>;
+};
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  try {
+    await requireAdmin(request);
+    const { platform, handle, runId } = await context.params;
+    const queryString = request.nextUrl.searchParams.toString();
+    const data = await fetchSocialBackendJson(
+      `/profiles/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/comments/runs/${encodeURIComponent(runId)}/progress`,
+      {
+        queryString,
+        fallbackError: "Failed to fetch social account comments scrape progress",
+        retries: 0,
+        timeoutMs: 30_000,
+      },
+    );
+    return NextResponse.json(data);
+  } catch (error) {
+    return socialProxyErrorResponse(error, "[api] Failed to fetch social account comments scrape progress");
+  }
+}

--- a/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/comments/scrape/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/comments/scrape/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/server/auth";
+import {
+  fetchSocialBackendJson,
+  socialProxyErrorResponse,
+} from "@/lib/server/trr-api/social-admin-proxy";
+
+export const dynamic = "force-dynamic";
+
+type RouteContext = {
+  params: Promise<{ platform: string; handle: string }>;
+};
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  try {
+    await requireAdmin(request);
+    const { platform, handle } = await context.params;
+    const body = await request.text();
+    const data = await fetchSocialBackendJson(
+      `/profiles/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/comments/scrape`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+        fallbackError: "Failed to start social account comments scrape",
+        retries: 0,
+        timeoutMs: 210_000,
+      },
+    );
+    return NextResponse.json(data);
+  } catch (error) {
+    return socialProxyErrorResponse(error, "[api] Failed to start social account comments scrape");
+  }
+}

--- a/apps/web/src/app/social/[platform]/[handle]/comments/page.tsx
+++ b/apps/web/src/app/social/[platform]/[handle]/comments/page.tsx
@@ -1,0 +1,39 @@
+import { notFound, redirect } from "next/navigation";
+import SocialAccountProfilePage from "@/components/admin/SocialAccountProfilePage";
+import {
+  SOCIAL_ACCOUNT_PROFILE_PLATFORMS,
+  type SocialPlatformSlug,
+} from "@/lib/admin/social-account-profile";
+import { normalizeSocialAccountProfileHandle } from "@/lib/admin/show-admin-routes";
+
+type PageProps = {
+  params: Promise<{ platform: string; handle: string }>;
+};
+
+const isValidHandle = (value: string): boolean => /^[a-z0-9._-]{1,64}$/i.test(value);
+
+/**
+ * Canonical comments page (P0-1b). New admin pages live under `/social/...` —
+ * the `/admin/social/...` tree is legacy and its `comments` sibling redirects
+ * here. See `feedback_app_url_conventions.md` in memory and the Locked Decisions
+ * section of `instagram-comments-scrapling-fixes.md`.
+ */
+export default async function SocialAccountProfileCommentsPage({ params }: PageProps) {
+  const resolved = await params;
+  const platform = resolved.platform.trim().toLowerCase();
+  const rawHandle = resolved.handle.trim().replace(/^@+/, "").toLowerCase();
+  if (!SOCIAL_ACCOUNT_PROFILE_PLATFORMS.includes(platform as (typeof SOCIAL_ACCOUNT_PROFILE_PLATFORMS)[number])) {
+    notFound();
+  }
+  if (!isValidHandle(rawHandle)) {
+    notFound();
+  }
+  const handle = normalizeSocialAccountProfileHandle(rawHandle);
+  if (!handle) {
+    notFound();
+  }
+  if (rawHandle !== handle) {
+    redirect(`/social/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/comments`);
+  }
+  return <SocialAccountProfilePage platform={platform as SocialPlatformSlug} handle={handle} activeTab="comments" />;
+}

--- a/apps/web/src/components/admin/SocialAccountProfilePage.tsx
+++ b/apps/web/src/components/admin/SocialAccountProfilePage.tsx
@@ -7,6 +7,8 @@ import ClientOnly from "@/components/ClientOnly";
 import AdminBreadcrumbs from "@/components/admin/AdminBreadcrumbs";
 import AdminGlobalHeader from "@/components/admin/AdminGlobalHeader";
 import SocialAccountProfileHashtagTimelineChart from "@/components/admin/SocialAccountProfileHashtagTimelineChart";
+import InstagramCommentsPanel from "@/components/admin/instagram/InstagramCommentsPanel";
+import PostScrapeCommentsButton from "@/components/admin/instagram/PostScrapeCommentsButton";
 import SocialGrowthSection from "@/components/admin/social-growth-section";
 import {
   type SocialAccountCatalogGapAnalysis,
@@ -235,6 +237,13 @@ const formatDateTime = (value?: string | null): string => {
   if (Number.isNaN(parsed.getTime())) return value;
   return parsed.toLocaleString();
 };
+
+const buildLocalCatalogCommand = (
+  platform: SocialPlatformSlug,
+  handle: string,
+  action: "backfill" | "fill_missing_photos",
+): string =>
+  `cd ~/Projects/TRR/TRR-Backend && source .venv/bin/activate && python3 scripts/socials/local_catalog_action.py --platform ${platform} --account ${handle} --action ${action}`;
 
 const formatDiagnosticToken = (value?: string | null): string => {
   const normalized = String(value || "").trim();
@@ -977,7 +986,9 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   const [catalogPage, setCatalogPage] = useState(1);
   const [catalogFilter, setCatalogFilter] = useState<"all" | "assigned" | "unassigned" | "ambiguous" | "needs_review">("all");
   const [catalogActionMessage, setCatalogActionMessage] = useState<string | null>(null);
-  const [runningCatalogAction, setRunningCatalogAction] = useState<"backfill" | "repair_auth" | "sync_recent" | "sync_newer" | null>(null);
+  const [runningCatalogAction, setRunningCatalogAction] = useState<
+    "backfill" | "fill_missing_photos" | "repair_auth" | "sync_recent" | "sync_newer" | null
+  >(null);
   const [reviewQueue, setReviewQueue] = useState<SocialAccountCatalogReviewItem[]>([]);
   const [reviewQueueLoading, setReviewQueueLoading] = useState(false);
   const [reviewQueueError, setReviewQueueError] = useState<string | null>(null);
@@ -1040,6 +1051,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   const [cookieRefreshMessage, setCookieRefreshMessage] = useState<string | null>(null);
 
   const supportsCatalog = SOCIAL_ACCOUNT_CATALOG_ENABLED_PLATFORMS.includes(platform);
+  const supportsComments = platform === "instagram";
   const supportsSocialBlade = SOCIAL_ACCOUNT_SOCIALBLADE_ENABLED_PLATFORMS.includes(platform);
   const hasSummary = summary !== null;
   const shouldDeferSecondaryCatalogReads =
@@ -1086,9 +1098,9 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   const visibleTabs = useMemo(
     () =>
       (Object.keys(SOCIAL_ACCOUNT_PROFILE_TAB_LABELS) as SocialAccountProfileTab[]).filter(
-        (tab) => tab !== "socialblade" || supportsSocialBlade,
+        (tab) => (tab !== "socialblade" || supportsSocialBlade) && (tab !== "comments" || supportsComments),
       ),
-    [supportsSocialBlade],
+    [supportsComments, supportsSocialBlade],
   );
   const isLocalDevHost = useMemo(() => {
     return typeof window !== "undefined" && isLocalDevHostname(window.location.hostname);
@@ -1806,6 +1818,16 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     return supportsCatalog && displayTotalPosts !== displayCatalogTotalPosts;
   }, [displayCatalogTotalPosts, displayTotalPosts, supportsCatalog]);
 
+  const postsSummaryLabel = useMemo(() => {
+    // All catalog-supporting platforms use "Saved / Account total" after the
+    // label refresh. The narrow Instagram-only condition was a pre-existing
+    // Codex inconsistency vs. the runtime test at line ~284 (twitter case).
+    if (supportsCatalog) {
+      return "Saved / Account total";
+    }
+    return "Cataloged / Profile total";
+  }, [supportsCatalog]);
+
   const applyCatalogGapAnalysisStatus = useCallback(
     (payload: CatalogGapAnalysisStatusPayload) => {
       const normalizedStatus = payload.status ?? "idle";
@@ -2393,7 +2415,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
 
   const catalogGapAnalysisPresentation = useMemo(() => {
     if (!catalogGapAnalysis) return null;
-    const sampleIds = catalogGapAnalysis.sample_missing_source_ids.slice(0, 5).join(", ");
+    const sampleIds = (catalogGapAnalysis.sample_missing_source_ids ?? []).slice(0, 5).join(", ");
     if (catalogGapAnalysis.gap_type === "tail_gap") {
       return {
         tone: "border-amber-200 bg-amber-50 text-amber-900",
@@ -3252,6 +3274,113 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     }
   };
 
+  const copyLocalCatalogCommand = async (action: "backfill" | "fill_missing_photos") => {
+    const clipboard = navigator.clipboard;
+    if (!clipboard?.writeText) {
+      setCatalogActionMessage("Clipboard copy is unavailable in this browser.");
+      return;
+    }
+    try {
+      await clipboard.writeText(buildLocalCatalogCommand(platform, handle, action));
+      setCatalogActionMessage(
+        action === "backfill"
+          ? "Copied Backfill Posts terminal command."
+          : "Copied Fill Missing Photos terminal command.",
+      );
+    } catch (error) {
+      setCatalogActionMessage(error instanceof Error ? error.message : "Failed to copy terminal command.");
+    }
+  };
+
+  const runFillMissingPhotos = async () => {
+    if (!user) return;
+    setRunningCatalogAction("fill_missing_photos");
+    setCatalogActionMessage(null);
+    setCatalogGapAnalysisError(null);
+    try {
+      const response = await fetchAdminWithAuth(
+        `/api/admin/trr-api/social/profiles/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/catalog/gap-analysis/run`,
+        { method: "POST" },
+        { preferredUser: user },
+      );
+      const data = (await response.json().catch(() => ({}))) as CatalogGapAnalysisStatusPayload;
+      if (!response.ok) {
+        throw buildSocialAccountRequestError(data, "Failed to start social account catalog gap analysis");
+      }
+
+      applyCatalogGapAnalysisStatus(data);
+
+      let result = data.result ?? null;
+      let status = data.status ?? "idle";
+      let attempts = 0;
+
+      while (!result && (status === "queued" || status === "running") && attempts < 30) {
+        attempts += 1;
+        await new Promise<void>((resolve) => {
+          window.setTimeout(resolve, CATALOG_GAP_ANALYSIS_POLL_INTERVAL_MS);
+        });
+        const statusResponse = await fetchAdminWithAuth(
+          `/api/admin/trr-api/social/profiles/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/catalog/gap-analysis`,
+          undefined,
+          { preferredUser: user },
+        );
+        const statusData = (await statusResponse.json().catch(() => ({}))) as CatalogGapAnalysisStatusPayload;
+        if (!statusResponse.ok) {
+          throw buildSocialAccountRequestError(statusData, "Failed to fetch social account catalog gap analysis");
+        }
+        applyCatalogGapAnalysisStatus(statusData);
+        result = statusData.result ?? null;
+        status = statusData.status ?? "idle";
+      }
+
+      if (!result) {
+        if (status === "failed") {
+          throw new Error("Failed to analyze social account catalog gaps");
+        }
+        throw new Error("Catalog gap analysis did not return a repair recommendation.");
+      }
+
+      if (result.recommended_action === "sync_newer") {
+        await runCatalogAction("sync_newer", {
+          source_scope: activeCatalogSourceScope,
+        });
+        return;
+      }
+
+      if (result.recommended_action === "backfill_posts") {
+        await runCatalogAction("backfill", {
+          backfill_scope: "full_history",
+        });
+        return;
+      }
+
+      if (result.recommended_action === "bounded_window_backfill") {
+        if (!result.repair_window_start || !result.repair_window_end) {
+          throw new Error("Gap analysis requested a bounded repair window without dates.");
+        }
+        await runCatalogAction("backfill", {
+          backfill_scope: "bounded_window",
+          date_start: result.repair_window_start,
+          date_end: result.repair_window_end,
+        });
+        return;
+      }
+
+      if (result.recommended_action === "wait_for_active_run") {
+        setCatalogActionMessage("A catalog run is already active. Wait for it to finish before filling missing posts.");
+        return;
+      }
+
+      setCatalogActionMessage("No missing posts to fill right now.");
+    } catch (error) {
+      setCatalogActionMessage(
+        error instanceof Error ? error.message : "Failed to analyze social account catalog gaps",
+      );
+    } finally {
+      setRunningCatalogAction((current) => (current === "fill_missing_photos" ? null : current));
+    }
+  };
+
   const runCatalogRepairAuth = async (runId: string, requestBody: CatalogRepairAuthRequest = {}) => {
     const normalizedRunId = runId.trim();
     if (!user || !normalizedRunId) return;
@@ -3484,22 +3613,38 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                       >
                         {runningCatalogAction === "backfill" ? "Queueing Backfill…" : "Backfill Posts"}
                       </button>
-                      {platform === "instagram" ? (
-                        <button
-                          type="button"
-                          title="Copy direct backfill command for terminal"
-                          onClick={() => {
-                            const cmd = `cd ~/Projects/TRR/TRR-Backend && source .venv/bin/activate && python3 scripts/socials/instagram/direct_catalog_backfill.py --account ${handle}`;
-                            void navigator.clipboard.writeText(cmd);
-                          }}
-                          className="inline-flex items-center rounded-lg border border-zinc-200 bg-white px-2 py-2 text-sm text-zinc-500 hover:bg-zinc-50 hover:text-zinc-700"
-                        >
-                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
-                            <path d="M7 3.5A1.5 1.5 0 0 1 8.5 2h3.879a1.5 1.5 0 0 1 1.06.44l3.122 3.12A1.5 1.5 0 0 1 17 6.622V12.5a1.5 1.5 0 0 1-1.5 1.5h-1v-3.379a3 3 0 0 0-.879-2.121L10.5 5.379A3 3 0 0 0 8.379 4.5H7v-1Z" />
-                            <path d="M4.5 6A1.5 1.5 0 0 0 3 7.5v9A1.5 1.5 0 0 0 4.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L9.44 6.44A1.5 1.5 0 0 0 8.378 6H4.5Z" />
-                          </svg>
-                        </button>
-                      ) : null}
+                      <button
+                        type="button"
+                        aria-label="Copy terminal command"
+                        title="Copy Backfill Posts terminal command"
+                        onClick={() => void copyLocalCatalogCommand("backfill")}
+                        className="inline-flex items-center rounded-lg border border-zinc-200 bg-white px-2 py-2 text-sm text-zinc-500 hover:bg-zinc-50 hover:text-zinc-700"
+                      >
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
+                          <path d="M7 3.5A1.5 1.5 0 0 1 8.5 2h3.879a1.5 1.5 0 0 1 1.06.44l3.122 3.12A1.5 1.5 0 0 1 17 6.622V12.5a1.5 1.5 0 0 1-1.5 1.5h-1v-3.379a3 3 0 0 0-.879-2.121L10.5 5.379A3 3 0 0 0 8.379 4.5H7v-1Z" />
+                          <path d="M4.5 6A1.5 1.5 0 0 0 3 7.5v9A1.5 1.5 0 0 0 4.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L9.44 6.44A1.5 1.5 0 0 0 8.378 6H4.5Z" />
+                        </svg>
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void runFillMissingPhotos()}
+                        disabled={catalogActionsBlocked}
+                        className="inline-flex rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-900 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {runningCatalogAction === "fill_missing_photos" ? "Analyzing Gaps…" : "Fill Missing Photos"}
+                      </button>
+                      <button
+                        type="button"
+                        aria-label="Copy terminal command"
+                        title="Copy Fill Missing Photos terminal command"
+                        onClick={() => void copyLocalCatalogCommand("fill_missing_photos")}
+                        className="inline-flex items-center rounded-lg border border-zinc-200 bg-white px-2 py-2 text-sm text-zinc-500 hover:bg-zinc-50 hover:text-zinc-700"
+                      >
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
+                          <path d="M7 3.5A1.5 1.5 0 0 1 8.5 2h3.879a1.5 1.5 0 0 1 1.06.44l3.122 3.12A1.5 1.5 0 0 1 17 6.622V12.5a1.5 1.5 0 0 1-1.5 1.5h-1v-3.379a3 3 0 0 0-.879-2.121L10.5 5.379A3 3 0 0 0 8.379 4.5H7v-1Z" />
+                          <path d="M4.5 6A1.5 1.5 0 0 0 3 7.5v9A1.5 1.5 0 0 0 4.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L9.44 6.44A1.5 1.5 0 0 0 8.378 6H4.5Z" />
+                        </svg>
+                      </button>
                       {platform !== "instagram" ? (
                         <button
                           type="button"
@@ -3726,7 +3871,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                       <p className="mt-2 text-2xl font-bold leading-tight text-zinc-900">
                         {formatInteger(displayCatalogTotalPosts)} / {formatInteger(displayTotalPosts)}
                       </p>
-                      <p className="mt-1 text-xs text-zinc-500">Cataloged / Profile total</p>
+                      <p className="mt-1 text-xs text-zinc-500">{postsSummaryLabel}</p>
                     </>
                   ) : (
                     <p className="mt-2 text-2xl font-bold text-zinc-900">{formatInteger(displayTotalPosts)}</p>
@@ -4612,6 +4757,17 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
             )
           ) : null}
 
+          {hasSummary && activeTab === "comments" && supportsComments ? (
+            <InstagramCommentsPanel
+              platform={platform}
+              handle={handle}
+              summary={summary}
+              onSummaryRefresh={async () => {
+                await refreshSummary();
+              }}
+            />
+          ) : null}
+
           {hasSummary && activeTab === "posts" ? (
             <section className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
               <div className="flex items-center justify-between gap-3">
@@ -4637,13 +4793,14 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                           <th className="pb-3 pr-4">Show</th>
                           <th className="pb-3 pr-4">Season</th>
                           <th className="pb-3 pr-4">Metrics</th>
+                          {supportsComments ? <th className="pb-3 pr-4">Comments Lane</th> : null}
                           <th className="pb-3">Published</th>
                         </tr>
                       </thead>
                       <tbody className="divide-y divide-zinc-100">
                         {(posts?.items ?? []).length === 0 ? (
                           <tr>
-                            <td colSpan={5} className="py-6 text-sm text-zinc-500">
+                            <td colSpan={supportsComments ? 6 : 5} className="py-6 text-sm text-zinc-500">
                               No posts found for this account.
                             </td>
                           </tr>
@@ -4680,6 +4837,18 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                                   <div>{formatInteger(item.metrics.comments_count)} comments</div>
                                 </div>
                               </td>
+                              {supportsComments ? (
+                                <td className="py-4 pr-4 align-top text-zinc-700">
+                                  <PostScrapeCommentsButton
+                                    platform={platform}
+                                    handle={handle}
+                                    sourceId={item.source_id}
+                                    onCompleted={async () => {
+                                      await refreshSummary();
+                                    }}
+                                  />
+                                </td>
+                              ) : null}
                               <td className="py-4 align-top text-xs text-zinc-500">{formatDateTime(item.posted_at)}</td>
                             </tr>
                           ))

--- a/apps/web/src/components/admin/instagram/InstagramCommentsPanel.tsx
+++ b/apps/web/src/components/admin/instagram/InstagramCommentsPanel.tsx
@@ -1,0 +1,352 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { fetchAdminWithAuth as fetchAdminWithAuthBase } from "@/lib/admin/client-auth";
+import { useSharedPollingResource } from "@/lib/admin/shared-live-resource";
+import { useAdminGuard } from "@/lib/admin/useAdminGuard";
+import type {
+  SocialAccountCommentsRunProgress,
+  SocialAccountCommentsScrapeRequest,
+  SocialAccountCommentsScrapeResponse,
+  SocialAccountProfileCommentsResponse,
+  SocialAccountProfileSummary,
+  SocialPlatformSlug,
+} from "@/lib/admin/social-account-profile";
+
+type Props = {
+  platform: SocialPlatformSlug;
+  handle: string;
+  summary: SocialAccountProfileSummary | null;
+  onSummaryRefresh?: () => Promise<void> | void;
+};
+
+type ProxyErrorPayload = {
+  error?: string;
+  detail?: string;
+  code?: string;
+  retryable?: boolean;
+  retry_after_seconds?: number;
+  // P2-7: The app proxy extracts the FastAPI `detail.code` into these fields
+  // (see apps/web/src/lib/server/trr-api/social-admin-proxy.ts). The UI
+  // branches on `upstream_detail_code` to show actionable copy for the
+  // specific failure modes users can act on.
+  upstream_detail_code?: string;
+  upstream_status?: number;
+  upstream_detail?: unknown;
+};
+
+const ACTIVE_RUN_STATUSES = new Set(["queued", "pending", "retrying", "running"]);
+const TERMINAL_RUN_STATUSES = new Set(["completed", "failed", "cancelled"]);
+// P2-8: 2s matches the existing admin polling cadence used elsewhere on the profile page.
+const COMMENTS_PROGRESS_POLL_INTERVAL_MS = 2_000;
+const PRIMARY_BUTTON_CLASS =
+  "inline-flex rounded-lg border border-zinc-900 bg-zinc-900 px-3 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50";
+
+const formatInteger = (value: number | null | undefined): string => {
+  return new Intl.NumberFormat("en-US").format(Number.isFinite(Number(value)) ? Number(value) : 0);
+};
+
+const formatDateTime = (value?: string | null): string => {
+  if (!value) return "Never";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleString();
+};
+
+const normalizeRunStatus = (value?: string | null): string => String(value || "").trim().toLowerCase();
+
+const readErrorMessage = (payload: ProxyErrorPayload | null | undefined, fallback: string): string => {
+  // P2-7: Map structured backend codes to actionable operator copy.
+  const code = typeof payload?.upstream_detail_code === "string" ? payload.upstream_detail_code : "";
+  if (code === "SOCIAL_WORKER_UNAVAILABLE") {
+    return (
+      "No Instagram comments worker is online. Start one with: " +
+      "TRR_SOCIAL_INGEST_WORKER_ENABLED=1 TRR_SOCIAL_INGEST_WORKER_COMMENTS_SCRAPLING=1 ./scripts/start_remote_job_workers.sh"
+    );
+  }
+  if (code === "instagram_comments_auth_failed") {
+    return "Instagram session expired. Refresh cookies via scripts/socials/cookie_refresh_worker.py.";
+  }
+  if (typeof payload?.error === "string" && payload.error.trim()) return payload.error;
+  if (typeof payload?.detail === "string" && payload.detail.trim()) return payload.detail;
+  return fallback;
+};
+
+export default function InstagramCommentsPanel({ platform, handle, summary, onSummaryRefresh }: Props) {
+  const { user, checking, hasAccess } = useAdminGuard();
+  const fetchAdminWithAuth = useCallback(
+    (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+      options?: Parameters<typeof fetchAdminWithAuthBase>[2],
+    ) =>
+      fetchAdminWithAuthBase(input, init, {
+        ...options,
+        preferredUser: options?.preferredUser ?? user,
+        allowDevAdminBypass: options?.allowDevAdminBypass ?? true,
+      }),
+    [user],
+  );
+  const [comments, setComments] = useState<SocialAccountProfileCommentsResponse | null>(null);
+  const [commentsLoading, setCommentsLoading] = useState(false);
+  const [commentsError, setCommentsError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+  const [scrapeMessage, setScrapeMessage] = useState<string | null>(null);
+  const [scrapeError, setScrapeError] = useState<string | null>(null);
+  const [scrapeRunId, setScrapeRunId] = useState<string | null>(null);
+  const handledTerminalRunRef = useRef<string | null>(null);
+
+  const refreshComments = useCallback(async () => {
+    if (checking || !user || !hasAccess) return;
+    setCommentsLoading(true);
+    setCommentsError(null);
+    try {
+      const response = await fetchAdminWithAuth(
+        `/api/admin/trr-api/social/profiles/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/comments?page=${page}&page_size=25`,
+        undefined,
+        { preferredUser: user },
+      );
+      const data = (await response.json().catch(() => ({}))) as SocialAccountProfileCommentsResponse & ProxyErrorPayload;
+      if (!response.ok) {
+        throw new Error(readErrorMessage(data, "Failed to load Instagram comments"));
+      }
+      setComments(data);
+    } catch (error) {
+      setCommentsError(error instanceof Error ? error.message : "Failed to load Instagram comments");
+    } finally {
+      setCommentsLoading(false);
+    }
+  }, [checking, fetchAdminWithAuth, handle, hasAccess, page, platform, user]);
+
+  useEffect(() => {
+    if (platform !== "instagram") return;
+    void refreshComments();
+  }, [platform, refreshComments]);
+
+  const runProgress = useSharedPollingResource<SocialAccountCommentsRunProgress>({
+    key: `instagram-comments-run:${platform}:${handle}:${scrapeRunId ?? "none"}`,
+    shouldRun: !checking && Boolean(user) && hasAccess && platform === "instagram" && Boolean(scrapeRunId),
+    intervalMs: COMMENTS_PROGRESS_POLL_INTERVAL_MS,
+    fetchData: async (signal) => {
+      const response = await fetchAdminWithAuth(
+        `/api/admin/trr-api/social/profiles/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/comments/runs/${encodeURIComponent(scrapeRunId || "")}/progress`,
+        { signal },
+        { preferredUser: user },
+      );
+      const data = (await response.json().catch(() => ({}))) as SocialAccountCommentsRunProgress & ProxyErrorPayload;
+      if (!response.ok) {
+        throw new Error(readErrorMessage(data, "Failed to load comments scrape progress"));
+      }
+      return data;
+    },
+  });
+
+  useEffect(() => {
+    const progress = runProgress.data;
+    if (!progress) return;
+    const runId = String(progress.run_id || "").trim();
+    const status = normalizeRunStatus(progress.run_status);
+    if (!runId) return;
+    if (ACTIVE_RUN_STATUSES.has(status)) {
+      setScrapeMessage(`Comments scrape ${status}. Run ${runId.slice(0, 8)}.`);
+      setScrapeError(null);
+      return;
+    }
+    if (!TERMINAL_RUN_STATUSES.has(status) || handledTerminalRunRef.current === runId) return;
+    handledTerminalRunRef.current = runId;
+    if (status === "completed") {
+      setScrapeMessage(`Comments scrape completed. Run ${runId.slice(0, 8)}.`);
+      setScrapeError(null);
+      void refreshComments();
+      void onSummaryRefresh?.();
+    } else {
+      setScrapeError(progress.error_message || `Comments scrape ${status}.`);
+    }
+    setScrapeRunId(null);
+  }, [onSummaryRefresh, refreshComments, runProgress.data]);
+
+  useEffect(() => {
+    if (!runProgress.error) return;
+    setScrapeError(runProgress.error);
+    setScrapeRunId(null);
+  }, [runProgress.error]);
+
+  const startProfileScrape = useCallback(async () => {
+    if (!user) return;
+    setScrapeError(null);
+    setScrapeMessage(null);
+    handledTerminalRunRef.current = null;
+    const body: SocialAccountCommentsScrapeRequest = {
+      mode: "profile",
+      source_scope: "bravo",
+      refresh_policy: "stale_or_missing",
+      max_posts: 50,
+      max_comments_per_post: 200,
+    };
+    try {
+      const response = await fetchAdminWithAuth(
+        `/api/admin/trr-api/social/profiles/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/comments/scrape`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        },
+        { preferredUser: user },
+      );
+      const data = (await response.json().catch(() => ({}))) as SocialAccountCommentsScrapeResponse & ProxyErrorPayload;
+      if (!response.ok) {
+        throw new Error(readErrorMessage(data, "Failed to start comments scrape"));
+      }
+      const runId = String(data.run_id || "").trim();
+      setScrapeRunId(runId || null);
+      setScrapeMessage(runId ? `Comments scrape queued. Run ${runId.slice(0, 8)}.` : "Comments scrape queued.");
+    } catch (error) {
+      setScrapeError(error instanceof Error ? error.message : "Failed to start comments scrape");
+    }
+  }, [fetchAdminWithAuth, handle, platform, user]);
+
+  const coverage = summary?.comments_coverage;
+  // P0-1: `Available Posts` must match the saved-post total shown by the Posts card —
+  // `live_catalog_total_posts` first, falling back to `catalog_total_posts`. Do NOT
+  // derive from `coverage.available_posts`; that field conflates the commentable subset
+  // with the saved-post inventory. `Commentable now` stays on `coverage.eligible_posts`.
+  const availablePosts = Number(summary?.live_catalog_total_posts ?? summary?.catalog_total_posts ?? 0);
+  const commentablePosts = Number(coverage?.eligible_posts ?? 0);
+  const runStatus = useMemo(() => normalizeRunStatus(runProgress.data?.run_status), [runProgress.data?.run_status]);
+  const isScraping = Boolean(scrapeRunId) || ACTIVE_RUN_STATUSES.has(runStatus);
+
+  return (
+    <section className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-zinc-900">Instagram Comments</h2>
+          <p className="text-sm text-zinc-500">
+            Review saved comment coverage and run the dedicated Scrapling comments lane for stale or missing posts.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void startProfileScrape()}
+          disabled={isScraping || checking || !user || !hasAccess}
+          className={PRIMARY_BUTTON_CLASS}
+        >
+          {isScraping ? "Scraping Comments..." : "Scrape Comments"}
+        </button>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+        <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Available Posts</p>
+          <p className="mt-2 text-2xl font-bold text-zinc-900">{formatInteger(availablePosts)}</p>
+          <p className="mt-1 text-xs text-zinc-500">Commentable now: {formatInteger(commentablePosts)}</p>
+        </div>
+        <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Missing</p>
+          <p className="mt-2 text-2xl font-bold text-zinc-900">{formatInteger(coverage?.missing_posts)}</p>
+        </div>
+        <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Stale</p>
+          <p className="mt-2 text-2xl font-bold text-zinc-900">{formatInteger(coverage?.stale_posts)}</p>
+        </div>
+        <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Last Run</p>
+          <p className="mt-2 text-sm font-semibold text-zinc-900">{formatDateTime(coverage?.last_comments_run_at)}</p>
+        </div>
+        <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Status</p>
+          <p className="mt-2 text-sm font-semibold capitalize text-zinc-900">
+            {coverage?.last_comments_run_status || "idle"}
+          </p>
+        </div>
+      </div>
+
+      {scrapeMessage ? <p className="mt-4 text-sm text-zinc-600">{scrapeMessage}</p> : null}
+      {scrapeError ? <p className="mt-4 text-sm text-red-700">{scrapeError}</p> : null}
+
+      <div className="mt-6 overflow-x-auto">
+        <table className="min-w-full divide-y divide-zinc-200 text-sm">
+          <thead>
+            <tr className="text-left text-xs uppercase tracking-[0.14em] text-zinc-500">
+              <th className="pb-3 pr-4">Post</th>
+              <th className="pb-3 pr-4">User</th>
+              <th className="pb-3 pr-4">Comment</th>
+              <th className="pb-3 pr-4">Likes</th>
+              <th className="pb-3">Created</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-zinc-100">
+            {commentsLoading ? (
+              <tr>
+                <td colSpan={5} className="py-6 text-sm text-zinc-500">
+                  Loading comments...
+                </td>
+              </tr>
+            ) : commentsError ? (
+              <tr>
+                <td colSpan={5} className="py-6 text-sm text-red-700">
+                  {commentsError}
+                </td>
+              </tr>
+            ) : (comments?.items ?? []).length === 0 ? (
+              <tr>
+                <td colSpan={5} className="py-6 text-sm text-zinc-500">
+                  No comments stored for this account yet.
+                </td>
+              </tr>
+            ) : (
+              (comments?.items ?? []).map((item) => (
+                <tr key={item.id}>
+                  <td className="py-4 pr-4 align-top text-zinc-700">
+                    {item.post_url ? (
+                      <a
+                        href={item.post_url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-xs font-semibold text-blue-600 hover:text-blue-800 hover:underline"
+                      >
+                        {item.post_source_id || "Open post"}
+                      </a>
+                    ) : (
+                      <span>{item.post_source_id || "Unknown post"}</span>
+                    )}
+                  </td>
+                  <td className="py-4 pr-4 align-top text-zinc-700">{item.username || "Unknown"}</td>
+                  <td className="py-4 pr-4 align-top text-zinc-700">
+                    <div className="max-w-xl">
+                      <p className="leading-5 text-zinc-700">{item.text || "No text"}</p>
+                      {item.is_reply ? <p className="mt-1 text-xs text-zinc-500">Reply</p> : null}
+                    </div>
+                  </td>
+                  <td className="py-4 pr-4 align-top text-zinc-700">{formatInteger(item.likes)}</td>
+                  <td className="py-4 align-top text-xs text-zinc-500">{formatDateTime(item.created_at)}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-4 flex items-center justify-between">
+        <button
+          type="button"
+          onClick={() => setPage((current) => Math.max(1, current - 1))}
+          disabled={page <= 1 || commentsLoading}
+          className="rounded-lg border border-zinc-200 px-3 py-2 text-sm font-semibold text-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Previous
+        </button>
+        <div className="text-sm text-zinc-500">
+          Page {comments?.pagination.page ?? page} of {comments?.pagination.total_pages ?? 1}
+        </div>
+        <button
+          type="button"
+          onClick={() => setPage((current) => current + 1)}
+          disabled={Boolean(comments && page >= comments.pagination.total_pages) || commentsLoading}
+          className="rounded-lg border border-zinc-200 px-3 py-2 text-sm font-semibold text-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Next
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/admin/instagram/PostScrapeCommentsButton.tsx
+++ b/apps/web/src/components/admin/instagram/PostScrapeCommentsButton.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { fetchAdminWithAuth as fetchAdminWithAuthBase } from "@/lib/admin/client-auth";
+import { useSharedPollingResource } from "@/lib/admin/shared-live-resource";
+import { useAdminGuard } from "@/lib/admin/useAdminGuard";
+import type {
+  SocialAccountCommentsRunProgress,
+  SocialAccountCommentsScrapeRequest,
+  SocialAccountCommentsScrapeResponse,
+  SocialPlatformSlug,
+} from "@/lib/admin/social-account-profile";
+
+type Props = {
+  platform: SocialPlatformSlug;
+  handle: string;
+  sourceId: string;
+  onCompleted?: () => Promise<void> | void;
+};
+
+type ProxyErrorPayload = {
+  error?: string;
+  detail?: string;
+  // P2-7: Extracted by the admin proxy from FastAPI's `detail.code`. The
+  // button branches on this to show actionable copy for known failure modes.
+  upstream_detail_code?: string;
+  upstream_status?: number;
+};
+
+const ACTIVE_RUN_STATUSES = new Set(["queued", "pending", "retrying", "running"]);
+const TERMINAL_RUN_STATUSES = new Set(["completed", "failed", "cancelled"]);
+// P2-8: Match the 2s cadence used elsewhere in the admin via `useSharedPollingResource`.
+const COMMENTS_PROGRESS_POLL_INTERVAL_MS = 2_000;
+
+const readErrorMessage = (payload: ProxyErrorPayload | null | undefined, fallback: string): string => {
+  // P2-7: Map structured backend codes to actionable operator copy so the
+  // per-post button shows specific guidance, not a generic 400/503.
+  const code = typeof payload?.upstream_detail_code === "string" ? payload.upstream_detail_code : "";
+  if (code === "SOCIAL_WORKER_UNAVAILABLE") {
+    return "No comments worker online — start it, then retry.";
+  }
+  if (code === "instagram_comments_auth_failed") {
+    return "Instagram session expired — refresh cookies, then retry.";
+  }
+  if (typeof payload?.error === "string" && payload.error.trim()) return payload.error;
+  if (typeof payload?.detail === "string" && payload.detail.trim()) return payload.detail;
+  return fallback;
+};
+
+const normalizeRunStatus = (value?: string | null): string => String(value || "").trim().toLowerCase();
+
+export default function PostScrapeCommentsButton({ platform, handle, sourceId, onCompleted }: Props) {
+  const { user, checking, hasAccess } = useAdminGuard();
+  const fetchAdminWithAuth = useCallback(
+    (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+      options?: Parameters<typeof fetchAdminWithAuthBase>[2],
+    ) =>
+      fetchAdminWithAuthBase(input, init, {
+        ...options,
+        preferredUser: options?.preferredUser ?? user,
+        allowDevAdminBypass: options?.allowDevAdminBypass ?? true,
+      }),
+    [user],
+  );
+  const [scrapeRunId, setScrapeRunId] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const handledTerminalRunRef = useRef<string | null>(null);
+
+  const runProgress = useSharedPollingResource<SocialAccountCommentsRunProgress>({
+    key: `instagram-post-comments-run:${platform}:${handle}:${sourceId}:${scrapeRunId ?? "none"}`,
+    shouldRun: !checking && Boolean(user) && hasAccess && Boolean(scrapeRunId),
+    intervalMs: COMMENTS_PROGRESS_POLL_INTERVAL_MS,
+    fetchData: async (signal) => {
+      const response = await fetchAdminWithAuth(
+        `/api/admin/trr-api/social/profiles/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/comments/runs/${encodeURIComponent(scrapeRunId || "")}/progress`,
+        { signal },
+        { preferredUser: user },
+      );
+      const data = (await response.json().catch(() => ({}))) as SocialAccountCommentsRunProgress & ProxyErrorPayload;
+      if (!response.ok) {
+        throw new Error(readErrorMessage(data, "Failed to load comments scrape progress"));
+      }
+      return data;
+    },
+  });
+
+  useEffect(() => {
+    const progress = runProgress.data;
+    if (!progress) return;
+    const runId = String(progress.run_id || "").trim();
+    const status = normalizeRunStatus(progress.run_status);
+    if (!runId) return;
+    if (ACTIVE_RUN_STATUSES.has(status)) {
+      setMessage(`Run ${runId.slice(0, 8)} ${status}.`);
+      setErrorMessage(null);
+      return;
+    }
+    if (!TERMINAL_RUN_STATUSES.has(status) || handledTerminalRunRef.current === runId) return;
+    handledTerminalRunRef.current = runId;
+    if (status === "completed") {
+      setMessage("Comments refreshed.");
+      setErrorMessage(null);
+      void onCompleted?.();
+    } else {
+      setErrorMessage(progress.error_message || `Comments scrape ${status}.`);
+    }
+    setScrapeRunId(null);
+  }, [onCompleted, runProgress.data]);
+
+  useEffect(() => {
+    if (!runProgress.error) return;
+    setErrorMessage(runProgress.error);
+    setScrapeRunId(null);
+  }, [runProgress.error]);
+
+  const startScrape = useCallback(async () => {
+    if (!user) return;
+    handledTerminalRunRef.current = null;
+    setMessage(null);
+    setErrorMessage(null);
+    const body: SocialAccountCommentsScrapeRequest = {
+      mode: "single_post",
+      source_id: sourceId,
+      max_comments_per_post: 500,
+    };
+    try {
+      const response = await fetchAdminWithAuth(
+        `/api/admin/trr-api/social/profiles/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/comments/scrape`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        },
+        { preferredUser: user },
+      );
+      const data = (await response.json().catch(() => ({}))) as SocialAccountCommentsScrapeResponse & ProxyErrorPayload;
+      if (!response.ok) {
+        throw new Error(readErrorMessage(data, "Failed to start comments scrape"));
+      }
+      const runId = String(data.run_id || "").trim();
+      setScrapeRunId(runId || null);
+      setMessage(runId ? `Queued ${runId.slice(0, 8)}.` : "Queued.");
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Failed to start comments scrape");
+    }
+  }, [fetchAdminWithAuth, handle, platform, sourceId, user]);
+
+  const runStatus = normalizeRunStatus(runProgress.data?.run_status);
+  const isRunning = Boolean(scrapeRunId) || ACTIVE_RUN_STATUSES.has(runStatus);
+
+  // P2-8: Defense-in-depth platform guard. Parent SocialAccountProfilePage
+  // already gates rendering on `supportsComments`, but if that guard ever
+  // regresses we must not POST a comments-scrape request for a non-Instagram
+  // platform (the backend would 400 and the user sees a confusing error).
+  // The check must live AFTER all hooks to stay compliant with Rules of Hooks.
+  if (platform !== "instagram") return null;
+
+  return (
+    <div className="flex flex-col items-start gap-1">
+      <button
+        type="button"
+        onClick={() => void startScrape()}
+        disabled={isRunning || checking || !user || !hasAccess}
+        className="inline-flex rounded-lg border border-zinc-900 bg-zinc-900 px-3 py-2 text-xs font-semibold text-white hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {isRunning ? "Scraping..." : "Scrape Comments"}
+      </button>
+      {message ? <p className="text-[11px] text-zinc-500">{message}</p> : null}
+      {errorMessage ? <p className="text-[11px] text-red-700">{errorMessage}</p> : null}
+    </div>
+  );
+}

--- a/apps/web/src/lib/admin/api-references/generated/inventory.ts
+++ b/apps/web/src/lib/admin/api-references/generated/inventory.ts
@@ -4,9 +4,9 @@ import type { AdminApiReferenceInventory } from "@/lib/admin/api-references/type
 export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
   "inventorySchemaVersion": "1.0.0",
   "generatorVersion": "1.0.0",
-  "generatedAt": "2026-04-14T03:54:15.360Z",
-  "sourceCommitSha": "23227b232d514e14b4c772a010dfdd46fab3807b",
-  "overrideDigest": "a29b267e3edd1915ce8b856036892160e0fbd1171e516987d38acd697ee8676b",
+  "generatedAt": "2026-04-15T11:36:50.007Z",
+  "sourceCommitSha": "b510b22e068c42cbc2c4b6a33d84556ab760cbdf",
+  "overrideDigest": "ddca008fc34e0b3820391e86a4d0620aa57e942244342eab2e4b94e2bcfdb211",
   "nodes": [
     {
       "id": "backend:DELETE:/api/v1/admin/brands/logos/options/saved/[assetId]",
@@ -5768,7 +5768,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "set-interval",
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 1410,
+        "line": 1453,
         "matchedText": "setInterval"
       },
       "provenance": "static_scan",
@@ -5799,7 +5799,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "set-interval",
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 7767,
+        "line": 7872,
         "matchedText": "setInterval"
       },
       "provenance": "static_scan",
@@ -12124,6 +12124,73 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "fanoutRisk": "low"
     },
     {
+      "id": "route:GET:/api/admin/trr-api/social/profiles/[platform]/[handle]/comments",
+      "kind": "api_route",
+      "title": "GET /api/admin/trr-api/social/profiles/[platform]/[handle]/comments",
+      "pathPattern": "/api/admin/trr-api/social/profiles/[platform]/[handle]/comments",
+      "symbol": "GET",
+      "sourceFile": "src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/comments/route.ts",
+      "sourceLocator": {
+        "line": 14,
+        "symbol": "GET"
+      },
+      "provenance": "static_scan",
+      "confidence": "high",
+      "verificationStatus": "verified",
+      "basis": [
+        "static_scan:app_api_route"
+      ],
+      "usageTier": "manual",
+      "polls": false,
+      "pollCadenceMs": null,
+      "automatic": false,
+      "loadsLargeDatasets": false,
+      "usesPagination": false,
+      "returnsWideRowsOrBlobsOrRawJson": false,
+      "fansOutQueries": false,
+      "postgresAccess": "none",
+      "viewKinds": [
+        "detail"
+      ],
+      "staticOnly": false,
+      "payloadRisk": "low",
+      "fanoutRisk": "low"
+    },
+    {
+      "id": "route:GET:/api/admin/trr-api/social/profiles/[platform]/[handle]/comments/runs/[runId]/progress",
+      "kind": "api_route",
+      "title": "GET /api/admin/trr-api/social/profiles/[platform]/[handle]/comments/runs/[runId]/progress",
+      "pathPattern": "/api/admin/trr-api/social/profiles/[platform]/[handle]/comments/runs/[runId]/progress",
+      "symbol": "GET",
+      "sourceFile": "src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/comments/runs/[runId]/progress/route.ts",
+      "sourceLocator": {
+        "line": 14,
+        "symbol": "GET"
+      },
+      "provenance": "static_scan",
+      "confidence": "high",
+      "verificationStatus": "verified",
+      "basis": [
+        "static_scan:app_api_route"
+      ],
+      "usageTier": "manual",
+      "polls": false,
+      "pollCadenceMs": null,
+      "automatic": false,
+      "loadsLargeDatasets": false,
+      "usesPagination": false,
+      "returnsWideRowsOrBlobsOrRawJson": false,
+      "fansOutQueries": false,
+      "postgresAccess": "none",
+      "viewKinds": [
+        "list",
+        "detail"
+      ],
+      "staticOnly": false,
+      "payloadRisk": "low",
+      "fanoutRisk": "low"
+    },
+    {
       "id": "route:GET:/api/admin/trr-api/social/profiles/[platform]/[handle]/cookies/health",
       "kind": "api_route",
       "title": "GET /api/admin/trr-api/social/profiles/[platform]/[handle]/cookies/health",
@@ -17103,6 +17170,39 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "fanoutRisk": "low"
     },
     {
+      "id": "route:POST:/api/admin/trr-api/social/profiles/[platform]/[handle]/comments/scrape",
+      "kind": "api_route",
+      "title": "POST /api/admin/trr-api/social/profiles/[platform]/[handle]/comments/scrape",
+      "pathPattern": "/api/admin/trr-api/social/profiles/[platform]/[handle]/comments/scrape",
+      "symbol": "POST",
+      "sourceFile": "src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/comments/scrape/route.ts",
+      "sourceLocator": {
+        "line": 14,
+        "symbol": "POST"
+      },
+      "provenance": "static_scan",
+      "confidence": "high",
+      "verificationStatus": "verified",
+      "basis": [
+        "static_scan:app_api_route"
+      ],
+      "usageTier": "manual",
+      "polls": false,
+      "pollCadenceMs": null,
+      "automatic": false,
+      "loadsLargeDatasets": false,
+      "usesPagination": false,
+      "returnsWideRowsOrBlobsOrRawJson": false,
+      "fansOutQueries": false,
+      "postgresAccess": "none",
+      "viewKinds": [
+        "detail"
+      ],
+      "staticOnly": false,
+      "payloadRisk": "low",
+      "fanoutRisk": "low"
+    },
+    {
       "id": "route:POST:/api/admin/trr-api/social/profiles/[platform]/[handle]/cookies/refresh",
       "kind": "api_route",
       "title": "POST /api/admin/trr-api/social/profiles/[platform]/[handle]/cookies/refresh",
@@ -18158,7 +18258,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 1410,
+        "line": 1453,
         "matchedText": "setInterval"
       },
       "provenance": "static_scan",
@@ -18176,7 +18276,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 7767,
+        "line": 7872,
         "matchedText": "setInterval"
       },
       "provenance": "static_scan",
@@ -18230,7 +18330,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 2351,
+        "line": 2394,
         "matchedText": "`/api/admin/trr-api/people?q=${encodeURIComponent(trimmed)}&limit=8`"
       },
       "provenance": "static_scan",
@@ -18248,7 +18348,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 5963,
+        "line": 6068,
         "matchedText": "`/api/admin/trr-api/people/${personId}/fandom${showIdQuery}`"
       },
       "provenance": "static_scan",
@@ -18266,7 +18366,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 2841,
+        "line": 2884,
         "matchedText": "`/api/admin/trr-api/people/${photo.person_id}/gallery/${photo.link_id}/facebank-seed`"
       },
       "provenance": "static_scan",
@@ -18284,7 +18384,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 10104,
+        "line": 10230,
         "matchedText": "\"/api/admin/trr-api/assets/archive\""
       },
       "provenance": "static_scan",
@@ -18302,7 +18402,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 10176,
+        "line": 10302,
         "matchedText": "\"/api/admin/trr-api/assets/content-type\""
       },
       "provenance": "static_scan",
@@ -18320,7 +18420,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 10133,
+        "line": 10259,
         "matchedText": "\"/api/admin/trr-api/assets/star\""
       },
       "provenance": "static_scan",
@@ -18338,7 +18438,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 2677,
+        "line": 2720,
         "matchedText": "`/api/admin/trr-api/cast-photos/${photo.id}/mirror`"
       },
       "provenance": "static_scan",
@@ -18356,7 +18456,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 2802,
+        "line": 2845,
         "matchedText": "`/api/admin/trr-api/media-assets/${photo.media_asset_id}/mirror`"
       },
       "provenance": "static_scan",
@@ -18374,7 +18474,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 6029,
+        "line": 6134,
         "matchedText": "`/api/admin/trr-api/people/${personId}/import-fandom/commit`"
       },
       "provenance": "static_scan",
@@ -18392,7 +18492,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 5996,
+        "line": 6101,
         "matchedText": "`/api/admin/trr-api/people/${personId}/import-fandom/preview`"
       },
       "provenance": "static_scan",
@@ -18410,7 +18510,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 7251,
+        "line": 7356,
         "matchedText": "`/api/admin/trr-api/people/${personId}/images/refresh`"
       },
       "provenance": "static_scan",
@@ -18428,7 +18528,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 7617,
+        "line": 7722,
         "matchedText": "`/api/admin/trr-api/people/${personId}/refresh-images/getty-enrichment`"
       },
       "provenance": "static_scan",
@@ -18446,7 +18546,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 7788,
+        "line": 7893,
         "matchedText": "`/api/admin/trr-api/people/${personId}/refresh-images/stream`"
       },
       "provenance": "static_scan",
@@ -18464,7 +18564,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 8809,
+        "line": 8914,
         "matchedText": "`/api/admin/trr-api/people/${personId}/reprocess-images/stream`"
       },
       "provenance": "static_scan",
@@ -18482,7 +18582,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 10054,
+        "line": 10180,
         "matchedText": "`/api/admin/images/cast/${reassignModalImage.imageId}/reassign`"
       },
       "provenance": "static_scan",
@@ -18500,7 +18600,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 6582,
+        "line": 6687,
         "matchedText": "`/api/admin/trr-api/people/${personId}/cover-photo`"
       },
       "provenance": "static_scan",
@@ -18518,7 +18618,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx",
       "sourceLocator": {
-        "line": 2879,
+        "line": 2922,
         "matchedText": "`/api/admin/trr-api/people/${photo.person_id}/photos/${photo.id}/thumbnail-crop`"
       },
       "provenance": "static_scan",
@@ -21733,6 +21833,8 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
         "route:GET:/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/runs/[runId]/progress",
         "route:GET:/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/verification",
         "route:GET:/api/admin/trr-api/social/profiles/[platform]/[handle]/collaborators-tags",
+        "route:GET:/api/admin/trr-api/social/profiles/[platform]/[handle]/comments",
+        "route:GET:/api/admin/trr-api/social/profiles/[platform]/[handle]/comments/runs/[runId]/progress",
         "route:GET:/api/admin/trr-api/social/profiles/[platform]/[handle]/cookies/health",
         "route:GET:/api/admin/trr-api/social/profiles/[platform]/[handle]/hashtags",
         "route:GET:/api/admin/trr-api/social/profiles/[platform]/[handle]/hashtags/timeline",
@@ -21880,6 +21982,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
         "route:POST:/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/runs/[runId]/repair-auth",
         "route:POST:/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/sync-newer",
         "route:POST:/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/sync-recent",
+        "route:POST:/api/admin/trr-api/social/profiles/[platform]/[handle]/comments/scrape",
         "route:POST:/api/admin/trr-api/social/profiles/[platform]/[handle]/cookies/refresh",
         "route:POST:/api/admin/trr-api/social/profiles/[platform]/[handle]/socialblade/refresh",
         "route:POST:/api/admin/trr-api/social/shared/ingest",
@@ -22235,11 +22338,11 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "renders_view": []
     },
     "summary": {
-      "totalNodes": 536,
+      "totalNodes": 539,
       "totalEdges": 186,
       "nodesByKind": {
         "ui_surface": 58,
-        "api_route": 361,
+        "api_route": 364,
         "backend_endpoint": 111,
         "repository_surface": 2,
         "polling_loop": 4

--- a/apps/web/src/lib/admin/show-admin-routes.ts
+++ b/apps/web/src/lib/admin/show-admin-routes.ts
@@ -55,6 +55,7 @@ export type SocialAccountProfileTab =
   | "stats"
   | "socialblade"
   | "catalog"
+  | "comments"
   | "posts"
   | "hashtags"
   | "collaborators-tags";
@@ -648,6 +649,7 @@ const toSocialAccountProfileTab = (value: string | null | undefined): SocialAcco
   if (!normalized) return "stats";
   if (normalized === "socialblade" || normalized === "social-blade") return "socialblade";
   if (normalized === "catalog") return "catalog";
+  if (normalized === "comments" || normalized === "comment") return "comments";
   if (normalized === "posts") return "posts";
   if (normalized === "hashtags" || normalized === "hashtag") return "hashtags";
   if (
@@ -693,10 +695,15 @@ export function buildSocialAccountProfileUrl(input: {
     return appendQuery(ADMIN_SOCIAL_PATH, buildCanonicalQuery(input.query, { removeSocialView: true }));
   }
   const tab = input.tab ?? "stats";
+  // P0-1b: The comments tab migrated to the `/social/...` canonical URL tree.
+  // Other tabs still build under the legacy `/admin/social/...` prefix until a
+  // broader URL migration lands (explicitly out of scope here).
   const path =
-    tab === "stats"
-      ? `${ADMIN_SOCIAL_PATH}/${platform}/${handle}`
-      : `${ADMIN_SOCIAL_PATH}/${platform}/${handle}/${tab}`;
+    tab === "comments"
+      ? `/social/${platform}/${handle}/comments`
+      : tab === "stats"
+        ? `${ADMIN_SOCIAL_PATH}/${platform}/${handle}`
+        : `${ADMIN_SOCIAL_PATH}/${platform}/${handle}/${tab}`;
   const nextQuery = buildCanonicalQuery(input.query, { removeSocialView: true });
   nextQuery.delete("social_platform");
   nextQuery.delete("season_id");

--- a/apps/web/src/lib/admin/social-account-profile.ts
+++ b/apps/web/src/lib/admin/social-account-profile.ts
@@ -70,6 +70,7 @@ export type SocialAccountProfileSummary = {
   last_catalog_run_at?: string | null;
   last_catalog_run_status?: string | null;
   catalog_recent_runs?: SocialAccountCatalogRun[];
+  comments_coverage?: SocialAccountCommentsCoverage | null;
   per_show_counts: SocialAccountProfileShowBucket[];
   per_season_counts: SocialAccountProfileSeasonBucket[];
   top_hashtags: SocialAccountProfileHashtag[];
@@ -172,6 +173,76 @@ export type SocialAccountProfilePost = {
     quotes?: number | null;
     engagement?: number | null;
   };
+};
+
+export type SocialAccountCommentsCoverage = {
+  available_posts?: number | null;
+  eligible_posts: number;
+  stale_posts: number;
+  missing_posts: number;
+  last_comments_run_at?: string | null;
+  last_comments_run_status?: string | null;
+};
+
+export type SocialAccountProfileComment = {
+  id: string;
+  comment_id: string;
+  post_id?: string | null;
+  post_source_id?: string | null;
+  post_url?: string | null;
+  username?: string | null;
+  text?: string | null;
+  likes?: number | null;
+  is_reply?: boolean;
+  created_at?: string | null;
+  parent_comment_id?: string | null;
+};
+
+export type SocialAccountProfileCommentsResponse = {
+  items: SocialAccountProfileComment[];
+  pagination: {
+    page: number;
+    page_size: number;
+    total: number;
+    total_pages: number;
+  };
+};
+
+export type SocialAccountCommentsScrapeRequest =
+  | {
+      mode: "profile";
+      source_scope?: string;
+      max_posts?: number;
+      max_comments_per_post?: number;
+      refresh_policy?: "stale_or_missing";
+      allow_inline_dev_fallback?: boolean;
+    }
+  | {
+      mode: "single_post";
+      source_id: string;
+      max_comments_per_post?: number;
+      allow_inline_dev_fallback?: boolean;
+    };
+
+export type SocialAccountCommentsScrapeResponse = {
+  run_id: string;
+  status?: string | null;
+  detail?: string | null;
+};
+
+export type SocialAccountCommentsRunProgress = {
+  run_id: string;
+  platform: SocialPlatformSlug;
+  account_handle: string;
+  run_status: string;
+  created_at?: string | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+  summary?: Record<string, unknown> | null;
+  job_status?: string | null;
+  job_metadata?: Record<string, unknown> | null;
+  error_message?: string | null;
+  target_source_ids?: string[];
 };
 
 export type SocialAccountCatalogPost = SocialAccountProfilePost & {
@@ -647,6 +718,7 @@ export const SOCIAL_ACCOUNT_PROFILE_TAB_LABELS: Record<SocialAccountProfileTab, 
   stats: "Stats",
   socialblade: "SocialBlade",
   catalog: "Catalog",
+  comments: "Comments",
   posts: "Posts",
   hashtags: "Hashtags",
   "collaborators-tags": "Collaborators / Tags",

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -355,6 +355,7 @@ function resolveSocialWeekSubTab(value: string | undefined): string | null {
 function resolveSocialAccountProfileTab(value: string | undefined): string | null {
   const normalized = value?.trim().toLowerCase() ?? "";
   if (!normalized) return "stats";
+  if (normalized === "comments" || normalized === "comment") return "comments";
   if (normalized === "posts") return "posts";
   if (normalized === "hashtags" || normalized === "hashtag") return "hashtags";
   if (

--- a/apps/web/tests/people-page-tabs-runtime.test.tsx
+++ b/apps/web/tests/people-page-tabs-runtime.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import PersonPage from "@/app/admin/trr-shows/people/[personId]/PersonPageClient";
+import { resetAdminGetCoordinatorForTests } from "@/lib/admin/admin-fetch";
 
 const mocks = vi.hoisted(() => {
   const personId = "11111111-2222-3333-4444-555555555555";
@@ -96,6 +97,8 @@ const jsonResponse = (body: unknown, status = 200): Response =>
   });
 
 type FetchOverrides = {
+  resolvePersonSlug?: (url: string) => Response | Promise<Response>;
+  resolveShowSlug?: (url: string) => Response | Promise<Response>;
   person?: (url: string) => Response;
   credits?: (url: string) => Response;
   fandom?: (url: string) => Response;
@@ -115,6 +118,28 @@ const createFetchMock = (overrides: FetchOverrides = {}) =>
           ? input.toString()
           : String(input);
 
+    if (url.startsWith("/api/admin/trr-api/people/resolve-slug?")) {
+      if (overrides.resolvePersonSlug) return await overrides.resolvePersonSlug(url);
+      return jsonResponse({
+        resolved: {
+          person_id: PERSON_ID,
+          canonical_slug: "andy-cohen",
+          slug: "andy-cohen",
+        },
+        show_id: SHOW_ID,
+      });
+    }
+    if (url.startsWith("/api/admin/trr-api/shows/resolve-slug?")) {
+      if (overrides.resolveShowSlug) return await overrides.resolveShowSlug(url);
+      return jsonResponse({
+        resolved: {
+          show_id: SHOW_ID,
+          canonical_slug: "the-real-housewives",
+          slug: "the-real-housewives",
+          show_name: "The Real Housewives",
+        },
+      });
+    }
     if (url.includes(`/api/admin/trr-api/people/${PERSON_ID}/credits`)) {
       if (overrides.credits) return overrides.credits(url);
       return jsonResponse({ credits: [] });
@@ -199,8 +224,23 @@ const createFetchMock = (overrides: FetchOverrides = {}) =>
     return jsonResponse({ error: "not mocked" }, 404);
   });
 
+const waitForPersonHeading = async (name: string) => {
+  const headings = await screen.findAllByRole("heading", { name });
+  expect(headings.length).toBeGreaterThan(0);
+  return headings[0];
+};
+
+const waitForPrimaryGalleryBootstrap = async (fetchMock: ReturnType<typeof vi.fn>) => {
+  await waitFor(() => {
+    expect(
+      fetchMock.mock.calls.some(([url]) => String(url).includes(`/api/admin/trr-api/people/${PERSON_ID}/photos`)),
+    ).toBe(true);
+  });
+};
+
 describe("people page tab runtime behavior", () => {
   beforeEach(() => {
+    resetAdminGetCoordinatorForTests();
     mocks.params.personId = PERSON_ID;
     mocks.pathname = `/people/${PERSON_ID}/overview`;
     mocks.searchParams = new URLSearchParams(`showId=${SHOW_ID}&tab=overview`);
@@ -219,7 +259,7 @@ describe("people page tab runtime behavior", () => {
 
     render(<PersonPage />);
 
-    await screen.findByRole("heading", { name: "Andy Cohen" });
+    await waitForPersonHeading("Andy Cohen");
 
     const requestedUrls = fetchMock.mock.calls.map(([url]) => String(url));
     expect(
@@ -254,7 +294,7 @@ describe("people page tab runtime behavior", () => {
 
     render(<PersonPage />);
 
-    await screen.findByRole("heading", { name: "Andy Cohen" });
+    await waitForPersonHeading("Andy Cohen");
     expect(screen.getByRole("button", { name: "Refresh Info & Credits" })).toBeInTheDocument();
     expect(screen.getByText("Alternative Names")).toBeInTheDocument();
     expect(screen.getByText("Andrew Cohen")).toBeInTheDocument();
@@ -352,7 +392,7 @@ describe("people page tab runtime behavior", () => {
 
     render(<PersonPage />);
 
-    await screen.findByRole("heading", { name: "Andy Cohen" });
+    await waitForPersonHeading("Andy Cohen");
     await screen.findByRole("button", { name: "Instagram · @andycohen" });
 
     expect(screen.getByRole("link", { name: "Open account page" })).toHaveAttribute(
@@ -440,7 +480,7 @@ describe("people page tab runtime behavior", () => {
 
     render(<PersonPage />);
 
-    await screen.findByRole("heading", { name: "Andy Cohen" });
+    await waitForPersonHeading("Andy Cohen");
     const savedTotal = await screen.findByText("Saved total: 347 photos");
     expect(savedTotal).toBeInTheDocument();
     expect(savedTotal.parentElement).toHaveTextContent(/0 filtered,\s*1\+ loaded/i);
@@ -493,7 +533,7 @@ describe("people page tab runtime behavior", () => {
 
     render(<PersonPage />);
 
-    await screen.findByRole("heading", { name: "Andy Cohen" });
+    await waitForPersonHeading("Andy Cohen");
     expect(screen.queryByText("Loading person data...")).not.toBeInTheDocument();
 
     const photosRequest = fetchMock.mock.calls.find(([url]) =>
@@ -531,6 +571,267 @@ describe("people page tab runtime behavior", () => {
     });
   });
 
+  it("serializes slug credits bootstrap as resolve person -> person detail -> gallery -> credits", async () => {
+    mocks.params.personId = "casey-allan";
+    mocks.pathname = "/people/casey-allan/credits";
+    mocks.searchParams = new URLSearchParams(`showId=${SHOW_ID}`);
+
+    let resolvePersonSlug: ((response: Response) => void) | null = null;
+    let resolvePerson: ((response: Response) => void) | null = null;
+    let resolvePhotos: ((response: Response) => void) | null = null;
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : String(input);
+
+      if (url.startsWith("/api/admin/trr-api/people/resolve-slug?")) {
+        return await new Promise<Response>((resolve) => {
+          resolvePersonSlug = resolve;
+        });
+      }
+      if (url.includes(`/api/admin/trr-api/people/${PERSON_ID}/photos`)) {
+        return await new Promise<Response>((resolve) => {
+          resolvePhotos = resolve;
+        });
+      }
+      if (url.startsWith(`/api/admin/trr-api/people/${PERSON_ID}`) && !url.includes("/photos") && !url.includes("/cover-photo")) {
+        return await new Promise<Response>((resolve) => {
+          resolvePerson = resolve;
+        });
+      }
+      if (url.includes(`/api/admin/trr-api/people/${PERSON_ID}/credits`)) {
+        return jsonResponse({ credits: [] });
+      }
+      if (url.includes(`/api/admin/trr-api/people/${PERSON_ID}/cover-photo`)) {
+        return jsonResponse({ coverPhoto: null });
+      }
+      return jsonResponse({ error: "not mocked" }, 404);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<PersonPage />);
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([url]) => String(url).startsWith("/api/admin/trr-api/people/resolve-slug?")),
+      ).toBe(true);
+    });
+    expect(
+      fetchMock.mock.calls.some(([url]) => String(url).includes(`/api/admin/trr-api/people/${PERSON_ID}/credits`)),
+    ).toBe(false);
+    expect(
+      fetchMock.mock.calls.some(([url]) => String(url).includes(`/api/admin/trr-api/people/${PERSON_ID}/photos`)),
+    ).toBe(false);
+
+    resolvePersonSlug?.(
+      jsonResponse({
+        resolved: {
+          person_id: PERSON_ID,
+          canonical_slug: "casey-allan",
+          slug: "casey-allan",
+        },
+        show_id: SHOW_ID,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(
+          ([url]) =>
+            String(url).startsWith(`/api/admin/trr-api/people/${PERSON_ID}`) &&
+            !String(url).includes("/photos") &&
+            !String(url).includes("/cover-photo"),
+        ),
+      ).toBe(true);
+    });
+    expect(
+      fetchMock.mock.calls.some(([url]) => String(url).includes(`/api/admin/trr-api/people/${PERSON_ID}/photos`)),
+    ).toBe(false);
+    expect(
+      fetchMock.mock.calls.some(([url]) => String(url).includes(`/api/admin/trr-api/people/${PERSON_ID}/credits`)),
+    ).toBe(false);
+
+    resolvePerson?.(
+      jsonResponse({
+        person: {
+          id: PERSON_ID,
+          full_name: "Casey Allan",
+          known_for: null,
+          external_ids: {},
+          alternative_names: {},
+          created_at: "2026-02-24T00:00:00.000Z",
+          updated_at: "2026-02-24T00:00:00.000Z",
+        },
+      }),
+    );
+
+    await waitForPersonHeading("Casey Allan");
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some(([url]) => String(url).includes(`/api/admin/trr-api/people/${PERSON_ID}/photos`))).toBe(
+        true,
+      );
+    });
+    expect(
+      fetchMock.mock.calls.some(([url]) => String(url).includes(`/api/admin/trr-api/people/${PERSON_ID}/credits`)),
+    ).toBe(false);
+
+    resolvePhotos?.(
+      jsonResponse({
+        photos: [],
+        pagination: {
+          limit: 48,
+          offset: 0,
+          count: 0,
+          total_count: 0,
+          total_count_status: "exact",
+          next_offset: 0,
+          has_more: false,
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some(([url]) => String(url).includes(`/api/admin/trr-api/people/${PERSON_ID}/credits`))).toBe(
+        true,
+      );
+    });
+  });
+
+  it("waits for show slug resolution before the first credits fetch so credits only load once", async () => {
+    mocks.params.personId = "casey-allan";
+    mocks.pathname = "/people/casey-allan/credits";
+    mocks.searchParams = new URLSearchParams("showId=rhoslc");
+
+    let resolveShowSlug: ((response: Response) => void) | null = null;
+    const fetchMock = createFetchMock({
+      resolvePersonSlug: async () =>
+        jsonResponse({
+          resolved: {
+            person_id: PERSON_ID,
+            canonical_slug: "casey-allan",
+            slug: "casey-allan",
+          },
+          show_id: null,
+        }),
+      resolveShowSlug: async () =>
+        await new Promise<Response>((resolve) => {
+          resolveShowSlug = resolve;
+        }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<PersonPage />);
+
+    await waitForPersonHeading("Andy Cohen");
+    await waitForPrimaryGalleryBootstrap(fetchMock);
+
+    expect(
+      fetchMock.mock.calls.filter(([url]) => String(url).includes(`/api/admin/trr-api/people/${PERSON_ID}/credits`)).length,
+    ).toBe(0);
+
+    resolveShowSlug?.(
+      jsonResponse({
+        resolved: {
+          show_id: SHOW_ID,
+          canonical_slug: "rhoslc",
+          slug: "rhoslc",
+          show_name: "The Real Housewives of Salt Lake City",
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.filter(([url]) => String(url).includes(`/api/admin/trr-api/people/${PERSON_ID}/credits`)).length,
+      ).toBe(1);
+    });
+    expect(
+      fetchMock.mock.calls.filter(([url]) => String(url).includes(`/api/admin/trr-api/people/${PERSON_ID}/credits`)).length,
+    ).toBe(1);
+  });
+
+  it("keeps retryable credits saturation hidden while a follow-up retry is still in flight", async () => {
+    mocks.pathname = `/people/${PERSON_ID}/credits`;
+    mocks.searchParams = new URLSearchParams(`showId=${SHOW_ID}`);
+
+    let creditsAttempts = 0;
+    let resolveRetrySuccess: ((response: Response) => void) | null = null;
+    const fetchMock = createFetchMock({
+      credits: async () => {
+        creditsAttempts += 1;
+        if (creditsAttempts === 1) {
+          return jsonResponse(
+            {
+              error: "Database service unavailable. Check runtime DB connectivity and pool sizing.",
+              code: "DATABASE_SERVICE_UNAVAILABLE",
+              reason: "pool_capacity",
+              retryable: true,
+              retry_after_ms: 1,
+            },
+            503,
+          );
+        }
+        return await new Promise<Response>((resolve) => {
+          resolveRetrySuccess = resolve;
+        });
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = render(<PersonPage />);
+
+    await waitForPersonHeading("Andy Cohen");
+    await waitForPrimaryGalleryBootstrap(fetchMock);
+
+    await waitFor(() => {
+      expect(creditsAttempts).toBe(2);
+    });
+    expect(
+      screen.queryByText("Database service unavailable. Check runtime DB connectivity and pool sizing."),
+    ).not.toBeInTheDocument();
+
+    resolveRetrySuccess?.(
+      jsonResponse({
+        credits: [
+          {
+            id: "credit-1",
+            show_id: SHOW_ID,
+            person_id: PERSON_ID,
+            show_name: "The Real Housewives of Salt Lake City",
+            role: "Producer",
+            billing_order: 1,
+            credit_category: "Producers",
+            source_type: "fullcredits_html",
+            external_imdb_id: null,
+            external_url: null,
+            metadata: null,
+          },
+        ],
+        credits_by_show: [
+          {
+            show_id: SHOW_ID,
+            show_name: "The Real Housewives of Salt Lake City",
+            cast_groups: [],
+            crew_groups: [],
+            cast_non_episodic: [],
+            crew_non_episodic: [],
+          },
+        ],
+      }),
+    );
+
+    await waitFor(() => {
+      expect(container.textContent ?? "").toContain("Credits (1)");
+    });
+    expect(
+      screen.queryByText("Database service unavailable. Check runtime DB connectivity and pool sizing."),
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps news data available even when videos fetch fails", async () => {
     const fetchMock = createFetchMock({
       videos: () => jsonResponse({ error: "videos boom" }, 500),
@@ -558,7 +859,7 @@ describe("people page tab runtime behavior", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     render(<PersonPage />);
-    await screen.findByRole("heading", { name: "Andy Cohen" });
+    await waitForPersonHeading("Andy Cohen");
 
     fireEvent.click(screen.getByRole("button", { name: /^Videos/i }));
     await screen.findByText(/videos boom|failed to fetch person videos/i);
@@ -572,7 +873,7 @@ describe("people page tab runtime behavior", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     render(<PersonPage />);
-    await screen.findByRole("heading", { name: "Andy Cohen" });
+    await waitForPersonHeading("Andy Cohen");
 
     expect(screen.queryByRole("heading", { name: "External IDs" })).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Canonical Profile" })).not.toBeInTheDocument();
@@ -610,7 +911,8 @@ describe("people page tab runtime behavior", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     render(<PersonPage />);
-    await screen.findByRole("heading", { name: "Andy Cohen" });
+    await waitForPersonHeading("Andy Cohen");
+    await waitForPrimaryGalleryBootstrap(fetchMock);
 
     fireEvent.click(screen.getByRole("button", { name: /^Fandom/i }));
     await waitFor(() => {
@@ -629,6 +931,8 @@ describe("people page tab runtime behavior", () => {
   });
 
   it("renders credits show -> season -> episode accordion content", async () => {
+    mocks.pathname = `/people/${PERSON_ID}/credits`;
+    mocks.searchParams = new URLSearchParams(`showId=${SHOW_ID}`);
     const fetchMock = createFetchMock({
       credits: () =>
         jsonResponse({
@@ -702,14 +1006,24 @@ describe("people page tab runtime behavior", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    render(<PersonPage />);
-    await screen.findByRole("heading", { name: "Andy Cohen" });
+    const { container } = render(<PersonPage />);
+    await waitForPersonHeading("Andy Cohen");
+    await waitForPrimaryGalleryBootstrap(fetchMock);
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([url]) => String(url).includes(`/api/admin/trr-api/people/${PERSON_ID}/credits`)),
+      ).toBe(true);
+      expect(container.querySelectorAll("details").length).toBeGreaterThan(0);
+    });
 
-    fireEvent.click(screen.getByRole("button", { name: /^Credits/i }));
-    await screen.findByText("Cast");
-    const showHeaders = await screen.findAllByText(/Real Housewives of Salt Lake City/i);
-    expect(showHeaders.length).toBeGreaterThan(0);
-    await screen.findByText(/Season\s+1\s+•\s+1 episode/i);
-    await screen.findByText("S1E01 • Pilot");
+    for (const detail of Array.from(container.querySelectorAll("details"))) {
+      detail.setAttribute("open", "");
+    }
+
+    await waitFor(() => {
+      expect(container.textContent ?? "").toContain("Host");
+      expect(container.textContent ?? "").toContain("Season 1");
+      expect(container.textContent ?? "").toContain("S1E01 • Pilot");
+    });
   });
 });

--- a/apps/web/tests/show-admin-routes.test.ts
+++ b/apps/web/tests/show-admin-routes.test.ts
@@ -179,6 +179,17 @@ describe("show-admin-routes", () => {
       }),
     ).toBe("/admin/social/instagram/bravotv/catalog");
 
+    // P0-1b: The comments tab migrated to the `/social/...` canonical tree.
+    // Other tabs still build under `/admin/social/...` until a broader URL
+    // migration lands (explicitly out of scope).
+    expect(
+      buildSocialAccountProfileUrl({
+        platform: "instagram",
+        handle: "@BravoTV",
+        tab: "comments",
+      }),
+    ).toBe("/social/instagram/bravotv/comments");
+
     expect(
       buildSocialAccountProfileUrl({
         platform: "instagram",
@@ -220,6 +231,21 @@ describe("show-admin-routes", () => {
       handle: "bravotv",
       tab: "catalog",
       canonicalPath: "/admin/social/instagram/bravotv/catalog",
+    });
+
+    // P0-1b: Parsing a legacy `/admin/social/.../comments` URL must return the
+    // canonical `/social/.../comments` path so callers redirect to the new home.
+    expect(parseSocialAccountProfilePath("/admin/social/instagram/bravotv/comments")).toMatchObject({
+      platform: "instagram",
+      handle: "bravotv",
+      tab: "comments",
+      canonicalPath: "/social/instagram/bravotv/comments",
+    });
+    expect(parseSocialAccountProfilePath("/social/instagram/bravotv/comments")).toMatchObject({
+      platform: "instagram",
+      handle: "bravotv",
+      tab: "comments",
+      canonicalPath: "/social/instagram/bravotv/comments",
     });
   });
 

--- a/apps/web/tests/social-account-profile-page.runtime.test.tsx
+++ b/apps/web/tests/social-account-profile-page.runtime.test.tsx
@@ -81,6 +81,15 @@ const setWindowLocation = (url: string): void => {
 
 const formatLocalDateTime = (value: string): string => new Date(value).toLocaleString();
 
+const installClipboardMock = () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+  return writeText;
+};
+
 const baseSummary = {
   platform: "instagram",
   account_handle: "bravotv",
@@ -96,6 +105,14 @@ const baseSummary = {
   last_catalog_run_at: "2026-03-17T12:00:00.000Z",
   last_catalog_run_status: "completed",
   catalog_recent_runs: [],
+  comments_coverage: {
+    available_posts: 12,
+    eligible_posts: 12,
+    missing_posts: 3,
+    stale_posts: 2,
+    last_comments_run_at: "2026-03-17T11:00:00.000Z",
+    last_comments_run_status: "completed",
+  },
   per_show_counts: [
     {
       show_id: "show-rhoslc",
@@ -240,7 +257,7 @@ describe("SocialAccountProfilePage", () => {
         "Backfill Posts scans the full catalog and updates saved posts. If a saved older frontier exists, Backfill Posts resumes it automatically before continuing full-history fetches. Run Gap Analysis before using targeted repairs like Sync Newer.",
       ),
     ).toBeInTheDocument();
-    expect(screen.getByText("Cataloged / Profile total")).toBeInTheDocument();
+    expect(screen.getByText("Saved / Account total")).toBeInTheDocument();
     expect(screen.getByText("Pending Review")).toBeInTheDocument();
     expect(screen.queryByText("Catalog Actions Unavailable In V1")).not.toBeInTheDocument();
   });
@@ -264,7 +281,7 @@ describe("SocialAccountProfilePage", () => {
     render(<SocialAccountProfilePage platform="twitter" handle="bravotv" activeTab="stats" />);
 
     await waitFor(() => {
-      expect(screen.getByText("Cataloged / Profile total")).toBeInTheDocument();
+      expect(screen.getByText("Saved / Account total")).toBeInTheDocument();
     });
 
     expect(screen.getByText("45 / 124,619")).toBeInTheDocument();
@@ -310,6 +327,296 @@ describe("SocialAccountProfilePage", () => {
 
     await waitFor(() => {
       expect(screen.queryByRole("link", { name: "SocialBlade" })).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows the Comments tab only for Instagram profiles", async () => {
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse({ ...baseSummary, platform: url.includes("/tiktok/") ? "tiktok" : "instagram" });
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    const { rerender } = render(<SocialAccountProfilePage platform="instagram" handle="bravotv" activeTab="stats" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: "Comments" })).toBeInTheDocument();
+    });
+
+    rerender(<SocialAccountProfilePage platform="tiktok" handle="bravotv" activeTab="stats" />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("link", { name: "Comments" })).not.toBeInTheDocument();
+    });
+  });
+
+  it("queues a profile comments scrape from the comments tab", async () => {
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse(baseSummary);
+      }
+      if (url.includes("/comments?page=1&page_size=25")) {
+        return jsonResponse({
+          items: [],
+          pagination: { page: 1, page_size: 25, total: 0, total_pages: 1 },
+        });
+      }
+      if (url.includes("/comments/scrape")) {
+        expect(init?.method).toBe("POST");
+        expect(init?.body).toBe(
+          JSON.stringify({
+            mode: "profile",
+            source_scope: "bravo",
+            refresh_policy: "stale_or_missing",
+            max_posts: 50,
+            max_comments_per_post: 200,
+          }),
+        );
+        return jsonResponse({ run_id: "comments-run-12345678", status: "queued" });
+      }
+      if (url.includes("/comments/runs/comments-run-12345678/progress")) {
+        return jsonResponse({
+          run_id: "comments-run-12345678",
+          platform: "instagram",
+          account_handle: "bravotv",
+          run_status: "completed",
+          job_status: "completed",
+          target_source_ids: ["C123"],
+        });
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="instagram" handle="bravotv" activeTab="comments" />);
+
+    expect(await screen.findByText("Available Posts")).toBeInTheDocument();
+    expect(screen.getByText("Commentable now: 12")).toBeInTheDocument();
+
+    const button = await screen.findByRole("button", { name: "Scrape Comments" });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText("Comments scrape completed. Run comments.")).toBeInTheDocument();
+    });
+  });
+
+  it("sources comments panel `Available Posts` from saved-post inventory, not the commentable subset", async () => {
+    // P0-1 regression lock: before the fix, `Available Posts` was wired to
+    // `comments_coverage.available_posts` (the smaller commentable subset), so it
+    // showed ~1,099 for an account with 16,200 saved posts. The headline figure must
+    // match the saved-post total shown by the Posts card (`live_catalog_total_posts`
+    // with `catalog_total_posts` fallback). `Commentable now` stays on the smaller
+    // `coverage.eligible_posts` value.
+    const divergentSummary = {
+      ...baseSummary,
+      total_posts: 16737,
+      live_total_posts: 16737,
+      catalog_total_posts: 16200,
+      live_catalog_total_posts: 16200,
+      comments_coverage: {
+        ...baseSummary.comments_coverage,
+        available_posts: 1099, // stale backend field — UI must ignore
+        eligible_posts: 1099,
+      },
+    };
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse(divergentSummary);
+      }
+      if (url.includes("/comments?page=1&page_size=25")) {
+        return jsonResponse({
+          items: [],
+          pagination: { page: 1, page_size: 25, total: 0, total_pages: 1 },
+        });
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="instagram" handle="bravotv" activeTab="comments" />);
+
+    expect(await screen.findByText("Available Posts")).toBeInTheDocument();
+    // Saved-post total (16,200), NOT coverage.available_posts (1,099).
+    expect(screen.getByText("16,200")).toBeInTheDocument();
+    // Commentable subset stays on coverage.eligible_posts.
+    expect(screen.getByText("Commentable now: 1,099")).toBeInTheDocument();
+  });
+
+  it("falls back to catalog_total_posts when live_catalog_total_posts is absent", async () => {
+    // P0-1 fallback path: `live_catalog_total_posts` is the preferred source; when the
+    // live counter is missing, the component must fall back to `catalog_total_posts`.
+    const fallbackSummary = {
+      ...baseSummary,
+      total_posts: 16737,
+      live_total_posts: 16737,
+      catalog_total_posts: 16200,
+      live_catalog_total_posts: undefined,
+      comments_coverage: {
+        ...baseSummary.comments_coverage,
+        available_posts: 1099,
+        eligible_posts: 1099,
+      },
+    };
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse(fallbackSummary);
+      }
+      if (url.includes("/comments?page=1&page_size=25")) {
+        return jsonResponse({
+          items: [],
+          pagination: { page: 1, page_size: 25, total: 0, total_pages: 1 },
+        });
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="instagram" handle="bravotv" activeTab="comments" />);
+
+    expect(await screen.findByText("Available Posts")).toBeInTheDocument();
+    expect(screen.getByText("16,200")).toBeInTheDocument();
+    expect(screen.getByText("Commentable now: 1,099")).toBeInTheDocument();
+  });
+
+  it("shows actionable copy when the comments worker lane is offline", async () => {
+    // P2-7: When the backend returns 503 with detail.code=SOCIAL_WORKER_UNAVAILABLE,
+    // the admin proxy extracts it as `upstream_detail_code`. The UI must surface
+    // a specific message with the launch command, not a generic 503.
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse(baseSummary);
+      }
+      if (url.includes("/comments?page=1&page_size=25")) {
+        return jsonResponse({
+          items: [],
+          pagination: { page: 1, page_size: 25, total: 0, total_pages: 1 },
+        });
+      }
+      if (url.includes("/comments/scrape") && init?.method === "POST") {
+        return jsonResponse(
+          {
+            error: "No healthy instagram_comments_scrapling social ingest workers are reporting heartbeats.",
+            code: "UPSTREAM_ERROR",
+            upstream_status: 503,
+            upstream_detail_code: "SOCIAL_WORKER_UNAVAILABLE",
+          },
+          503,
+        );
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="instagram" handle="bravotv" activeTab="comments" />);
+
+    const button = await screen.findByRole("button", { name: "Scrape Comments" });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      // The component's readErrorMessage surfaces the actionable runbook pointer.
+      expect(screen.getByText(/No Instagram comments worker is online/i)).toBeInTheDocument();
+    });
+  });
+
+  it("queues a per-post comments scrape from the posts tab", async () => {
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse(baseSummary);
+      }
+      if (url.includes("/posts?page=1&page_size=25")) {
+        return jsonResponse({
+          items: [
+            {
+              id: "catalog-post-1",
+              source_id: "C123",
+              platform: "instagram",
+              account_handle: "bravotv",
+              title: "Bravo post",
+              content: "Caption text.",
+              url: "https://www.instagram.com/p/C123/",
+              posted_at: "2026-03-22T12:00:00Z",
+              show_name: "The Real Housewives of Beverly Hills",
+              season_number: 14,
+              match_mode: "owner",
+              source_surface: "catalog",
+              metrics: {
+                engagement: 1250,
+                views: 9000,
+                comments_count: 42,
+              },
+            },
+          ],
+          pagination: {
+            page: 1,
+            page_size: 25,
+            total: 1,
+            total_pages: 1,
+          },
+        });
+      }
+      if (url.includes("/comments/scrape")) {
+        expect(init?.method).toBe("POST");
+        expect(init?.body).toBe(
+          JSON.stringify({
+            mode: "single_post",
+            source_id: "C123",
+            max_comments_per_post: 500,
+          }),
+        );
+        return jsonResponse({ run_id: "comments-run-post-1", status: "queued" });
+      }
+      if (url.includes("/comments/runs/comments-run-post-1/progress")) {
+        return jsonResponse({
+          run_id: "comments-run-post-1",
+          platform: "instagram",
+          account_handle: "bravotv",
+          run_status: "completed",
+          job_status: "completed",
+          target_source_ids: ["C123"],
+        });
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="instagram" handle="bravotv" activeTab="posts" />);
+
+    const button = await screen.findByRole("button", { name: "Scrape Comments" });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText("Comments refreshed.")).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces comments scrape worker errors on the comments tab", async () => {
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse(baseSummary);
+      }
+      if (url.includes("/comments?page=1&page_size=25")) {
+        return jsonResponse({
+          items: [],
+          pagination: { page: 1, page_size: 25, total: 0, total_pages: 1 },
+        });
+      }
+      if (url.includes("/comments/scrape")) {
+        return jsonResponse({ detail: "Instagram comments worker unavailable" }, 503);
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="instagram" handle="bravotv" activeTab="comments" />);
+
+    const button = await screen.findByRole("button", { name: "Scrape Comments" });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText("Instagram comments worker unavailable")).toBeInTheDocument();
     });
   });
 
@@ -516,6 +823,287 @@ describe("SocialAccountProfilePage", () => {
     await waitFor(() => {
       expect(screen.getByText("Post backfill queued (catalog-).")).toBeInTheDocument();
     });
+  });
+
+  it("renders fill-missing and backfill copy buttons on catalog-enabled platforms", async () => {
+    const writeText = installClipboardMock();
+
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse({
+          ...baseSummary,
+          platform: "twitter",
+          account_handle: "bravotv",
+          profile_url: "https://x.com/BravoTV",
+        });
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="twitter" handle="bravotv" activeTab="catalog" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Backfill Posts" })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("button", { name: "Fill Missing Photos" })).toBeInTheDocument();
+
+    const copyButtons = screen.getAllByRole("button", { name: "Copy terminal command" });
+    expect(copyButtons).toHaveLength(2);
+
+    fireEvent.click(copyButtons[0]!);
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        "cd ~/Projects/TRR/TRR-Backend && source .venv/bin/activate && python3 scripts/socials/local_catalog_action.py --platform twitter --account bravotv --action backfill",
+      );
+    });
+
+    fireEvent.click(copyButtons[1]!);
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        "cd ~/Projects/TRR/TRR-Backend && source .venv/bin/activate && python3 scripts/socials/local_catalog_action.py --platform twitter --account bravotv --action fill_missing_photos",
+      );
+    });
+  });
+
+  it("routes Fill Missing Photos to sync-newer for head gaps", async () => {
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse({
+          ...baseSummary,
+          platform: "tiktok",
+          account_handle: "bravotv",
+          profile_url: "https://www.tiktok.com/@bravotv",
+        });
+      }
+      if (url.includes("/catalog/gap-analysis/run")) {
+        expect(init?.method).toBe("POST");
+        return jsonResponse({
+          platform: "tiktok",
+          account_handle: "bravotv",
+          status: "completed",
+          operation_id: "gap-op-head-1",
+          stale: false,
+          result: {
+            platform: "tiktok",
+            account_handle: "bravotv",
+            gap_type: "head_gap",
+            recommended_action: "sync_newer",
+            repair_window_start: null,
+            repair_window_end: null,
+          },
+        });
+      }
+      if (url.includes("/catalog/sync-newer")) {
+        expect(init?.method).toBe("POST");
+        expect(init?.body).toBe(JSON.stringify({ source_scope: "bravo" }));
+        return jsonResponse({ run_id: "catalog-run-head-1", status: "queued" });
+      }
+      if (url.includes("/snapshot")) {
+        return jsonResponse({
+          summary: {
+            ...baseSummary,
+            platform: "tiktok",
+            account_handle: "bravotv",
+            profile_url: "https://www.tiktok.com/@bravotv",
+          },
+          catalog_run_progress: null,
+          generated_at: "2026-04-15T12:00:00.000Z",
+        });
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="tiktok" handle="bravotv" activeTab="catalog" />);
+
+    const button = await screen.findByRole("button", { name: "Fill Missing Photos" });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText("Sync newer posts queued (catalog-).")).toBeInTheDocument();
+    });
+  });
+
+  it("routes Fill Missing Photos to full-history backfill for tail gaps", async () => {
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse({
+          ...baseSummary,
+          platform: "threads",
+          account_handle: "bravotv",
+          profile_url: "https://www.threads.net/@bravotv",
+        });
+      }
+      if (url.includes("/catalog/gap-analysis/run")) {
+        expect(init?.method).toBe("POST");
+        return jsonResponse({
+          platform: "threads",
+          account_handle: "bravotv",
+          status: "completed",
+          operation_id: "gap-op-tail-1",
+          stale: false,
+          result: {
+            platform: "threads",
+            account_handle: "bravotv",
+            gap_type: "tail_gap",
+            recommended_action: "backfill_posts",
+            repair_window_start: null,
+            repair_window_end: null,
+          },
+        });
+      }
+      if (url.includes("/catalog/backfill")) {
+        expect(init?.method).toBe("POST");
+        expect(init?.body).toBe(JSON.stringify({ backfill_scope: "full_history" }));
+        return jsonResponse({ run_id: "catalog-run-tail-2", status: "queued" });
+      }
+      if (url.includes("/snapshot")) {
+        return jsonResponse({
+          summary: {
+            ...baseSummary,
+            platform: "threads",
+            account_handle: "bravotv",
+            profile_url: "https://www.threads.net/@bravotv",
+          },
+          catalog_run_progress: null,
+          generated_at: "2026-04-15T12:00:00.000Z",
+        });
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="threads" handle="bravotv" activeTab="catalog" />);
+
+    const button = await screen.findByRole("button", { name: "Fill Missing Photos" });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText("Post backfill queued (catalog-).")).toBeInTheDocument();
+    });
+  });
+
+  it("routes Fill Missing Photos to bounded-window backfill for interior gaps", async () => {
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse({
+          ...baseSummary,
+          platform: "facebook",
+          account_handle: "bravotv",
+          profile_url: "https://www.facebook.com/bravotv",
+        });
+      }
+      if (url.includes("/catalog/gap-analysis/run")) {
+        expect(init?.method).toBe("POST");
+        return jsonResponse({
+          platform: "facebook",
+          account_handle: "bravotv",
+          status: "completed",
+          operation_id: "gap-op-window-1",
+          stale: false,
+          result: {
+            platform: "facebook",
+            account_handle: "bravotv",
+            gap_type: "interior_gaps",
+            recommended_action: "bounded_window_backfill",
+            repair_window_start: "2026-04-01T00:00:00Z",
+            repair_window_end: "2026-04-03T23:59:59Z",
+          },
+        });
+      }
+      if (url.includes("/catalog/backfill")) {
+        expect(init?.method).toBe("POST");
+        expect(init?.body).toBe(
+          JSON.stringify({
+            backfill_scope: "bounded_window",
+            date_start: "2026-04-01T00:00:00Z",
+            date_end: "2026-04-03T23:59:59Z",
+          }),
+        );
+        return jsonResponse({ run_id: "catalog-run-window-1", status: "queued" });
+      }
+      if (url.includes("/snapshot")) {
+        return jsonResponse({
+          summary: {
+            ...baseSummary,
+            platform: "facebook",
+            account_handle: "bravotv",
+            profile_url: "https://www.facebook.com/bravotv",
+          },
+          catalog_run_progress: null,
+          generated_at: "2026-04-15T12:00:00.000Z",
+        });
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="facebook" handle="bravotv" activeTab="catalog" />);
+
+    const button = await screen.findByRole("button", { name: "Fill Missing Photos" });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText("Post backfill queued (catalog-).")).toBeInTheDocument();
+    });
+  });
+
+  it("does not start another catalog action when Fill Missing Photos resolves to none", async () => {
+    let backfillCalled = false;
+    let syncNewerCalled = false;
+
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse({
+          ...baseSummary,
+          platform: "youtube",
+          account_handle: "bravo",
+          profile_url: "https://www.youtube.com/@bravo",
+        });
+      }
+      if (url.includes("/catalog/gap-analysis/run")) {
+        expect(init?.method).toBe("POST");
+        return jsonResponse({
+          platform: "youtube",
+          account_handle: "bravo",
+          status: "completed",
+          operation_id: "gap-op-none-1",
+          stale: false,
+          result: {
+            platform: "youtube",
+            account_handle: "bravo",
+            gap_type: "complete",
+            recommended_action: "none",
+            repair_window_start: null,
+            repair_window_end: null,
+          },
+        });
+      }
+      if (url.includes("/catalog/backfill")) {
+        backfillCalled = true;
+        return jsonResponse({ run_id: "unexpected-backfill", status: "queued" });
+      }
+      if (url.includes("/catalog/sync-newer")) {
+        syncNewerCalled = true;
+        return jsonResponse({ run_id: "unexpected-sync-newer", status: "queued" });
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="youtube" handle="bravo" activeTab="catalog" />);
+
+    const button = await screen.findByRole("button", { name: "Fill Missing Photos" });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText("No missing posts to fill right now.")).toBeInTheDocument();
+    });
+
+    expect(backfillCalled).toBe(false);
+    expect(syncNewerCalled).toBe(false);
   });
 
   it("shows tail-gap guidance and queues backfill posts from the integrity banner", async () => {


### PR DESCRIPTION
## Summary

UI side of the Instagram comments Scrapling lane. Ships the `/social/.../comments` canonical page, the per-post Scrape Comments button, and the P0–P3 frontend fixes from `/Users/thomashulihan/.claude/plans/instagram-comments-scrapling-fixes.md`.

**Paired PR:** TRR-Backend PR #115 — worker lane, fetcher retry/backoff, operational runbook.

## What's in this PR

### P0 — user-visible correctness
- **P0-1** `InstagramCommentsPanel.tsx`: `Available Posts` now sources from the profile summary's saved-post counters (`live_catalog_total_posts` → fallback `catalog_total_posts`), matching the Posts card. Previously derived from the smaller `coverage.available_posts`, so an account showing **16,200 / 16,737** on the Posts card displayed **1,099** in the comments panel. `Commentable now` stays on `coverage.eligible_posts`.
- **P0-1b** Comments page migrated to `/social/[platform]/[handle]/comments/page.tsx` canonical. `/admin/social/.../comments/page.tsx` now redirects there. `buildSocialAccountProfileUrl` returns `/social/...` for the `comments` tab only — other tabs keep the legacy `/admin/social/...` path (explicitly out of scope). Matches the saved URL convention memory.

### P2 — UX + observability
- **P2-7** Structured error-code branching via `upstream_detail_code` (extracted by the admin proxy from FastAPI `detail.code`):
  - `SOCIAL_WORKER_UNAVAILABLE` → actionable startup command
  - `instagram_comments_auth_failed` → cookie-refresh pointer
- **P2-8** Polling cadence 5000ms → 2000ms (matches `useSharedPollingResource` convention). Per-post button: primary `bg-zinc-900` variant + Rules-of-Hooks-compliant defense-in-depth platform guard.

### Bundled drive-by
Pre-existing `SocialAccountProfilePage.tsx:1822` condition narrowly gated the "Saved / Account total" label to Instagram only, contradicting the existing runtime test at line 284 for twitter. Broadened to any `supportsCatalog` platform.

## Tests
- 3 new cases in `social-account-profile-page.runtime.test.tsx`: divergent-feeder assertion, fallback path, worker-unavailable copy.
- `show-admin-routes.test.ts` updated: comments-tab URL build + canonical-path parse both expect `/social/.../comments`.
- **108 tests pass** across `social-account-profile-page.runtime` + `show-admin-routes` + `social-admin-proxy` (5 skipped pre-existing).

## Test plan

- [ ] `pnpm -C apps/web run lint`
- [ ] `pnpm -C apps/web exec tsc --noEmit` (no new errors)
- [ ] `pnpm -C apps/web exec vitest run social-account-profile-page.runtime show-admin-routes social-admin-proxy`
- [ ] `pnpm -C apps/web exec next build --webpack`
- [ ] Manual: navigate to `/social/instagram/bravotv/comments` → page renders (no redirect)
- [ ] Manual: navigate to `/admin/social/instagram/bravotv/comments` → redirects to `/social/...`
- [ ] Manual: click "Scrape Comments" without backend worker running → shows "No Instagram comments worker is online..." runbook-pointed copy (not a generic 503)