### PR TITLE
fix(app): harden social account profile runtime flows

### DIFF
--- a/apps/web/src/components/admin/SocialAccountProfilePage.tsx
+++ b/apps/web/src/components/admin/SocialAccountProfilePage.tsx
@@ -19,6 +19,7 @@ import {
   type CatalogBackfillRequest,
   type CatalogBackfillLaunchResponse,
   type CatalogBackfillSelectedTask,
+  type SocialAccountCatalogAttachedFollowups,
   type CatalogRemediateDriftRequest,
   type CatalogRemediateDriftResponse,
   type CatalogRepairAuthRequest,
@@ -190,6 +191,14 @@ type CatalogRunProgressHandleCard = {
   stages: Array<CatalogRunProgressStageStats & { stage: string }>;
 };
 
+type CatalogLaneCard = {
+  key: "catalog" | "comments" | "media";
+  label: string;
+  status?: string | null;
+  sourceLabel?: string | null;
+  detail?: string | null;
+};
+
 const socialProfileRequestInflight = new Map<string, Promise<unknown>>();
 
 const withSocialProfileRequestDedup = <T,>(key: string, loader: () => Promise<T>): Promise<T> => {
@@ -279,13 +288,6 @@ const CATALOG_STAGE_SORT_ORDER: Record<string, number> = {
 
 const formatInteger = (value: number | null | undefined): string => {
   return INTEGER_FORMATTER.format(Number.isFinite(Number(value)) ? Number(value) : 0);
-};
-
-const formatPercent = (saved: number | null | undefined, total: number | null | undefined): string => {
-  const normalizedTotal = Math.max(0, Number(total ?? 0));
-  const normalizedSaved = Math.max(0, Number(saved ?? 0));
-  if (normalizedTotal <= 0) return "0%";
-  return `${Math.round((Math.min(normalizedSaved, normalizedTotal) / normalizedTotal) * 100)}%`;
 };
 
 const formatDateTime = (value?: string | null): string => {
@@ -812,6 +814,67 @@ const shortRunId = (value?: string | null): string => {
   return normalized ? normalized.slice(0, 8) : "pending";
 };
 
+const formatAttachedLaneSourceLabel = (value?: string | null): string | null => {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!normalized) return null;
+  if (normalized === "new_run") return "New";
+  if (normalized === "reused_run") return "Reused";
+  if (normalized === "deferred_after_catalog") return "Deferred";
+  if (normalized === "catalog_media_mirror") return "Attached";
+  if (normalized === "comments_media_followups") return "Comment Follow-ups";
+  return formatRunStatusLabel(normalized);
+};
+
+const buildCatalogLaneCards = (options: {
+  runStatus?: string | null;
+  selectedTasks?: CatalogBackfillSelectedTask[] | null;
+  effectiveSelectedTasks?: CatalogBackfillSelectedTask[] | null;
+  commentsRunId?: string | null;
+  attachedFollowups?: SocialAccountCatalogAttachedFollowups | null;
+}): CatalogLaneCard[] => {
+  const taskSet = new Set<CatalogBackfillSelectedTask>([
+    ...(options.selectedTasks ?? []),
+    ...(options.effectiveSelectedTasks ?? []),
+  ]);
+  const commentsFollowup = options.attachedFollowups?.comments ?? null;
+  const mediaFollowup = options.attachedFollowups?.media ?? null;
+  const cards: CatalogLaneCard[] = [
+    {
+      key: "catalog",
+      label: "Catalog",
+      status: options.runStatus,
+    },
+  ];
+  if (taskSet.has("comments") || commentsFollowup || options.commentsRunId) {
+    const commentsRunId = String(commentsFollowup?.run_id || options.commentsRunId || "").trim() || null;
+    const sourceLabel = formatAttachedLaneSourceLabel(commentsFollowup?.source);
+    cards.push({
+      key: "comments",
+      label: "Comments",
+      status: commentsFollowup?.status ?? (commentsRunId ? "queued" : null),
+      sourceLabel,
+      detail: commentsRunId ? `Run ${shortRunId(commentsRunId)}` : sourceLabel === "Deferred" ? "Starts after catalog completion" : null,
+    });
+  }
+  if (taskSet.has("media") || mediaFollowup) {
+    const attachmentId = String(mediaFollowup?.attachment_id || "").trim() || null;
+    const enqueuedCount = typeof mediaFollowup?.enqueued_job_count === "number" ? mediaFollowup.enqueued_job_count : null;
+    cards.push({
+      key: "media",
+      label: "Media",
+      status: mediaFollowup?.status ?? null,
+      sourceLabel: formatAttachedLaneSourceLabel(mediaFollowup?.source),
+      detail:
+        enqueuedCount && enqueuedCount > 0
+          ? `${formatInteger(enqueuedCount)} repair jobs`
+          : attachmentId
+            ? `Attachment ${shortRunId(attachmentId)}`
+            : null,
+    });
+  }
+  return cards;
+};
+
 const getCatalogRunStatusTone = (value?: string | null): string => {
   const normalized = String(value || "").trim().toLowerCase();
   if (normalized === "blocked_auth") return "border-red-200 bg-red-50 text-red-700";
@@ -1271,12 +1334,13 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   const supportsCatalog = SOCIAL_ACCOUNT_CATALOG_ENABLED_PLATFORMS.includes(platform);
   const supportsComments = platform === "instagram";
   const supportsSocialBlade = SOCIAL_ACCOUNT_SOCIALBLADE_ENABLED_PLATFORMS.includes(platform);
+  const selectedTab: SocialAccountProfileTab = supportsCatalog && activeTab === "posts" ? "catalog" : activeTab;
   const hasSummary = summary !== null;
   const hasFullSummary = Boolean(summary && (summary.summary_detail ?? "full") === "full");
   const summaryInitialStatePending = !hasSummary && !summaryError && !summaryUninitialized;
   const shouldDeferSecondaryCatalogReads =
     !hasSummary || summaryLoading || summarySaturationActive || catalogProgressSaturationActive;
-  const commentsTabNeedsFullSummary = activeTab === "comments" && supportsComments;
+  const commentsTabNeedsFullSummary = selectedTab === "comments" && supportsComments;
   const hashtagsRequestKey = `hashtags:${platform}:${handle}:${hashtagWindow}`;
   const hashtagTimelineRequestKey = `hashtags-timeline:${platform}:${handle}:${hashtagWindow}`;
   const collaboratorsRequestKey = `collaborators-tags:${platform}:${handle}`;
@@ -1318,9 +1382,12 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   const visibleTabs = useMemo(
     () =>
       (Object.keys(SOCIAL_ACCOUNT_PROFILE_TAB_LABELS) as SocialAccountProfileTab[]).filter(
-        (tab) => (tab !== "socialblade" || supportsSocialBlade) && (tab !== "comments" || supportsComments),
+        (tab) =>
+          (tab !== "socialblade" || supportsSocialBlade) &&
+          (tab !== "comments" || supportsComments) &&
+          (tab !== "posts" || !supportsCatalog),
       ),
-    [supportsComments, supportsSocialBlade],
+    [supportsCatalog, supportsComments, supportsSocialBlade],
   );
   const isLocalDevHost = useMemo(() => {
     return typeof window !== "undefined" && isLocalDevHostname(window.location.hostname);
@@ -1700,10 +1767,12 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     const loadSummary = async () => {
       setSummaryLoading(true);
       setSummaryError(null);
+      let snapshotHydrated = false;
       const snapshotPromise = fetchProfileSnapshotRef.current()
         .then((snapshot) => {
           if (cancelled) return;
           if (snapshot.payload.summary) {
+            snapshotHydrated = true;
             setSummary(snapshot.payload.summary);
             setSummaryUninitialized(false);
             setSummaryError(null);
@@ -1715,8 +1784,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
           }
         })
         .catch(() => {
-          // Best-effort snapshot hydration only. The live summary request below
-          // remains the source of truth for first paint.
+          // Best-effort snapshot hydration only.
         });
       try {
         await refreshSummaryRef.current({ detail: "lite" });
@@ -1724,9 +1792,13 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
         setSummarySaturationActive(false);
         setSummaryError(null);
       } catch (error) {
-        // Snapshot hydrates in the background; the live /summary endpoint is what
-        // should gate the initial account render.
+        await snapshotPromise.catch(() => undefined);
         if (cancelled) return;
+        if (snapshotHydrated) {
+          setSummarySaturationActive(false);
+          setSummaryError(null);
+          return;
+        }
         setSummaryUninitialized(false);
         if (!isBackendSaturationError(error)) {
           setSummarySaturationActive(false);
@@ -1920,7 +1992,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   ]);
 
   useEffect(() => {
-    if (checking || !user || !hasAccess || activeTab !== "posts" || summaryUninitialized) return;
+    if (checking || !user || !hasAccess || selectedTab !== "posts" || summaryUninitialized) return;
     let cancelled = false;
 
     const loadPosts = async () => {
@@ -1950,10 +2022,10 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     return () => {
       cancelled = true;
     };
-  }, [activeTab, checking, fetchAdminWithAuth, handle, hasAccess, page, platform, summaryUninitialized, user]);
+  }, [checking, fetchAdminWithAuth, handle, hasAccess, page, platform, selectedTab, summaryUninitialized, user]);
 
   useEffect(() => {
-    if (checking || !user || !hasAccess || activeTab !== "catalog" || !supportsCatalog || summaryUninitialized) return;
+    if (checking || !user || !hasAccess || selectedTab !== "catalog" || !supportsCatalog || summaryUninitialized) return;
     let cancelled = false;
 
     const loadCatalogPosts = async () => {
@@ -1990,18 +2062,18 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     return () => {
       cancelled = true;
     };
-  }, [activeTab, catalogFilter, catalogPage, checking, fetchAdminWithAuth, handle, hasAccess, platform, summaryUninitialized, supportsCatalog, user]);
+  }, [catalogFilter, catalogPage, checking, fetchAdminWithAuth, handle, hasAccess, platform, selectedTab, summaryUninitialized, supportsCatalog, user]);
 
   const hasLoadedExactHashtagWindow = hashtagsLoadedRequestKey === hashtagsRequestKey;
   const useSummaryTopHashtagsPreview = shouldUseSummaryTopHashtagsPreview({
-    activeTab,
+    activeTab: selectedTab,
     hashtagWindow,
     summaryTopHashtags: summary?.top_hashtags ?? [],
     hasLoadedExactWindow: hasLoadedExactHashtagWindow,
   });
 
   useEffect(() => {
-    const shouldLoadHashtags = activeTab === "hashtags";
+    const shouldLoadHashtags = selectedTab === "hashtags";
     if (checking || !user || !hasAccess || !shouldLoadHashtags || summaryUninitialized || shouldDeferSecondaryCatalogReads) {
       return;
     }
@@ -2043,13 +2115,13 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       cancelled = true;
     };
   }, [
-    activeTab,
     checking,
     hashtagWindow,
     hasAccess,
     hashtagsRequestKey,
     platform,
     refreshHashtags,
+    selectedTab,
     useSummaryTopHashtagsPreview,
     shouldDeferSecondaryCatalogReads,
     summaryUninitialized,
@@ -2057,7 +2129,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   ]);
 
   useEffect(() => {
-    if (checking || !user || !hasAccess || activeTab !== "hashtags" || platform !== "instagram" || summaryUninitialized) {
+    if (checking || !user || !hasAccess || selectedTab !== "hashtags" || platform !== "instagram" || summaryUninitialized) {
       if (platform !== "instagram") {
         setHashtagTimeline(null);
         setHashtagTimelineError(null);
@@ -2084,7 +2156,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     return () => {
       cancelled = true;
     };
-  }, [activeTab, checking, hasAccess, platform, refreshHashtagTimeline, summaryUninitialized, user]);
+  }, [checking, hasAccess, platform, refreshHashtagTimeline, selectedTab, summaryUninitialized, user]);
 
   useEffect(() => {
     if (
@@ -2093,7 +2165,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       !hasAccess ||
       !supportsCatalog ||
       summaryUninitialized ||
-      (activeTab !== "hashtags" && activeTab !== "catalog")
+      (selectedTab !== "hashtags" && selectedTab !== "catalog")
     ) {
       return;
     }
@@ -2126,10 +2198,10 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     return () => {
       cancelled = true;
     };
-  }, [activeTab, checking, fetchAdminWithAuth, handle, hasAccess, platform, summaryUninitialized, supportsCatalog, user]);
+  }, [checking, fetchAdminWithAuth, handle, hasAccess, platform, selectedTab, summaryUninitialized, supportsCatalog, user]);
 
   useEffect(() => {
-    if (checking || !user || !hasAccess || activeTab !== "collaborators-tags" || summaryUninitialized) return;
+    if (checking || !user || !hasAccess || selectedTab !== "collaborators-tags" || summaryUninitialized) return;
     let cancelled = false;
 
     const loadCollaboratorsTags = async () => {
@@ -2164,7 +2236,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     return () => {
       cancelled = true;
     };
-  }, [activeTab, checking, collaboratorsRequestKey, fetchAdminWithAuth, handle, hasAccess, platform, summaryUninitialized, user]);
+  }, [checking, collaboratorsRequestKey, fetchAdminWithAuth, handle, hasAccess, platform, selectedTab, summaryUninitialized, user]);
 
   const displayCatalogTotalPosts = useMemo(() => {
     if (supportsCatalog && Number(summary?.live_catalog_total_posts ?? 0) > 0) {
@@ -2266,7 +2338,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   }, [hashtags, summaryTopHashtagsPreview, useSummaryTopHashtagsPreview]);
 
   const statsHashtagsPending = useMemo(() => {
-    const shouldShowFetchedHashtags = activeTab === "hashtags";
+    const shouldShowFetchedHashtags = selectedTab === "hashtags";
     if (!shouldShowFetchedHashtags) {
       return false;
     }
@@ -2274,7 +2346,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       return false;
     }
     return hashtagsLoadedRequestKey !== hashtagsRequestKey;
-  }, [activeTab, hashtagsLoadedRequestKey, hashtagsRequestKey, useSummaryTopHashtagsPreview]);
+  }, [hashtagsLoadedRequestKey, hashtagsRequestKey, selectedTab, useSummaryTopHashtagsPreview]);
 
   const hashtagsErrorMessage = useMemo(() => formatHashtagRequestErrorMessage(hashtagsError), [hashtagsError]);
   const hashtagsErrorToneClass = useMemo(() => {
@@ -2286,7 +2358,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       checking ||
       !user ||
       !hasAccess ||
-      activeTab !== "catalog" ||
+      selectedTab !== "catalog" ||
       !supportsCatalog ||
       platform !== "instagram" ||
       summaryUninitialized ||
@@ -2350,7 +2422,6 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     };
   }, [
     activeCatalogRun,
-    activeTab,
     checking,
     fetchAdminWithAuth,
     handle,
@@ -2358,6 +2429,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     latestCatalogRun?.run_id,
     latestCatalogRun?.status,
     platform,
+    selectedTab,
     shouldDeferSecondaryCatalogReads,
     summaryUninitialized,
     supportsCatalog,
@@ -2369,7 +2441,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       checking ||
       !user ||
       !hasAccess ||
-      activeTab !== "catalog" ||
+      selectedTab !== "catalog" ||
       !supportsCatalog ||
       platform !== "instagram" ||
       summaryUninitialized ||
@@ -2433,7 +2505,6 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     };
   }, [
     activeCatalogRun,
-    activeTab,
     applyCatalogGapAnalysisStatus,
     catalogCountsMismatch,
     catalogGapAnalysisRequestNonce,
@@ -2443,6 +2514,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     hasAccess,
     latestCatalogRun?.status,
     platform,
+    selectedTab,
     shouldDeferSecondaryCatalogReads,
     summaryUninitialized,
     supportsCatalog,
@@ -2454,7 +2526,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       checking ||
       !user ||
       !hasAccess ||
-      activeTab !== "catalog" ||
+      selectedTab !== "catalog" ||
       !supportsCatalog ||
       platform !== "instagram" ||
       summaryUninitialized ||
@@ -2535,7 +2607,6 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [
-    activeTab,
     applyCatalogGapAnalysisStatus,
     catalogCountsMismatch,
     catalogGapAnalysisOperationId,
@@ -2545,6 +2616,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     handle,
     hasAccess,
     platform,
+    selectedTab,
     shouldDeferSecondaryCatalogReads,
     summaryUninitialized,
     supportsCatalog,
@@ -3381,19 +3453,15 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     return "Catalog fetch is complete and the saved catalog totals shown above reflect the latest stored rows.";
   }, [catalogRunProgress?.classify_incomplete, catalogRunProgress?.scrape_complete]);
 
-  const commentsSavedPosts = useMemo(() => {
-    return Number(summary?.comments_saved_summary?.saved_posts ?? 0);
-  }, [summary?.comments_saved_summary?.saved_posts]);
+  const commentsSavedCount = useMemo(() => {
+    return Number(summary?.comments_saved_summary?.saved_comments ?? 0);
+  }, [summary?.comments_saved_summary?.saved_comments]);
 
-  const commentsTargetPosts = useMemo(
-    () => Number(summary?.comments_saved_summary?.total_posts ?? 0),
-    [summary?.comments_saved_summary?.total_posts],
+  const commentsRetrievedCount = useMemo(
+    () => Number(summary?.comments_saved_summary?.retrieved_comments ?? 0),
+    [summary?.comments_saved_summary?.retrieved_comments],
   );
-
-  const displayCommentsSaved = useMemo(
-    () => formatPercent(commentsSavedPosts, commentsTargetPosts),
-    [commentsSavedPosts, commentsTargetPosts],
-  );
+  const commentsSavedSummaryUnavailable = !summaryInitialStatePending && summary?.comments_saved_summary == null;
 
   const mediaSavedFiles = useMemo(
     () => Number(summary?.media_coverage?.saved_files ?? 0),
@@ -3405,10 +3473,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     [summary?.media_coverage?.total_files],
   );
 
-  const displayMediaSaved = useMemo(
-    () => formatPercent(mediaSavedFiles, mediaTotalFiles),
-    [mediaSavedFiles, mediaTotalFiles],
-  );
+  const mediaCoverageUnavailable = !summaryInitialStatePending && summary?.media_coverage == null;
 
   const displayLastPostAt = useMemo(() => {
     if (supportsCatalog && Number(summary?.live_catalog_total_posts ?? 0) > 0 && summary?.live_catalog_last_post_at) {
@@ -3847,10 +3912,19 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
         if (action === "backfill" && platform === "instagram") {
           const launchTaskResolutionPending =
             data.launch_state === "pending" || Boolean(data.launch_task_resolution_pending);
+          const attachedFollowups = data.attached_followups ?? null;
+          const attachedComments = attachedFollowups?.comments ?? null;
+          const attachedMedia = attachedFollowups?.media ?? null;
+          const commentsSourceLabel = formatAttachedLaneSourceLabel(attachedComments?.source);
           const launchParts = [
             data.launch_group_id ? `Launch ${data.launch_group_id.slice(0, 8)}` : null,
             catalogRunId ? `Catalog ${catalogRunId.slice(0, 8)}` : null,
-            commentsRunId ? `Comments ${commentsRunId.slice(0, 8)}` : null,
+            commentsRunId
+              ? `Comments ${commentsRunId.slice(0, 8)}${commentsSourceLabel ? ` (${commentsSourceLabel.toLowerCase()})` : ""}`
+              : attachedComments?.source === "deferred_after_catalog"
+                ? "Comments deferred"
+                : null,
+            attachedMedia ? "Media attached" : null,
             commentsDeferredUntilCatalogComplete ? "Comments deferred until catalog completes" : null,
           ].filter(Boolean);
           const selectedTaskSet =
@@ -4690,24 +4764,34 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                   </div>
                   <div className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm">
                     <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Comments Saved</p>
-                    {summaryInitialStatePending ? (
-                      <p className="mt-2 text-sm font-semibold text-zinc-500">Loading…</p>
+                    {summaryInitialStatePending || commentsSavedSummaryUnavailable ? (
+                      <>
+                        <p className="mt-2 text-sm font-semibold text-zinc-500">Loading…</p>
+                        {commentsSavedSummaryUnavailable ? (
+                          <p className="mt-1 text-xs text-zinc-500">Loads with full profile insights.</p>
+                        ) : null}
+                      </>
                     ) : (
                       <>
-                        <p className="mt-2 text-2xl font-bold text-zinc-900">{displayCommentsSaved}</p>
+                        <p className="mt-2 text-2xl font-bold text-zinc-900">{formatInteger(commentsSavedCount)}</p>
                         <p className="mt-1 text-xs text-zinc-500">
-                          {formatInteger(commentsSavedPosts)} / {formatInteger(commentsTargetPosts)} posts
+                          {formatInteger(commentsSavedCount)} / {formatInteger(commentsRetrievedCount)} comments
                         </p>
                       </>
                     )}
                   </div>
                   <div className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm">
                     <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Media Saved</p>
-                    {summaryInitialStatePending ? (
-                      <p className="mt-2 text-sm font-semibold text-zinc-500">Loading…</p>
+                    {summaryInitialStatePending || mediaCoverageUnavailable ? (
+                      <>
+                        <p className="mt-2 text-sm font-semibold text-zinc-500">Loading…</p>
+                        {mediaCoverageUnavailable ? (
+                          <p className="mt-1 text-xs text-zinc-500">Loads with full profile insights.</p>
+                        ) : null}
+                      </>
                     ) : (
                       <>
-                        <p className="mt-2 text-2xl font-bold text-zinc-900">{displayMediaSaved}</p>
+                        <p className="mt-2 text-2xl font-bold text-zinc-900">{formatInteger(mediaSavedFiles)}</p>
                         <p className="mt-1 text-xs text-zinc-500">
                           {formatInteger(mediaSavedFiles)} / {formatInteger(mediaTotalFiles)} files
                         </p>
@@ -4739,7 +4823,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
 
             <nav className="mt-6 flex flex-wrap items-center gap-2" aria-label="Social account profile tabs">
               {visibleTabs.map((tab) => {
-                const isActive = tab === activeTab;
+                const isActive = tab === selectedTab;
                 return (
                   <Link
                     key={tab}
@@ -4908,6 +4992,8 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                   <p className="mt-1 text-sm text-zinc-500">
                     Run {shortRunId(displayedCatalogRunId)} · {displayedCatalogRunStatusLabel}
                     {catalogRunProgress?.created_at ? ` · queued ${formatDateTime(catalogRunProgress.created_at)}` : ""}
+                    {catalogRunProgress?.launch_group_id ? ` · launch ${shortRunId(catalogRunProgress.launch_group_id)}` : ""}
+                    {catalogRunProgress?.launch_state ? ` · ${formatRunStatusLabel(catalogRunProgress.launch_state)}` : ""}
                     {catalogProgressLastSuccessAt ? ` · last refresh ${formatDateTime(catalogProgressLastSuccessAt)}` : ""}
                   </p>
                   {catalogPhaseLabel ? <p className="mt-2 text-sm font-medium text-zinc-700">{catalogPhaseLabel}</p> : null}
@@ -5038,6 +5124,43 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                   style={{ width: `${catalogProgressBarWidthPct}%` }}
                 />
               </div>
+
+              {buildCatalogLaneCards({
+                runStatus: catalogRunProgress?.run_status ?? displayedCatalogRunStatus,
+                selectedTasks: catalogRunProgress?.selected_tasks,
+                effectiveSelectedTasks: catalogRunProgress?.effective_selected_tasks,
+                commentsRunId: catalogRunProgress?.comments_run_id,
+                attachedFollowups: catalogRunProgress?.attached_followups,
+              }).length > 0 ? (
+                <div className="mt-4 grid gap-3 md:grid-cols-3">
+                  {buildCatalogLaneCards({
+                    runStatus: catalogRunProgress?.run_status ?? displayedCatalogRunStatus,
+                    selectedTasks: catalogRunProgress?.selected_tasks,
+                    effectiveSelectedTasks: catalogRunProgress?.effective_selected_tasks,
+                    commentsRunId: catalogRunProgress?.comments_run_id,
+                    attachedFollowups: catalogRunProgress?.attached_followups,
+                  }).map((lane) => (
+                    <div key={lane.key} className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-500">{lane.label}</p>
+                      <div className="mt-2 flex flex-wrap items-center gap-2">
+                        <span
+                          className={`rounded-full border px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.12em] ${getCatalogRunStatusTone(
+                            lane.status,
+                          )}`}
+                        >
+                          {formatRunStatusLabel(lane.status)}
+                        </span>
+                        {lane.sourceLabel ? (
+                          <span className="rounded-full border border-zinc-200 bg-white px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-zinc-600">
+                            {lane.sourceLabel}
+                          </span>
+                        ) : null}
+                      </div>
+                      {lane.detail ? <p className="mt-2 text-xs text-zinc-600">{lane.detail}</p> : null}
+                    </div>
+                  ))}
+                </div>
+              ) : null}
 
               {catalogRunProgressLoading && !catalogRunProgress ? (
                 <p className="mt-4 text-sm text-zinc-500">Loading live run progress…</p>
@@ -5269,14 +5392,14 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
             </section>
           ) : null}
 
-          {activeTab === "socialblade" ? (
+          {selectedTab === "socialblade" ? (
             <SocialGrowthSection
               platform={platform as Extract<SocialPlatformSlug, "instagram" | "facebook" | "youtube">}
               handle={handle}
             />
           ) : null}
 
-          {hasSummary && activeTab === "stats" ? (
+          {hasSummary && selectedTab === "stats" ? (
             <div className="grid gap-6 lg:grid-cols-[1.15fr_0.85fr]">
               <section className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
                 <h2 className="text-lg font-semibold text-zinc-900">Distribution</h2>
@@ -5457,7 +5580,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
             </div>
           ) : null}
 
-          {hasSummary && activeTab === "catalog" ? (
+          {hasSummary && selectedTab === "catalog" ? (
             supportsCatalog ? (
               <div className="space-y-6">
                 <section className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
@@ -5595,12 +5718,58 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                                   Status {formatRunStatusLabel(run.status)}
                                 </span>
                                 <span className="text-xs font-semibold text-zinc-500">Run {shortRunId(run.run_id)}</span>
+                                {run.launch_group_id ? (
+                                  <span className="text-xs font-semibold text-zinc-500">
+                                    Launch {shortRunId(run.launch_group_id)}
+                                  </span>
+                                ) : null}
                               </div>
                               <p className="mt-2 text-xs text-zinc-500">
                                 Queued {formatDateTime(run.created_at)}
                                 {run.started_at ? ` · started ${formatDateTime(run.started_at)}` : ""}
                                 {run.completed_at ? ` · finished ${formatDateTime(run.completed_at)}` : ""}
+                                {run.launch_state ? ` · ${formatRunStatusLabel(run.launch_state)}` : ""}
                               </p>
+                              {run.selected_tasks && run.selected_tasks.length > 0 ? (
+                                <p className="mt-2 text-xs text-zinc-500">
+                                  Selected: {run.selected_tasks.map((task) => formatBackfillTaskLabel(task)).join(", ")}
+                                  {run.effective_selected_tasks && run.effective_selected_tasks.length > 0
+                                    ? ` · Executing: ${run.effective_selected_tasks
+                                        .map((task) => formatBackfillTaskLabel(task))
+                                        .join(", ")}`
+                                    : ""}
+                                </p>
+                              ) : null}
+                              <div className="mt-3 grid gap-2 md:grid-cols-3">
+                                {buildCatalogLaneCards({
+                                  runStatus: run.status,
+                                  selectedTasks: run.selected_tasks,
+                                  effectiveSelectedTasks: run.effective_selected_tasks,
+                                  commentsRunId: run.comments_run_id,
+                                  attachedFollowups: run.attached_followups,
+                                }).map((lane) => (
+                                  <div key={`${run.run_id}-${lane.key}`} className="rounded-xl border border-zinc-200 bg-white px-3 py-2">
+                                    <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-500">
+                                      {lane.label}
+                                    </p>
+                                    <div className="mt-1 flex flex-wrap items-center gap-2">
+                                      <span
+                                        className={`rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] ${getCatalogRunStatusTone(
+                                          lane.status,
+                                        )}`}
+                                      >
+                                        {formatRunStatusLabel(lane.status)}
+                                      </span>
+                                      {lane.sourceLabel ? (
+                                        <span className="rounded-full border border-zinc-200 bg-zinc-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-600">
+                                          {lane.sourceLabel}
+                                        </span>
+                                      ) : null}
+                                    </div>
+                                    {lane.detail ? <p className="mt-1 text-xs text-zinc-600">{lane.detail}</p> : null}
+                                  </div>
+                                ))}
+                              </div>
                             </div>
                             <div className="flex items-center gap-2">
                               {(String(run.status || "").trim().toLowerCase() === "failed" ||
@@ -5649,7 +5818,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
             )
           ) : null}
 
-          {hasSummary && activeTab === "comments" && supportsComments ? (
+          {hasSummary && selectedTab === "comments" && supportsComments ? (
             hasFullSummary ? (
               <InstagramCommentsPanel
                 platform={platform}
@@ -5680,7 +5849,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
             )
           ) : null}
 
-          {hasSummary && activeTab === "posts" ? (
+          {hasSummary && selectedTab === "posts" ? (
             <section className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
               <div className="flex items-center justify-between gap-3">
                 <div>
@@ -5791,7 +5960,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
             </section>
           ) : null}
 
-          {hasSummary && activeTab === "hashtags" ? (
+          {hasSummary && selectedTab === "hashtags" ? (
             <div className="space-y-6">
               {platform === "instagram" ? (
                 <SocialAccountProfileHashtagTimelineChart
@@ -6027,7 +6196,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
             </div>
           ) : null}
 
-          {hasSummary && activeTab === "collaborators-tags" ? (
+          {hasSummary && selectedTab === "collaborators-tags" ? (
             <div className="space-y-6">
               <section className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
                 <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">

--- a/apps/web/src/components/admin/SystemHealthModal.tsx
+++ b/apps/web/src/components/admin/SystemHealthModal.tsx
@@ -83,6 +83,8 @@ type FailureEntry = {
   completed_at: string | null;
 };
 
+const ACTION_MESSAGE_AUTO_DISMISS_MS = 10 * 60 * 1000;
+
 type StuckJobEntry = {
   id: string;
   run_id: string | null;
@@ -2117,6 +2119,19 @@ export default function SystemHealthModal({ isOpen, onClose }: { isOpen: boolean
   const [debugResult, setDebugResult] = useState<DebugJobResult | null>(null);
   const [debugError, setDebugError] = useState<string | null>(null);
   const [copyingDebugSnapshot, setCopyingDebugSnapshot] = useState(false);
+
+  useEffect(() => {
+    if (!actionNotice && !actionError) {
+      return;
+    }
+    const timeoutId = window.setTimeout(() => {
+      setActionNotice(null);
+      setActionError(null);
+    }, ACTION_MESSAGE_AUTO_DISMISS_MS);
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [actionError, actionNotice]);
 
   const statusData = useMemo<HealthDotStatus | null>(
     () =>

--- a/apps/web/src/lib/admin/social-account-profile.ts
+++ b/apps/web/src/lib/admin/social-account-profile.ts
@@ -210,13 +210,23 @@ export type SocialAccountCommentsCoverage = {
 };
 
 export type SocialAccountCommentsSavedSummary = {
-  saved_posts: number;
-  total_posts: number;
+  saved_comments: number;
+  retrieved_comments: number;
+  saved_comment_posts?: number | null;
+  retrieved_comment_posts?: number | null;
+  saved_comment_media_files?: number | null;
 };
 
 export type SocialAccountMediaCoverage = {
   saved_files: number;
   total_files: number;
+  saved_post_media_files?: number | null;
+  total_post_media_files?: number | null;
+  saved_comment_media_files?: number | null;
+  total_comment_media_files?: number | null;
+  saved_avatar_files?: number | null;
+  saved_reel_still_files?: number | null;
+  total_reel_still_files?: number | null;
 };
 
 export type SocialAccountProfileComment = {
@@ -340,6 +350,27 @@ export type SocialAccountCatalogActionScope =
   | "head_gap"
   | "frontier_resume";
 
+export type SocialAccountCatalogAttachedCommentsFollowup = {
+  run_id?: string | null;
+  state?: string | null;
+  status?: string | null;
+  source?: "new_run" | "reused_run" | "deferred_after_catalog" | null;
+};
+
+export type SocialAccountCatalogAttachedMediaFollowup = {
+  attachment_id?: string | null;
+  state?: string | null;
+  status?: string | null;
+  source?: "catalog_media_mirror" | "comments_media_followups" | null;
+  enqueued_job_ids?: string[];
+  enqueued_job_count?: number;
+};
+
+export type SocialAccountCatalogAttachedFollowups = {
+  comments?: SocialAccountCatalogAttachedCommentsFollowup | null;
+  media?: SocialAccountCatalogAttachedMediaFollowup | null;
+};
+
 export type SocialAccountCatalogRun = {
   job_id: string;
   run_id: string;
@@ -350,6 +381,12 @@ export type SocialAccountCatalogRun = {
   started_at?: string | null;
   completed_at?: string | null;
   error_message?: string | null;
+  launch_group_id?: string | null;
+  launch_state?: "pending" | "ready" | "failed" | null;
+  selected_tasks?: CatalogBackfillSelectedTask[];
+  effective_selected_tasks?: CatalogBackfillSelectedTask[];
+  comments_run_id?: string | null;
+  attached_followups?: SocialAccountCatalogAttachedFollowups | null;
 };
 
 export type SocialAccountCatalogRunProgressStage = {
@@ -529,8 +566,14 @@ export type SocialAccountCatalogRunProgressSnapshot = {
   season_id?: string | null;
   run_id: string;
   run_status: string;
+  launch_group_id?: string | null;
+  launch_state?: "pending" | "ready" | "failed" | null;
   catalog_action?: SocialAccountCatalogAction | null;
   catalog_action_scope?: SocialAccountCatalogActionScope | null;
+  selected_tasks?: CatalogBackfillSelectedTask[];
+  effective_selected_tasks?: CatalogBackfillSelectedTask[];
+  comments_run_id?: string | null;
+  attached_followups?: SocialAccountCatalogAttachedFollowups | null;
   operational_state?:
     | "blocked_auth"
     | "discovering"
@@ -745,6 +788,7 @@ export type CatalogBackfillLaunchResponse = {
   post_details_skipped_reason?: "already_materialized" | null;
   catalog_run_id?: string | null;
   comments_run_id?: string | null;
+  attached_followups?: SocialAccountCatalogAttachedFollowups | null;
   catalog_bootstrap_required?: boolean;
   comments_deferred_until_catalog_complete?: boolean;
 };

--- a/apps/web/tests/social-account-profile-page.runtime.test.tsx
+++ b/apps/web/tests/social-account-profile-page.runtime.test.tsx
@@ -107,6 +107,24 @@ const baseSummary = {
   last_catalog_run_at: "2026-03-17T12:00:00.000Z",
   last_catalog_run_status: "completed",
   catalog_recent_runs: [],
+  comments_saved_summary: {
+    saved_comments: 41,
+    retrieved_comments: 429,
+    saved_comment_posts: 8,
+    retrieved_comment_posts: 12,
+    saved_comment_media_files: 7,
+  },
+  media_coverage: {
+    saved_files: 1289,
+    total_files: 1400,
+    saved_post_media_files: 1200,
+    total_post_media_files: 1300,
+    saved_comment_media_files: 60,
+    total_comment_media_files: 75,
+    saved_avatar_files: 55,
+    saved_reel_still_files: 29,
+    total_reel_still_files: 29,
+  },
   comments_coverage: {
     available_posts: 12,
     eligible_posts: 12,
@@ -249,6 +267,75 @@ describe("SocialAccountProfilePage", () => {
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Backfill Posts" })).toBeInTheDocument();
     });
+  });
+
+  it("renders comment-row and media-file totals in the top summary tiles", async () => {
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse(baseSummary);
+      }
+      if (url.includes("/snapshot")) {
+        return jsonResponse({
+          summary: baseSummary,
+          catalog_run_progress: null,
+          generated_at: "2026-04-09T03:00:00.000Z",
+        });
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="instagram" handle="bravotv" activeTab="stats" />);
+
+    const commentsTile = await screen.findByText("Comments Saved");
+    const commentsCard = commentsTile.closest("div.rounded-2xl");
+    expect(commentsCard).not.toBeNull();
+    expect(within(commentsCard as HTMLElement).getByText("41")).toBeInTheDocument();
+    expect(within(commentsCard as HTMLElement).getByText("41 / 429 comments")).toBeInTheDocument();
+
+    const mediaTile = screen.getByText("Media Saved");
+    const mediaCard = mediaTile.closest("div.rounded-2xl");
+    expect(mediaCard).not.toBeNull();
+    expect(within(mediaCard as HTMLElement).getByText("1,289")).toBeInTheDocument();
+    expect(within(mediaCard as HTMLElement).getByText("1,289 / 1,400 files")).toBeInTheDocument();
+  });
+
+  it("aliases the legacy posts tab to catalog for catalog-backed platforms", async () => {
+    const requestUrls: string[] = [];
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      requestUrls.push(url);
+      if (url.includes("/snapshot")) {
+        return jsonResponse({
+          summary: baseSummary,
+          catalog_run_progress: null,
+          generated_at: "2026-04-09T03:00:00.000Z",
+        });
+      }
+      if (url.includes("/summary")) {
+        return jsonResponse(baseSummary);
+      }
+      if (url.includes("/catalog/posts")) {
+        return jsonResponse({
+          items: [],
+          pagination: { page: 1, page_size: 25, total: 0, total_pages: 1 },
+        });
+      }
+      if (url.includes("/catalog/review-queue")) {
+        return jsonResponse({ items: [] });
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="instagram" handle="bravotv" activeTab="posts" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Catalog" })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("link", { name: "Posts" })).not.toBeInTheDocument();
+    expect(requestUrls.some((url) => url.includes("/catalog/posts"))).toBe(true);
+    expect(requestUrls.some((url) => url.includes("/profiles/instagram/bravotv/posts?page="))).toBe(false);
   });
 
   it("renders supported-platform catalog actions on the stats tab", async () => {
@@ -1004,6 +1091,57 @@ describe("SocialAccountProfilePage", () => {
     expect(screen.queryByText("TRR-Backend request timed out.")).not.toBeInTheDocument();
   });
 
+  it("keeps the snapshot-backed shell visible when the live lite summary times out afterward", async () => {
+    let liveSummaryCalls = 0;
+    const liteSummary = {
+      ...baseSummary,
+      summary_detail: "lite" as const,
+      comments_saved_summary: null,
+      media_coverage: null,
+      comments_coverage: null,
+      per_show_counts: [],
+      per_season_counts: [],
+      top_hashtags: [],
+      top_collaborators: [],
+      top_tags: [],
+    };
+
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/snapshot")) {
+        return jsonResponse({
+          summary: liteSummary,
+          catalog_run_progress: null,
+          generated_at: "2026-04-21T12:00:00.000Z",
+        });
+      }
+      if (url.includes("/summary")) {
+        liveSummaryCalls += 1;
+        return jsonResponse(
+          {
+            error: "TRR-Backend request timed out.",
+            code: "BACKEND_REQUEST_TIMEOUT",
+            retryable: true,
+            upstream_status: 504,
+            upstream_detail_code: "REQUEST_TIMEOUT",
+          },
+          504,
+        );
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="instagram" handle="bravodailydish" activeTab="stats" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("12 / 12")).toBeInTheDocument();
+    });
+
+    expect(liveSummaryCalls).toBe(1);
+    expect(screen.queryByText("Summary read timed out before completion. Retry in a moment.")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Loads with full profile insights.").length).toBeGreaterThan(0);
+  });
+
   it("shows a timeout-specific summary banner when the lite summary fallback also times out", async () => {
     mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input);
@@ -1376,6 +1514,228 @@ describe("SocialAccountProfilePage", () => {
     expect(
       screen.getByText(/Post Details skipped because all catalog posts are already materialized\./),
     ).toBeInTheDocument();
+  });
+
+  it("shows reused comments and attached media in Instagram launch copy", async () => {
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse(baseSummary);
+      }
+      if (url.includes("/cookies/health")) {
+        return jsonResponse(healthyCookieHealth("instagram"));
+      }
+      if (url.includes("/catalog/backfill")) {
+        expect(init?.method).toBe("POST");
+        return jsonResponse({
+          run_id: "catalog-run-12345678",
+          status: "queued",
+          launch_group_id: "launch-group-1",
+          catalog_run_id: "catalog-run-12345678",
+          comments_run_id: "comments-run-12345679",
+          effective_selected_tasks: ["comments", "media"],
+          attached_followups: {
+            comments: {
+              run_id: "comments-run-12345679",
+              state: "running",
+              status: "running",
+              source: "reused_run",
+            },
+            media: {
+              attachment_id: "media-launch-group-1",
+              state: "pending",
+              status: "queued",
+              source: "catalog_media_mirror",
+              enqueued_job_ids: ["media-job-1"],
+              enqueued_job_count: 1,
+            },
+          },
+        });
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="instagram" handle="bravotv" activeTab="catalog" />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Backfill Posts" }));
+    fireEvent.click(screen.getByRole("button", { name: "Start Backfill" }));
+
+    expect(await screen.findByText(/comments comments.*\(reused\) · media attached\./i)).toBeInTheDocument();
+  });
+
+  it("renders deferred attached lanes on recent Instagram catalog runs", async () => {
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse({
+          ...baseSummary,
+          catalog_recent_runs: [
+            {
+              run_id: "catalog-run-deferred-1",
+              status: "running",
+              created_at: "2026-04-21T12:00:00Z",
+              launch_group_id: "launch-group-deferred-1",
+              launch_state: "ready",
+              selected_tasks: ["post_details", "comments", "media"],
+              effective_selected_tasks: ["post_details", "comments", "media"],
+              attached_followups: {
+                comments: {
+                  run_id: null,
+                  state: "pending",
+                  status: "pending",
+                  source: "deferred_after_catalog",
+                },
+                media: {
+                  attachment_id: "media-launch-group-deferred-1",
+                  state: "pending",
+                  status: "queued",
+                  source: "catalog_media_mirror",
+                  enqueued_job_ids: [],
+                  enqueued_job_count: 0,
+                },
+              },
+            },
+          ],
+        });
+      }
+      if (url.includes("/catalog/runs/catalog-run-deferred-1/progress")) {
+        return jsonResponse({
+          run_id: "catalog-run-deferred-1",
+          run_status: "running",
+          source_scope: "bravo",
+          stages: {},
+          per_handle: [],
+          recent_log: [],
+          alerts: [],
+          summary: {
+            total_jobs: 1,
+            completed_jobs: 0,
+            failed_jobs: 0,
+            active_jobs: 1,
+            items_found_total: 0,
+          },
+        });
+      }
+      if (url.includes("/cookies/health")) {
+        return jsonResponse(healthyCookieHealth("instagram"));
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="instagram" handle="bravotv" activeTab="catalog" />);
+
+    const recentRunsHeading = await screen.findByText("Recent Catalog Runs");
+    const recentRunsSection = recentRunsHeading.closest("section");
+    expect(recentRunsSection).not.toBeNull();
+    expect(within(recentRunsSection as HTMLElement).getByText("Deferred")).toBeInTheDocument();
+    expect(within(recentRunsSection as HTMLElement).getByText("Starts after catalog completion")).toBeInTheDocument();
+  });
+
+  it("renders reused comments and attached media lanes in catalog progress", async () => {
+    const progressPayload = {
+      run_id: "catalog-run-reused-1",
+      run_status: "running",
+      source_scope: "bravo",
+      selected_tasks: ["comments", "media"],
+      effective_selected_tasks: ["comments", "media"],
+      comments_run_id: "comments-run-reused-1",
+      attached_followups: {
+        comments: {
+          run_id: "comments-run-reused-1",
+          state: "running",
+          status: "running",
+          source: "reused_run",
+        },
+        media: {
+          attachment_id: "media-launch-group-reused-1",
+          state: "pending",
+          status: "queued",
+          source: "catalog_media_mirror",
+          enqueued_job_ids: ["media-job-1", "media-job-2"],
+          enqueued_job_count: 2,
+        },
+      },
+      stages: {},
+      per_handle: [],
+      recent_log: [],
+      alerts: [],
+      summary: {
+        total_jobs: 1,
+        completed_jobs: 0,
+        failed_jobs: 0,
+        active_jobs: 1,
+        items_found_total: 0,
+      },
+    };
+
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse({
+          ...baseSummary,
+          catalog_recent_runs: [
+            {
+              run_id: "catalog-run-reused-1",
+              status: "running",
+              created_at: "2026-04-21T12:00:00Z",
+              selected_tasks: ["comments", "media"],
+              effective_selected_tasks: ["comments", "media"],
+              comments_run_id: "comments-run-reused-1",
+              attached_followups: {
+                comments: {
+                  run_id: "comments-run-reused-1",
+                  state: "running",
+                  status: "running",
+                  source: "reused_run",
+                },
+                media: {
+                  attachment_id: "media-launch-group-reused-1",
+                  state: "pending",
+                  status: "queued",
+                  source: "catalog_media_mirror",
+                  enqueued_job_ids: ["media-job-1", "media-job-2"],
+                  enqueued_job_count: 2,
+                },
+              },
+            },
+          ],
+        });
+      }
+      if (url.includes("/snapshot")) {
+        return jsonResponse({
+          summary: {
+            ...baseSummary,
+            catalog_recent_runs: [
+              {
+                run_id: "catalog-run-reused-1",
+                status: "running",
+                created_at: "2026-04-21T12:00:00Z",
+                selected_tasks: ["comments", "media"],
+                effective_selected_tasks: ["comments", "media"],
+                comments_run_id: "comments-run-reused-1",
+                attached_followups: progressPayload.attached_followups,
+              },
+            ],
+          },
+          catalog_run_progress: progressPayload,
+        });
+      }
+      if (url.includes("/catalog/runs/catalog-run-reused-1/progress")) {
+        return jsonResponse(progressPayload);
+      }
+      if (url.includes("/cookies/health")) {
+        return jsonResponse(healthyCookieHealth("instagram"));
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="instagram" handle="bravotv" activeTab="catalog" />);
+
+    const progressHeading = await screen.findByText("Catalog Run Progress");
+    const progressSection = progressHeading.closest("section");
+    expect(progressSection).not.toBeNull();
+    expect(within(progressSection as HTMLElement).getByText("Reused")).toBeInTheDocument();
+    expect(within(progressSection as HTMLElement).getByText("2 repair jobs")).toBeInTheDocument();
   });
 
   it("does not POST comments scrape from the page when catalog completion is backend-driven", async () => {
@@ -4193,7 +4553,7 @@ it("prefers terminal cancelled status labels over stale recovering state", async
   render(<SocialAccountProfilePage platform="instagram" handle="bravotv" activeTab="catalog" />);
 
   await waitFor(() => {
-    expect(screen.getByText("Cancelled")).toBeInTheDocument();
+    expect(screen.getAllByText("Cancelled").length).toBeGreaterThan(0);
   });
   expect(screen.getByText(/Run run-canc · Cancelled/i)).toBeInTheDocument();
   expect(screen.queryByText(/^Recovering$/)).not.toBeInTheDocument();
@@ -6280,7 +6640,7 @@ it("prefers terminal cancelled status labels over stale recovering state", async
     expect(progressSection).not.toBeNull();
 
     await waitFor(() => {
-      expect(within(progressSection as HTMLElement).getByText("Completed")).toBeInTheDocument();
+      expect(within(progressSection as HTMLElement).getAllByText("Completed").length).toBeGreaterThan(0);
       expect(within(progressSection as HTMLElement).getByText("0%")).toBeInTheDocument();
       expect(within(progressSection as HTMLElement).getByText("0 / 431 posts checked")).toBeInTheDocument();
       expect(within(progressSection as HTMLElement).getByText("0 persisted")).toBeInTheDocument();

--- a/apps/web/tests/social-account-profile-page.runtime.test.tsx
+++ b/apps/web/tests/social-account-profile-page.runtime.test.tsx
@@ -815,7 +815,7 @@ describe("SocialAccountProfilePage", () => {
     });
   });
 
-  it("queues a per-post comments scrape from the posts tab", async () => {
+  it("routes the legacy posts tab to catalog actions for Instagram accounts", async () => {
     mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes("/summary")) {
@@ -852,38 +852,17 @@ describe("SocialAccountProfilePage", () => {
           },
         });
       }
-      if (url.includes("/comments/scrape")) {
-        expect(init?.method).toBe("POST");
-        expect(init?.body).toBe(
-          JSON.stringify({
-            mode: "single_post",
-            source_id: "C123",
-            max_comments_per_post: 500,
-          }),
-        );
-        return jsonResponse({ run_id: "comments-run-post-1", status: "queued" });
-      }
-      if (url.includes("/comments/runs/comments-run-post-1/progress")) {
-        return jsonResponse({
-          run_id: "comments-run-post-1",
-          platform: "instagram",
-          account_handle: "bravotv",
-          run_status: "completed",
-          job_status: "completed",
-          target_source_ids: ["C123"],
-        });
-      }
       throw new Error(`Unhandled request: ${url}`);
     });
 
     render(<SocialAccountProfilePage platform="instagram" handle="bravotv" activeTab="posts" />);
 
-    const button = await screen.findByRole("button", { name: "Sync Comments" });
-    fireEvent.click(button);
-
     await waitFor(() => {
-      expect(screen.getByText("Comments refreshed.")).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Catalog" })).toBeInTheDocument();
     });
+
+    expect(screen.getByRole("button", { name: "Backfill Posts" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Sync Comments" })).not.toBeInTheDocument();
   });
 
   it("surfaces comments scrape worker errors on the comments tab", async () => {
@@ -1252,7 +1231,7 @@ describe("SocialAccountProfilePage", () => {
     });
   });
 
-  it("renders collaborator-backed Instagram posts without requiring a new run", async () => {
+  it("renders collaborator-backed Instagram catalog posts without requiring a new run", async () => {
     mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.includes("/summary")) {
@@ -1312,7 +1291,7 @@ describe("SocialAccountProfilePage", () => {
       expect(screen.getByText("Bravo Daily Dish x Bravo")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("Collaborator match")).toBeInTheDocument();
+    expect(screen.getByText("Collaborator post already in the catalog.")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open post" })).toHaveAttribute(
       "href",
       "https://www.instagram.com/p/C123/",

--- a/apps/web/tests/system-health-modal-copy.runtime.test.tsx
+++ b/apps/web/tests/system-health-modal-copy.runtime.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   usePathname: vi.fn(() => "/admin/social"),
@@ -167,6 +167,10 @@ describe("SystemHealthModal copy snapshot", () => {
     });
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("copies a debugger-ready snapshot of the current modal state", async () => {
     const writeText = installClipboardMock();
 
@@ -188,6 +192,29 @@ describe("SystemHealthModal copy snapshot", () => {
     expect(copiedText).toContain("\"live_status_sequence\": 17");
 
     expect(await screen.findByText("Copied System Jobs Health debug snapshot to clipboard.")).toBeInTheDocument();
+  });
+
+  it("auto-dismisses action notices after ten minutes", async () => {
+    vi.useFakeTimers();
+    const writeText = installClipboardMock();
+
+    render(<SystemHealthModal isOpen onClose={() => undefined} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Copy debug snapshot" }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Copied System Jobs Health debug snapshot to clipboard.")).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(10 * 60 * 1000);
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText("Copied System Jobs Health debug snapshot to clipboard.")).not.toBeInTheDocument();
   });
 
   it("treats queue aggregate timeouts as degraded when workers are otherwise healthy", async () => {


### PR DESCRIPTION
## Summary
- harden social account profile summary hydration and catalog lane rendering
- make the profile page treat catalog as the canonical posts tab for supported platforms
- expand runtime coverage for the social account profile page and system health copy

## Validation
- local app validation in progress while PR CI runs
