### PR TITLE
Refine social admin profile surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,12 @@
 - Keep app behavior, API assumptions, and admin surfaces aligned with ../AGENTS.md.
 - Validate user-facing runtime assumptions against code, tests, or current runtime state before treating them as fixed.
 
+## Debugging Discipline
+- If the same command or workflow fails twice with the same substantive error, stop retrying blindly. Capture the exact command, full error, relevant stack trace/logs, and recent changes.
+- Inspect local evidence first: source code, config, lockfiles, versions, tests, runtime state, and existing project patterns.
+- If the cause is still unclear, or the failure involves third-party tooling, APIs, packages, browser/runtime behavior, or time-sensitive docs, research current primary sources such as official docs, release notes, and issue trackers. Identify 3-5 plausible causes or fixes before choosing one.
+- Apply the smallest evidence-backed fix one change at a time, then rerun the failing command or workflow to verify. If the best fix is risky or ambiguous, explain the options before editing.
+
 ## Validation
 - Run app-local validation or tests touched by the change.
 - Re-read ../AGENTS.md when workspace startup, MCP routing, or cross-repo policy is involved.

--- a/TRR App Brain/AGENTS.md
+++ b/TRR App Brain/AGENTS.md
@@ -14,3 +14,9 @@ Read files in this directory only when the user explicitly asks for saved memory
 - Old plans are stale by default.
 - Failed, superseded, incomplete, or already-implemented plans must not be resumed without current repo verification and explicit user intent.
 - If a saved note conflicts with current code or docs, current code and docs win.
+
+## Debugging Discipline
+- If the same command or workflow fails twice with the same substantive error, stop retrying blindly. Capture the exact command, full error, relevant stack trace/logs, and recent changes.
+- Inspect local evidence first: source code, config, lockfiles, versions, tests, runtime state, and existing project patterns.
+- If the cause is still unclear, or the failure involves third-party tooling, APIs, packages, browser/runtime behavior, or time-sensitive docs, research current primary sources such as official docs, release notes, and issue trackers. Identify 3-5 plausible causes or fixes before choosing one.
+- Apply the smallest evidence-backed fix one change at a time, then rerun the failing command or workflow to verify. If the best fix is risky or ambiguous, explain the options before editing.

--- a/apps/web/src/app/api/admin/social/landing/route.ts
+++ b/apps/web/src/app/api/admin/social/landing/route.ts
@@ -58,6 +58,13 @@ const SHOW_EXTERNAL_ID_KEYS_BY_PLATFORM = {
 type LandingTargetType = "network" | "show" | "person" | "shared_source";
 type LandingPlatform = keyof typeof SHOW_EXTERNAL_ID_KEYS_BY_PLATFORM;
 type SharedSourceTargetScope = (typeof SHARED_SOURCE_TARGET_SCOPES)[keyof typeof SHARED_SOURCE_TARGET_SCOPES];
+type NormalizedSocialSourceInput = {
+  accountHandle: string;
+  externalIdValue: string;
+  sourceType: "account" | "playlist";
+  sourceUrl?: string;
+  sourceExternalId?: string;
+};
 
 const isLandingTargetType = (value: unknown): value is LandingTargetType =>
   value === "network" || value === "show" || value === "person" || value === "shared_source";
@@ -89,6 +96,46 @@ const normalizeInternalHandle = (platform: LandingPlatform, rawValue: string): s
   return canonicalHandle;
 };
 
+const extractYouTubePlaylistId = (rawValue: string): string => {
+  const value = rawValue.trim();
+  if (!value) return "";
+  try {
+    const url = new URL(value.startsWith("http") ? value : `https://${value}`);
+    const playlistId = url.searchParams.get("list")?.trim() || "";
+    if (playlistId) return playlistId;
+  } catch {
+    // Fall through to raw-id parsing.
+  }
+  const direct = value.split(/[?#]/)[0]?.trim() || "";
+  if (/^(?:PL|UU|LL|FL|RD|OLAK5uy_)[A-Za-z0-9_-]{8,}$/.test(direct)) return direct;
+  const match = value.match(/(?:list=|\/playlist\/)([A-Za-z0-9_-]{10,})/);
+  return match?.[1]?.trim() || "";
+};
+
+const normalizeSocialSourceInput = (
+  platform: LandingPlatform,
+  rawValue: string,
+): NormalizedSocialSourceInput => {
+  if (platform === "youtube") {
+    const playlistId = extractYouTubePlaylistId(rawValue);
+    if (playlistId) {
+      return {
+        accountHandle: playlistId,
+        externalIdValue: playlistId,
+        sourceType: "playlist",
+        sourceUrl: `https://www.youtube.com/playlist?list=${playlistId}`,
+        sourceExternalId: playlistId,
+      };
+    }
+  }
+  const accountHandle = normalizeInternalHandle(platform, rawValue);
+  return {
+    accountHandle,
+    externalIdValue: accountHandle,
+    sourceType: "account",
+  };
+};
+
 const normalizePersonExternalId = (platform: LandingPlatform, rawValue: string): string => {
   const normalizedValue = normalizePersonExternalIdValue(platform, rawValue);
   if (!normalizedValue) {
@@ -110,12 +157,18 @@ const buildShowSharedSourceMetadata = ({
   showName,
   platform,
   accountHandle,
+  sourceType,
+  sourceUrl,
+  sourceExternalId,
   existingMetadata = {},
 }: {
   showId: string;
   showName: string;
   platform: LandingPlatform;
   accountHandle: string;
+  sourceType: "account" | "playlist";
+  sourceUrl?: string;
+  sourceExternalId?: string;
   existingMetadata?: Record<string, unknown>;
 }): Record<string, unknown> => ({
   ...existingMetadata,
@@ -128,7 +181,13 @@ const buildShowSharedSourceMetadata = ({
   source_scope: SHOW_HANDLE_SHARED_SOURCE_SCOPE,
   account_handle: accountHandle,
   platform,
-  assignment_mode: "community_match",
+  source_type: sourceType,
+  youtube_source_type: platform === "youtube" ? sourceType : undefined,
+  source_url: sourceUrl,
+  playlist_url: sourceType === "playlist" ? sourceUrl : undefined,
+  playlist_id: sourceType === "playlist" ? sourceExternalId : undefined,
+  source_external_id: sourceExternalId,
+  assignment_mode: sourceType === "playlist" ? "direct_source" : "community_match",
   assignment_rules: {
     use_hashtags: true,
     use_mentions: true,
@@ -143,13 +202,13 @@ const syncShowSharedSource = async ({
   showId,
   showName,
   platform,
-  accountHandle,
+  sourceInput,
 }: {
   adminContext: ReturnType<typeof toVerifiedAdminContext>;
   showId: string;
   showName: string;
   platform: LandingPlatform;
-  accountHandle: string;
+  sourceInput: NormalizedSocialSourceInput;
 }) => {
   const current = (await fetchSocialBackendJson("/shared/sources", {
     adminContext,
@@ -182,18 +241,21 @@ const syncShowSharedSource = async ({
   const existingIndex = nextSources.findIndex(
     (source) =>
       source.platform === platform &&
-      source.account_handle.toLowerCase() === accountHandle.toLowerCase(),
+      source.account_handle.toLowerCase() === sourceInput.accountHandle.toLowerCase(),
   );
   const nextSource = {
     platform,
-    account_handle: accountHandle,
+    account_handle: sourceInput.accountHandle,
     is_active: true,
     scrape_priority: existingIndex >= 0 ? nextSources[existingIndex].scrape_priority : 100,
     metadata: buildShowSharedSourceMetadata({
       showId,
       showName,
       platform,
-      accountHandle,
+      accountHandle: sourceInput.accountHandle,
+      sourceType: sourceInput.sourceType,
+      sourceUrl: sourceInput.sourceUrl,
+      sourceExternalId: sourceInput.sourceExternalId,
       existingMetadata: existingIndex >= 0 ? nextSources[existingIndex].metadata : {},
     }),
   };
@@ -396,16 +458,22 @@ export async function POST(request: NextRequest) {
       if (!isSharedSourceTargetScope(sourceScope)) {
         return NextResponse.json({ error: "source_scope must be news or creator" }, { status: 400 });
       }
-      const normalizedHandle = normalizeInternalHandle(platform, rawValue);
+      const sourceInput = normalizeSocialSourceInput(platform, rawValue);
       await upsertSharedSource({
         adminContext,
         sourceScope,
         platform,
-        accountHandle: normalizedHandle,
+        accountHandle: sourceInput.accountHandle,
         metadata: {
           seed_source: `admin-social-landing-${sourceScope}-add`,
-          display_name: displayName || normalizedHandle,
+          display_name: displayName || sourceInput.accountHandle,
           profile_kind: sourceScope,
+          source_type: sourceInput.sourceType,
+          youtube_source_type: platform === "youtube" ? sourceInput.sourceType : undefined,
+          source_url: sourceInput.sourceUrl,
+          playlist_url: sourceInput.sourceType === "playlist" ? sourceInput.sourceUrl : undefined,
+          playlist_id: sourceInput.sourceType === "playlist" ? sourceInput.sourceExternalId : undefined,
+          source_external_id: sourceInput.sourceExternalId,
         },
       });
     }
@@ -415,7 +483,7 @@ export async function POST(request: NextRequest) {
       if (!sourceScope) {
         return NextResponse.json({ error: "Network target not found" }, { status: 404 });
       }
-      const normalizedHandle = normalizeInternalHandle(platform, rawValue);
+      const sourceInput = normalizeSocialSourceInput(platform, rawValue);
       const current = (await fetchSocialBackendJson("/shared/sources", {
         adminContext,
         queryString: `source_scope=${sourceScope}&include_inactive=true`,
@@ -427,7 +495,10 @@ export async function POST(request: NextRequest) {
       const existingIndex = existingSources.findIndex(
         (entry) =>
           String(entry.platform || "").trim().toLowerCase() === platform &&
-          String(entry.account_handle || "").trim().replace(/^@+/, "").toLowerCase() === normalizedHandle.toLowerCase(),
+          String(entry.account_handle || "")
+            .trim()
+            .replace(/^@+/, "")
+            .toLowerCase() === sourceInput.accountHandle.toLowerCase(),
       );
       const nextSources = existingSources.map((entry) => ({
         platform: String(entry.platform || "").trim().toLowerCase(),
@@ -445,10 +516,17 @@ export async function POST(request: NextRequest) {
       } else {
         nextSources.push({
           platform,
-          account_handle: normalizedHandle,
+          account_handle: sourceInput.accountHandle,
           is_active: true,
           scrape_priority: 100,
-          metadata: {},
+          metadata: {
+            source_type: sourceInput.sourceType,
+            youtube_source_type: platform === "youtube" ? sourceInput.sourceType : undefined,
+            source_url: sourceInput.sourceUrl,
+            playlist_url: sourceInput.sourceType === "playlist" ? sourceInput.sourceUrl : undefined,
+            playlist_id: sourceInput.sourceType === "playlist" ? sourceInput.sourceExternalId : undefined,
+            source_external_id: sourceInput.sourceExternalId,
+          },
         });
       }
 
@@ -471,13 +549,18 @@ export async function POST(request: NextRequest) {
       if (!currentShow) {
         return NextResponse.json({ error: "Show not found" }, { status: 404 });
       }
-      const normalizedHandle = normalizeInternalHandle(platform, rawValue);
+      const sourceInput = normalizeSocialSourceInput(platform, rawValue);
       const existingExternalIds =
         currentShow.external_ids && typeof currentShow.external_ids === "object"
           ? { ...(currentShow.external_ids as Record<string, unknown>) }
           : {};
-      for (const key of SHOW_EXTERNAL_ID_KEYS_BY_PLATFORM[platform]) {
-        existingExternalIds[key] = normalizedHandle;
+      if (sourceInput.sourceType === "playlist" && platform === "youtube") {
+        existingExternalIds.youtube_playlist_id = sourceInput.sourceExternalId;
+        existingExternalIds.youtube_playlist_url = sourceInput.sourceUrl;
+      } else {
+        for (const key of SHOW_EXTERNAL_ID_KEYS_BY_PLATFORM[platform]) {
+          existingExternalIds[key] = sourceInput.externalIdValue;
+        }
       }
       await updateShowById(targetId, { externalIds: existingExternalIds });
       await syncShowSharedSource({
@@ -485,7 +568,7 @@ export async function POST(request: NextRequest) {
         showId: targetId,
         showName: currentShow.name || "Show",
         platform,
-        accountHandle: normalizedHandle,
+        sourceInput,
       });
       invalidateTrrShowReadCaches(`${user.uid}:`);
       await invalidateAdminBackendCache(`/admin/trr-api/shows/${targetId}/cache/invalidate`, {

--- a/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/cookies/health/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/cookies/health/route.ts
@@ -17,17 +17,19 @@ export async function GET(request: NextRequest, context: RouteContext) {
     const { platform, handle } = await context.params;
     const force = request.nextUrl.searchParams.get("force") === "true";
     const includePostsAuth = request.nextUrl.searchParams.get("posts_auth") === "true";
+    const includeCommentsAuth = request.nextUrl.searchParams.get("comments_auth") === "true";
     const params = new URLSearchParams();
     if (force) params.set("force", "true");
     if (includePostsAuth) params.set("posts_auth", "true");
+    if (includeCommentsAuth) params.set("comments_auth", "true");
     const qs = params.size > 0 ? `?${params.toString()}` : "";
     const data = await fetchSocialBackendJson(
       `/profiles/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/cookies/health${qs}`,
       {
         method: "GET",
         fallbackError: "Failed to check cookie health",
-        retries: includePostsAuth ? 0 : 1,
-        timeoutMs: includePostsAuth ? 60_000 : 15_000,
+        retries: includePostsAuth || includeCommentsAuth ? 0 : 1,
+        timeoutMs: includePostsAuth || includeCommentsAuth ? 60_000 : 15_000,
       },
     );
     return NextResponse.json(data);

--- a/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/snapshot/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/snapshot/route.ts
@@ -8,7 +8,7 @@ import {
 import { buildSnapshotResponse } from "@/lib/server/admin/admin-snapshot-route";
 import {
   fetchSocialBackendJson,
-  SOCIAL_PROXY_DEFAULT_TIMEOUT_MS,
+  SOCIAL_PROXY_LONG_TIMEOUT_MS,
   socialProxyErrorResponse,
 } from "@/lib/server/trr-api/social-admin-proxy";
 
@@ -187,7 +187,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
             fallbackError: "Failed to fetch social account profile dashboard",
             queryString: backendParams.toString(),
             retries: 0,
-            timeoutMs: SOCIAL_PROXY_DEFAULT_TIMEOUT_MS,
+            timeoutMs: SOCIAL_PROXY_LONG_TIMEOUT_MS,
           },
         );
         return normalizeDashboardSnapshot(dashboard as BackendDashboardPayload);
@@ -205,7 +205,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
             fallbackError: "Failed to fetch social account catalog run progress",
             queryString: progressParams.toString(),
             retries: 0,
-            timeoutMs: SOCIAL_PROXY_DEFAULT_TIMEOUT_MS,
+            timeoutMs: SOCIAL_PROXY_LONG_TIMEOUT_MS,
           },
         );
         return {

--- a/apps/web/src/components/admin/SocialAccountProfilePage.tsx
+++ b/apps/web/src/components/admin/SocialAccountProfilePage.tsx
@@ -251,6 +251,7 @@ const ACTIVE_CATALOG_RUN_STATUSES = new Set(["queued", "pending", "retrying", "r
 const ACTIVE_CATALOG_RECOVERY_STATUSES = new Set(["queued", "running", "fallback_enqueued", "blocked"]);
 const TERMINAL_CATALOG_RUN_STATUSES = new Set(["completed", "failed", "cancelled"]);
 const COMMENTS_PROGRESS_POLL_INTERVAL_MS = 5_000;
+const TWITTER_BACKFILL_LOOKBACK_DAYS = 365;
 const TIKTOK_EMPTY_FIRST_PAGE_ERROR_CODE = "tiktok_discovery_empty_first_page";
 const TIKTOK_EMPTY_FIRST_PAGE_ALERT_CODE = "tiktok_empty_first_page";
 const TIKTOK_DIRECT_FALLBACK_FAILED_ALERT_CODE = "tiktok_direct_fallback_failed";
@@ -560,6 +561,16 @@ const formatSeasonLabel = (seasonNumber?: number | null): string => {
 
 const formatBackfillTaskLabel = (task: CatalogBackfillSelectedTask): string => {
   return INSTAGRAM_BACKFILL_TASK_OPTIONS.find((option) => option.value === task)?.label ?? task;
+};
+
+const buildTwitterBackfillWindow = (now = new Date()): { dateStart: string; dateEnd: string } => {
+  const dateEnd = new Date(now);
+  const dateStart = new Date(dateEnd);
+  dateStart.setUTCDate(dateStart.getUTCDate() - TWITTER_BACKFILL_LOOKBACK_DAYS);
+  return {
+    dateStart: dateStart.toISOString(),
+    dateEnd: dateEnd.toISOString(),
+  };
 };
 
 const formatCoverageFieldLabel = (value: string): string => {
@@ -1376,6 +1387,17 @@ const formatActiveCommentsProgressWarning = (progress?: SocialAccountCommentsRun
     (typeof progress.warning_message === "string" && progress.warning_message.trim()) ||
     (progress.warnings ?? []).filter((warning) => typeof warning === "string" && warning.trim()).slice(0, 2).join(" ");
   if (explicitWarning) return explicitWarning;
+  const endpointProbe = progress.comments_endpoint_probe;
+  const endpointProbeStatus =
+    endpointProbe && typeof endpointProbe === "object"
+      ? String(endpointProbe.status || endpointProbe.result || "").trim().toLowerCase()
+      : "";
+  if (progress.manual_auth_required === true || endpointProbeStatus === "auth_blocked") {
+    return "Instagram comments auth is blocked. Repair Instagram auth, then rerun the comments scrape.";
+  }
+  if (endpointProbeStatus === "transport_blocked") {
+    return "Comments endpoint preflight timed out through the proxy; workers are continuing.";
+  }
   const targetCount =
     readFiniteNumber(progress.target_source_ids_count) ??
     readFiniteNumber(progress.post_progress?.total_posts) ??
@@ -2221,6 +2243,21 @@ const getCatalogLaunchGuardMessage = (
   return null;
 };
 
+const formatCookieHealthSourceLabel = (cookieHealth?: SocialProfileCookieHealth | null): string => {
+  if (!cookieHealth) return "";
+  if (cookieHealth.source_kind === "env_json") return " (env JSON)";
+  if (cookieHealth.source_kind === "runtime_override") return " (runtime override)";
+  if (cookieHealth.source_path) return ` (${cookieHealth.source_path.split("/").pop()})`;
+  return "";
+};
+
+const formatCookieHealthWarningLabel = (cookieHealth?: SocialProfileCookieHealth | null): string => {
+  if (cookieHealth?.warning_code === "env_json_source_refresh_writes_file") {
+    return "Refresh writes file";
+  }
+  return "Warning";
+};
+
 const INSTAGRAM_BACKFILL_BLOCKED_AUTH_MESSAGE =
   "Instagram backfill blocked before jobs were queued. Local cookies are present, but Modal posts auth was not accepted by Instagram. Use Repair Instagram Auth to sync local cookies into Modal and verify posts auth, then rerun Backfill Posts.";
 
@@ -2240,28 +2277,122 @@ const getInstagramPostsAuthStatusCopy = (
   const health = cookieHealth?.posts_auth_health ?? null;
   const probe = progress?.posts_auth_probe ?? cookieHealth?.posts_auth_probe ?? null;
   const probeStatus = String(probe?.status || probe?.result || "").trim().toLowerCase();
+  const healthStatus = String(health?.status || "").trim().toLowerCase();
+  const status = probeStatus || healthStatus;
   const healthReason = String(health?.reason || "").trim().toLowerCase();
   if (isInstagramPostsAuthVerified(cookieHealth)) {
     return { tone: "text-emerald-700", text: "Modal posts auth verified" };
   }
+  if (status === "transport_blocked") {
+    return { tone: "text-amber-700", text: "Instagram posts transport blocked" };
+  }
+  if (status === "fetch_blocked") {
+    return { tone: "text-amber-700", text: "Instagram posts fetch blocked" };
+  }
   if (
     operationalState === "blocked_auth" ||
     repairStatus === "failed" ||
-    probeStatus === "auth_blocked" ||
-    health?.ready === false
+    status === "auth_blocked" ||
+    healthReason === "checkpoint_required" ||
+    healthReason === "redirect_to_login" ||
+    healthReason === "redirect_to_checkpoint"
   ) {
     if (healthReason === "probe_function_unavailable" || healthReason === "probe_invocation_failed") {
       return { tone: "text-amber-700", text: "Modal posts auth probe unavailable" };
     }
     return { tone: "text-red-600", text: "Instagram posts auth blocked" };
   }
-  if (probeStatus === "valid" || health?.ready === true) {
+  if (status === "valid" || health?.ready === true) {
     return { tone: "text-emerald-700", text: "Modal posts auth verified" };
   }
   if (repairStatus === "succeeded") {
     return { tone: "text-emerald-700", text: "Modal posts auth repaired" };
   }
   return { tone: "text-zinc-500", text: "Modal posts auth not verified" };
+};
+
+const getInstagramCommentsAuthStatusCopy = (
+  cookieHealth?: SocialProfileCookieHealth | null,
+): { tone: string; text: string } => {
+  const health = cookieHealth?.comments_auth_health ?? null;
+  const probe = cookieHealth?.comments_auth_probe as JsonRecord | null | undefined;
+  const probeStatus = String(probe?.status || probe?.result || "").trim().toLowerCase();
+  const healthStatus = String(health?.status || "").trim().toLowerCase();
+  const status = probeStatus || healthStatus;
+  if (health?.ready === true || probe?.ready === true || status === "valid") {
+    return { tone: "text-emerald-700", text: "Modal comments auth verified" };
+  }
+  if (status === "transport_blocked") {
+    return { tone: "text-amber-700", text: "Instagram comments transport blocked" };
+  }
+  if (status === "fetch_blocked") {
+    const reason = String(health?.reason || probe?.reason || "").trim();
+    return {
+      tone: "text-amber-700",
+      text: reason
+        ? `Instagram comments auth probe blocked: ${formatDiagnosticToken(reason)}`
+        : "Instagram comments auth probe blocked",
+    };
+  }
+  if (status === "auth_blocked") {
+    const reason = String(health?.reason || probe?.reason || "").trim();
+    const fallbackEnabled =
+      health?.rendered_fallback_enabled === true ||
+      health?.advisory_continue === true ||
+      probe?.advisory_continue === true;
+    if (fallbackEnabled && reason === "html_challenge_or_auth_required") {
+      return {
+        tone: "text-amber-700",
+        text: "Instagram comments endpoint challenged; rendered fallback enabled",
+      };
+    }
+    return {
+      tone: "text-red-600",
+      text: reason
+        ? `Instagram comments auth blocked: ${formatDiagnosticToken(reason)}`
+        : "Instagram comments auth blocked",
+    };
+  }
+  return { tone: "text-zinc-500", text: "Modal comments endpoint not checked yet" };
+};
+
+const getInstagramCookiePayloadStatusCopy = (
+  cookieHealth: SocialProfileCookieHealth | null | undefined,
+  selectedTab: SocialAccountProfileTab,
+): { tone: string; text: string } | null => {
+  if (!cookieHealth?.cookie_fingerprint) return null;
+  const authHealth =
+    selectedTab === "comments" ? cookieHealth.comments_auth_health : cookieHealth.posts_auth_health;
+  const probe =
+    (selectedTab === "comments" ? cookieHealth.comments_auth_probe : cookieHealth.posts_auth_probe) as
+      | JsonRecord
+      | null
+      | undefined;
+  const remoteFingerprint = String(authHealth?.cookie_fingerprint || probe?.cookie_fingerprint || "").trim();
+  const explicitMatch = authHealth?.cookie_fingerprint_match;
+  const matches =
+    typeof explicitMatch === "boolean"
+      ? explicitMatch
+      : remoteFingerprint
+        ? remoteFingerprint === cookieHealth.cookie_fingerprint
+        : null;
+  if (matches === true) {
+    return { tone: "text-emerald-700", text: "Modal uses same cookie payload" };
+  }
+  if (matches === false) {
+    return { tone: "text-red-600", text: "Modal cookie payload differs from local file" };
+  }
+  return null;
+};
+
+const buildCommentsAuthCookieHealthProbeKey = (
+  platform: string,
+  handle: string,
+  cookieHealth: SocialProfileCookieHealth,
+): string => {
+  const fingerprint = String(cookieHealth.cookie_fingerprint || "").trim();
+  const sourcePath = String(cookieHealth.source_path || "").trim();
+  return [platform, handle, fingerprint || "no-fingerprint", cookieHealth.source_kind || "", sourcePath].join(":");
 };
 
 const buildProvisionalCatalogRunProgress = (input: {
@@ -2426,6 +2557,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   const [cookieRefreshMessage, setCookieRefreshMessage] = useState<string | null>(null);
   const pendingCatalogActionAfterCookieRepairRef = useRef<PendingCatalogAction | null>(null);
   const liveProfileTotalProbeKeyRef = useRef<string | null>(null);
+  const commentsAuthCookieHealthProbeKeyRef = useRef<string | null>(null);
 
   const supportsCatalog = SOCIAL_ACCOUNT_CATALOG_ENABLED_PLATFORMS.includes(platform);
   const supportsCatalogDetail = SOCIAL_ACCOUNT_CATALOG_DETAIL_ENABLED_PLATFORMS.includes(platform);
@@ -2582,6 +2714,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     setCookieHealthError(null);
     setCookieRefreshing(false);
     setCookieRefreshMessage(null);
+    commentsAuthCookieHealthProbeKeyRef.current = null;
     setCollaboratorsTags(null);
     setCollaboratorsLoading(false);
     setCollaboratorsError(null);
@@ -2665,7 +2798,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   }, [fetchAdminWithAuth, handle, platform, user]);
 
   const refreshCommentsSummary = useCallback(async () => {
-    await refreshSummary({ detail: "full" });
+    await refreshSummary({ detail: "lite" });
   }, [refreshSummary]);
 
   const fetchCatalogRunProgressSnapshot = useCallback(
@@ -4140,13 +4273,19 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   const rawActiveCommentsRunProgressStatus = String(rawActiveCommentsRunProgressData?.run_status || "").trim().toLowerCase();
   const activeCommentsRunProgressLastSuccessMs = activeCommentsRunProgress.lastSuccessAt?.getTime() ?? 0;
   const activeCommentsRunProgressFromThisMount = activeCommentsRunProgressLastSuccessMs >= mountedAtMsRef.current;
+  const suppressStaleActiveCommentsErroredProgress =
+    Boolean(activeCommentsRunId) &&
+    rawActiveCommentsRunProgressData?.run_id === activeCommentsRunId &&
+    Boolean(activeCommentsRunProgress.error) &&
+    !activeCommentsRunProgressFromThisMount;
   const suppressStaleActiveCommentsTerminalProgress =
     Boolean(activeCommentsRunId) &&
     rawActiveCommentsRunProgressData?.run_id === activeCommentsRunId &&
     TERMINAL_CATALOG_RUN_STATUSES.has(rawActiveCommentsRunProgressStatus) &&
     ACTIVE_CATALOG_RUN_STATUSES.has(activeCommentsRunStatus) &&
     !activeCommentsRunProgressFromThisMount;
-  const activeCommentsRunProgressData = suppressStaleActiveCommentsTerminalProgress
+  const activeCommentsRunProgressData =
+    suppressStaleActiveCommentsTerminalProgress || suppressStaleActiveCommentsErroredProgress
     ? null
     : rawActiveCommentsRunProgressData;
   const refetchActiveCommentsRunProgress = activeCommentsRunProgress.refetch;
@@ -4279,10 +4418,47 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   const catalogLaunchGuardMessage = useMemo(() => {
     return getCatalogLaunchGuardMessage(catalogRunProgress, cookieHealth);
   }, [catalogRunProgress, cookieHealth]);
+  const instagramCommentsModalAuthActive = useMemo(() => {
+    if (platform !== "instagram") return false;
+    const activeCommentsStatus = String(activeCommentsRunProgressData?.run_status || "").trim().toLowerCase();
+    return (
+      ["queued", "running", "retrying", "pending"].includes(activeCommentsStatus) &&
+      activeCommentsRunProgressData?.manual_auth_required === false
+    );
+  }, [activeCommentsRunProgressData, platform]);
+  const instagramCommentsAuthOwnsCurrentSurface =
+    instagramCommentsModalAuthActive && selectedTab === "comments";
   const instagramPostsAuthStatusCopy = useMemo(() => {
     if (platform !== "instagram") return null;
+    if (instagramCommentsModalAuthActive) {
+      return { tone: "text-emerald-700", text: "Modal Instagram comments auth active" };
+    }
+    if (activeCommentsRunProgressData?.manual_auth_required === true) {
+      return { tone: "text-red-600", text: "Instagram comments auth blocked" };
+    }
+    if (selectedTab === "comments") {
+      return getInstagramCommentsAuthStatusCopy(cookieHealth);
+    }
     return getInstagramPostsAuthStatusCopy(catalogRunProgress, cookieHealth);
-  }, [catalogRunProgress, cookieHealth, platform]);
+  }, [activeCommentsRunProgressData, catalogRunProgress, cookieHealth, instagramCommentsModalAuthActive, platform, selectedTab]);
+  const cookieHealthPrimaryLabel = useMemo(() => {
+    if (!cookieHealth) return null;
+    const sourceLabel = formatCookieHealthSourceLabel(cookieHealth);
+    if (platform === "instagram" && selectedTab === "comments") {
+      return `Cookie file present${sourceLabel}`;
+    }
+    return `Local cookies healthy${sourceLabel}`;
+  }, [cookieHealth, platform, selectedTab]);
+  const instagramCookiePayloadStatusCopy = useMemo(() => {
+    if (platform !== "instagram") return null;
+    return getInstagramCookiePayloadStatusCopy(cookieHealth, selectedTab);
+  }, [cookieHealth, platform, selectedTab]);
+  const showCookieHealthLoading =
+    cookieHealthLoading &&
+    !cookieHealth &&
+    !instagramPostsAuthStatusCopy &&
+    !instagramCookiePayloadStatusCopy;
+  const showCookieHealthError = Boolean(cookieHealthError) && !cookieHealth;
 
   const catalogActionsBlocked =
     runningCatalogAction !== null ||
@@ -5091,7 +5267,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     () => Number(summary?.comments_saved_summary?.retrieved_comments ?? 0),
     [summary?.comments_saved_summary?.retrieved_comments],
   );
-  const commentsMissingCount = useMemo(
+  const commentsGapCount = useMemo(
     () => Math.max(0, commentsRetrievedCount - commentsSavedCount),
     [commentsRetrievedCount, commentsSavedCount],
   );
@@ -5360,12 +5536,16 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   const fetchCookieHealth = useCallback(
     async (force = false): Promise<SocialProfileCookieHealth | null> => {
       if (!platformRequiresCookies || !user) return null;
+      const commentsAuthRequested = platform === "instagram" && selectedTab === "comments";
       setCookieHealthLoading(true);
       setCookieHealthError(null);
       try {
         const params = new URLSearchParams();
         if (force) params.set("force", "true");
-        if (platform === "instagram") params.set("posts_auth", "true");
+        if (platform === "instagram") {
+          params.set("posts_auth", "true");
+          if (commentsAuthRequested) params.set("comments_auth", "true");
+        }
         const qs = params.size > 0 ? `?${params.toString()}` : "";
         const response = await fetchAdminWithAuth(
           `/api/admin/trr-api/social/profiles/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/cookies/health${qs}`,
@@ -5375,6 +5555,9 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
         if (!response.ok) throw new Error("Failed to check cookie health");
         const data = (await response.json()) as SocialProfileCookieHealth;
         setCookieHealth(data);
+        if (commentsAuthRequested) {
+          commentsAuthCookieHealthProbeKeyRef.current = buildCommentsAuthCookieHealthProbeKey(platform, handle, data);
+        }
         return data;
       } catch (error) {
         setCookieHealthError(error instanceof Error ? error.message : "Cookie health check failed");
@@ -5383,22 +5566,35 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
         setCookieHealthLoading(false);
       }
     },
-    [platformRequiresCookies, user, platform, handle, fetchAdminWithAuth],
+    [platformRequiresCookies, user, platform, handle, selectedTab, fetchAdminWithAuth],
   );
 
   useEffect(() => {
+    const commentsAuthProbeMissing =
+      platform === "instagram" &&
+      selectedTab === "comments" &&
+      Boolean(cookieHealth) &&
+      !cookieHealth?.comments_auth_health &&
+      !cookieHealth?.comments_auth_probe;
+    const commentsAuthProbeKey =
+      commentsAuthProbeMissing && cookieHealth
+        ? buildCommentsAuthCookieHealthProbeKey(platform, handle, cookieHealth)
+        : null;
+    const commentsAuthProbeAlreadyRequested =
+      Boolean(commentsAuthProbeKey) && commentsAuthCookieHealthProbeKeyRef.current === commentsAuthProbeKey;
     if (
       checking ||
       !user ||
       !hasAccess ||
       !platformRequiresCookies ||
-      cookieHealth ||
+      (commentsAuthProbeMissing && commentsAuthProbeAlreadyRequested) ||
+      (cookieHealth && !commentsAuthProbeMissing) ||
       cookieHealthLoading
     ) {
       return;
     }
-    if (platformRequiresCookies && user && !cookieHealth && !cookieHealthLoading) {
-      void fetchCookieHealth();
+    if (platformRequiresCookies && user && (!cookieHealth || commentsAuthProbeMissing) && !cookieHealthLoading) {
+      void fetchCookieHealth(commentsAuthProbeMissing);
     }
   }, [
     checking,
@@ -5406,7 +5602,10 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     cookieHealthLoading,
     fetchCookieHealth,
     hasAccess,
+    handle,
+    platform,
     platformRequiresCookies,
+    selectedTab,
     user,
   ]);
 
@@ -5473,6 +5672,16 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
         : platform === "tiktok" ? [...TIKTOK_BACKFILL_DEFAULT_SELECTED_TASKS]
         : undefined;
       const resolvedSelectedTasks = selectedTasks ?? defaultSelectedTasks;
+      if (platform === "twitter") {
+        const { dateStart, dateEnd } = buildTwitterBackfillWindow();
+        return {
+          source_scope: activeCatalogSourceScope,
+          backfill_scope: "bounded_window",
+          date_start: dateStart,
+          date_end: dateEnd,
+          ...(resolvedSelectedTasks ? { selected_tasks: resolvedSelectedTasks } : {}),
+        };
+      }
       return {
         source_scope: activeCatalogSourceScope,
         backfill_scope: "full_history",
@@ -6336,6 +6545,8 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                   <p className="mt-2 text-xs text-zinc-500">
                     {platform === "instagram"
                       ? "Backfill Posts starts with listing saved post identities. Post Details, Comments, and Media are follow-up lanes and stay separate from listing completion."
+                      : platform === "twitter"
+                        ? "Backfill Posts runs the past-year catalog job. Sync Recent runs the same pipeline, limited to the last day."
                       : "Backfill Posts runs the full-history catalog job. Sync Recent runs the same pipeline, limited to the last day."}
                   </p>
                 ) : null}
@@ -6344,12 +6555,12 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                 {/* Cookie preflight card for cookie-dependent platforms */}
                 {supportsCatalog && platformRequiresCookies ? (
                   <div className="mt-3 flex items-center gap-3 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2.5">
-                    {cookieHealthLoading ? (
+                    {showCookieHealthLoading ? (
                       <>
                         <span className="inline-block h-2.5 w-2.5 animate-pulse rounded-full bg-zinc-400" />
                         <span className="text-xs text-zinc-500">Checking cookies…</span>
                       </>
-                    ) : cookieHealthError ? (
+                    ) : showCookieHealthError ? (
                       <>
                         <span className="inline-block h-2.5 w-2.5 rounded-full bg-amber-400" />
                         <span className="text-xs text-zinc-500">Cookie check failed</span>
@@ -6361,21 +6572,24 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                           Retry
                         </button>
                       </>
+                    ) : instagramCommentsAuthOwnsCurrentSurface ? (
+                      <>
+                        <span className="inline-block h-2.5 w-2.5 rounded-full bg-emerald-500" />
+                        <span className="text-xs text-zinc-600">Comments auth active</span>
+                      </>
                     ) : cookieHealth?.healthy === true ? (
                       <>
                         <span className="inline-block h-2.5 w-2.5 rounded-full bg-emerald-500" />
                         <span className="text-xs text-zinc-600">
-                          Local cookies healthy
-                          {cookieHealth.source_kind && cookieHealth.source_path
-                            ? ` (${cookieHealth.source_path.split("/").pop()})`
-                            : ""}
+                          {cookieHealthPrimaryLabel ?? "Local cookies healthy"}
                         </span>
                       </>
                     ) : cookieHealth?.healthy === false ? (
                       <>
                         <span className="inline-block h-2.5 w-2.5 rounded-full bg-red-500" />
                         <span className="text-xs text-zinc-600">
-                          Cookies expired{cookieHealth.reason ? ` — ${cookieHealth.reason}` : ""}
+                          {cookieHealth.auth_surface_blocked ? "Instagram auth blocked" : "Cookies expired"}
+                          {cookieHealth.reason ? ` — ${cookieHealth.reason}` : ""}
                         </span>
                         {cookieHealth.refresh_available ? (
                           <button
@@ -6398,12 +6612,17 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                         {instagramPostsAuthStatusCopy.text}
                       </span>
                     ) : null}
-                    {cookieRefreshMessage ? (
+                    {instagramCookiePayloadStatusCopy ? (
+                      <span className={`text-xs ${instagramCookiePayloadStatusCopy.tone}`}>
+                        {instagramCookiePayloadStatusCopy.text}
+                      </span>
+                    ) : null}
+                    {cookieRefreshMessage && !instagramCommentsAuthOwnsCurrentSurface ? (
                       <span className="text-xs text-zinc-500">{cookieRefreshMessage}</span>
                     ) : null}
                     {cookieHealth?.warning_message ? (
                       <span className="text-xs text-amber-600" title={cookieHealth.warning_message}>
-                        ⚠ {cookieHealth.warning_code === "env_json_source_refresh_writes_file" ? "env var source" : "warning"}
+                        ⚠ {formatCookieHealthWarningLabel(cookieHealth)}
                       </span>
                     ) : null}
                   </div>
@@ -6445,14 +6664,14 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                     )}
                   </div>
                   <div className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm">
-                    <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Missing Comments</p>
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Comment Gap</p>
                     {summaryInitialStatePending || commentsSavedSummaryUnavailable ? (
                       <p className="mt-2 text-sm font-semibold text-zinc-500">
                         {summaryInitialStatePending ? "Loading…" : "Unavailable"}
                       </p>
                     ) : (
                       <>
-                        <p className="mt-2 text-2xl font-bold text-zinc-900">{formatInteger(commentsMissingCount)}</p>
+                        <p className="mt-2 text-2xl font-bold text-zinc-900">{formatInteger(commentsGapCount)}</p>
                         <p className="mt-1 text-xs text-zinc-500">
                           {formatInteger(commentsRetrievedCount)} reported minus {formatInteger(commentsSavedCount)} saved
                         </p>

--- a/apps/web/src/components/admin/instagram/InstagramCommentsPanel.tsx
+++ b/apps/web/src/components/admin/instagram/InstagramCommentsPanel.tsx
@@ -89,8 +89,8 @@ const COMMENTS_SORT_COLUMNS: Array<{ key: CommentsSortField; label: string }> = 
   { key: "created", label: "Created" },
   { key: "caption", label: "Caption" },
   { key: "post_total", label: "Reported Comments" },
-  { key: "saved_comments", label: "Instagram Saved" },
-  { key: "missing_comments", label: "Missing Comments" },
+  { key: "saved_comments", label: "Saved Comments" },
+  { key: "missing_comments", label: "Comment Gap" },
   { key: "likes", label: "Likes" },
 ];
 const DEFAULT_COMMENTS_SORT: CommentsSortState = { field: "missing_comments", direction: "desc" };
@@ -417,6 +417,17 @@ const formatCommentsProgressWarning = (progress?: SocialAccountCommentsRunProgre
     (typeof progress.warning_message === "string" && progress.warning_message.trim()) ||
     (progress.warnings ?? []).filter((warning) => typeof warning === "string" && warning.trim()).slice(0, 2).join(" ");
   if (explicitWarning) return explicitWarning;
+  const endpointProbe = progress.comments_endpoint_probe;
+  const endpointProbeStatus =
+    endpointProbe && typeof endpointProbe === "object"
+      ? String(endpointProbe.status || endpointProbe.result || "").trim().toLowerCase()
+      : "";
+  if (progress.manual_auth_required === true || endpointProbeStatus === "auth_blocked") {
+    return "Instagram comments auth is blocked. Repair Instagram auth, then rerun the comments scrape.";
+  }
+  if (endpointProbeStatus === "transport_blocked") {
+    return "Comments endpoint preflight timed out through the proxy; workers are continuing.";
+  }
   const targetCount =
     readFiniteNumber(progress.target_source_ids_count) ??
     readFiniteNumber(progress.post_progress?.total_posts) ??
@@ -598,7 +609,7 @@ export default function InstagramCommentsPanel({
           return;
         }
 
-        const errorMessage = readInstagramCommentsErrorMessage(data, "Failed to load Instagram posts with comments");
+        const errorMessage = readInstagramCommentsErrorMessage(data, `Failed to load ${platformLabel} posts with comments`);
         if (attempt < 2 && isRetryablePostsLoadFailure(data, errorMessage, response.status)) {
           const retryAfterMs =
             typeof data.retry_after_seconds === "number" && data.retry_after_seconds > 0
@@ -610,7 +621,7 @@ export default function InstagramCommentsPanel({
         throw new Error(errorMessage);
       }
     } catch (error) {
-      setPostsError(error instanceof Error ? error.message : "Failed to load Instagram posts with comments");
+      setPostsError(error instanceof Error ? error.message : `Failed to load ${platformLabel} posts with comments`);
     } finally {
       setPostsLoading(false);
     }
@@ -1114,11 +1125,11 @@ export default function InstagramCommentsPanel({
             <p className="mt-1 text-xs text-zinc-500">Commentable now: {formatInteger(commentablePosts)}</p>
           </div>
           <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Missing</p>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Missing All Comments</p>
             <p className="mt-2 text-2xl font-bold text-zinc-900">{formatInteger(coverage?.missing_posts)}</p>
           </div>
           <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Stale</p>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">Refresh Candidates</p>
             <p className="mt-2 text-2xl font-bold text-zinc-900">{formatInteger(coverage?.stale_posts)}</p>
           </div>
           <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4">

--- a/apps/web/src/components/admin/instagram/InstagramCommentsPostModal.tsx
+++ b/apps/web/src/components/admin/instagram/InstagramCommentsPostModal.tsx
@@ -265,7 +265,7 @@ const normalizeCommentBreakdown = ({
     missingComments,
     formulaLabel: `${formatInteger(parentComments)} parent comments + ${formatInteger(childReplies)} child replies + ${formatInteger(
       facebookComments,
-    )} Facebook comments + ${formatInteger(missingComments)} missing comments = ${formatInteger(
+    )} Facebook comments + ${formatInteger(missingComments)} comments not captured = ${formatInteger(
       reportedComments,
     )} reported comments`,
   };
@@ -610,7 +610,7 @@ export default function InstagramCommentsPostModal({
               <span>{platformLabel}</span>
               <span>{post?.source_id || "Unknown post"}</span>
               <span>{formatDateTime(post?.posted_at)}</span>
-              <span>{formatInteger(commentBreakdown.savedInstagramComments)} Instagram rows</span>
+              <span>{formatInteger(commentBreakdown.savedInstagramComments)} {platformLabel} rows</span>
             </div>
             <p className="max-w-3xl whitespace-pre-wrap break-words text-sm leading-6 text-zinc-700">{captionPreview}</p>
             {post?.url ? (
@@ -654,7 +654,7 @@ export default function InstagramCommentsPostModal({
                     : "text-zinc-800"
                 }
               >
-                {formatInteger(commentBreakdown.missingComments)} missing comments
+                {formatInteger(commentBreakdown.missingComments)} not captured
               </span>
               <span className="text-zinc-400">=</span>
               <span>{formatInteger(commentBreakdown.reportedComments)} reported comments</span>

--- a/apps/web/src/lib/admin/api-references/generated/inventory.ts
+++ b/apps/web/src/lib/admin/api-references/generated/inventory.ts
@@ -4,7 +4,7 @@ import type { AdminApiReferenceInventory } from "@/lib/admin/api-references/type
 export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
   "inventorySchemaVersion": "1.0.0",
   "generatorVersion": "1.0.0",
-  "generatedAt": "2026-05-06T04:39:13.248Z",
+  "generatedAt": "2026-05-12T20:09:06.431Z",
   "sourceCommitSha": "b4198ec471d55204af3f5bbeca194ac0a9706ab7",
   "overrideDigest": "ddca008fc34e0b3820391e86a4d0620aa57e942244342eab2e4b94e2bcfdb211",
   "nodes": [
@@ -8712,7 +8712,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/social/landing/route.ts",
       "sourceLocator": {
-        "line": 301,
+        "line": 363,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -14118,7 +14118,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "POST",
       "sourceFile": "src/app/api/admin/social/landing/route.ts",
       "sourceLocator": {
-        "line": 370,
+        "line": 432,
         "symbol": "POST"
       },
       "provenance": "static_scan",

--- a/apps/web/src/lib/admin/social-account-profile.ts
+++ b/apps/web/src/lib/admin/social-account-profile.ts
@@ -580,6 +580,9 @@ export type SocialAccountCommentsRunProgress = {
   warning_code?: string | null;
   warning_message?: string | null;
   warnings?: string[];
+  auth_validation_mode?: string | null;
+  comments_endpoint_probe?: Record<string, unknown> | null;
+  manual_auth_required?: boolean | null;
   started_at_epoch_seconds?: number | null;
   updated_at?: string | null;
 };
@@ -1427,15 +1430,38 @@ export type SocialProfileCookieHealth = {
   refresh_label?: string;
   source_kind: string;
   source_path?: string;
+  cookie_fingerprint?: string | null;
+  cookie_fingerprint_algorithm?: string | null;
   refresh_target_path?: string;
   posts_auth_health?: {
     platform: string;
     account_handle?: string;
     ready: boolean;
+    status?: string | null;
+    category?: string | null;
     reason: string | null;
     execution_backend?: string;
+    cookie_fingerprint?: string | null;
+    cookie_fingerprint_match?: boolean | null;
   };
   posts_auth_probe?: Record<string, unknown> | null;
+  comments_auth_health?: {
+    platform: string;
+    account_handle?: string;
+    shortcode?: string | null;
+    ready: boolean;
+    status?: string | null;
+    category?: string | null;
+    reason: string | null;
+    execution_backend?: string;
+    cookie_fingerprint?: string | null;
+    cookie_fingerprint_match?: boolean | null;
+    rendered_fallback_enabled?: boolean | null;
+    advisory_continue?: boolean | null;
+    advisory_reason?: string | null;
+  };
+  comments_auth_probe?: Record<string, unknown> | null;
+  auth_surface_blocked?: boolean;
   warning_code?: string;
   warning_message?: string;
 };
@@ -1447,6 +1473,8 @@ export type SocialProfileCookieRefreshResult = {
   refresh_action?: "cookie_refresh" | "instagram_auth_repair";
   steps?: Array<{ name: string; status: string }>;
   remote_auth_probe?: Record<string, unknown> | null;
+  instagram_posts_auth_probe?: Record<string, unknown> | null;
+  instagram_comments_auth_probe?: Record<string, unknown> | null;
   warning_code?: string;
   warning_message?: string;
 };

--- a/apps/web/tests/social-account-profile-page.runtime.test.tsx
+++ b/apps/web/tests/social-account-profile-page.runtime.test.tsx
@@ -2291,8 +2291,8 @@ describe("SocialAccountProfilePage", () => {
     const postLink = await screen.findByRole("link", { name: "DVfQnTcjsCA" });
     expect(postLink).toBeInTheDocument();
     expect(screen.getByText("Reported Comments")).toBeInTheDocument();
-    expect(screen.getByText("Instagram Saved")).toBeInTheDocument();
-    expect(screen.getAllByText("Missing Comments").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("Saved Comments").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("Comment Gap").length).toBeGreaterThanOrEqual(2);
     const row = postLink.closest("tr") as HTMLElement;
     expect(within(row).getByText("27")).toBeInTheDocument();
     expect(within(row).getByText("13 parent")).toBeInTheDocument();
@@ -2315,7 +2315,7 @@ describe("SocialAccountProfilePage", () => {
     expect(within(dialog).getByText("13 parent comments")).toBeInTheDocument();
     expect(within(dialog).getByText("1 child replies")).toBeInTheDocument();
     expect(within(dialog).getByText("0 Facebook comments")).toBeInTheDocument();
-    expect(within(dialog).getByText("13 missing comments")).toBeInTheDocument();
+    expect(within(dialog).getByText("13 not captured")).toBeInTheDocument();
     expect(within(dialog).getByText("27 reported comments")).toBeInTheDocument();
     expect(within(dialog).getByText("Facebook comments: 0")).toBeInTheDocument();
     expect(within(dialog).queryByRole("link", { name: "Open Facebook post" })).not.toBeInTheDocument();
@@ -2382,8 +2382,8 @@ describe("SocialAccountProfilePage", () => {
       ["Created", "created", "desc"],
       ["Caption", "caption", "asc"],
       ["Reported Comments", "post_total", "desc"],
-      ["Instagram Saved", "saved_comments", "desc"],
-      ["Missing Comments", "missing_comments", "desc"],
+      ["Saved Comments", "saved_comments", "desc"],
+      ["Comment Gap", "missing_comments", "desc"],
       ["Likes", "likes", "desc"],
     ];
 
@@ -4529,6 +4529,45 @@ describe("SocialAccountProfilePage", () => {
     });
   });
 
+  it("does not keep rechecking cookie health when a comments auth probe response has no comments payload", async () => {
+    const cookieHealthUrls: string[] = [];
+
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse(baseSummary);
+      }
+      if (url.includes("/posts?page=1&page_size=25&comments_only=true")) {
+        return jsonResponse({
+          items: [],
+          pagination: { page: 1, page_size: 25, total: 0, total_pages: 1 },
+        });
+      }
+      if (url.includes("/cookies/health")) {
+        cookieHealthUrls.push(url);
+        return jsonResponse({
+          ...healthyCookieHealth("instagram"),
+          cookie_fingerprint: "cookie-fp-1",
+        });
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="instagram" handle="bravotv" activeTab="comments" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Cookie file present")).toBeInTheDocument();
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(cookieHealthUrls).toHaveLength(1);
+    expect(cookieHealthUrls[0]).toContain("comments_auth=true");
+    expect(screen.queryByText("Checking cookies…")).not.toBeInTheDocument();
+  });
+
   it("repairs Instagram auth and then auto-starts backfill when Backfill Posts is clicked with unhealthy cookies", async () => {
     let cookieHealthChecks = 0;
     const backfillBodies: unknown[] = [];
@@ -4772,6 +4811,238 @@ describe("SocialAccountProfilePage", () => {
       );
     });
   });
+
+  it("renders Twitter env-cookie source without a stale refresh warning when refresh auto-syncs env JSON", async () => {
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse({
+          ...baseSummary,
+          platform: "twitter",
+          account_handle: "bravotv",
+          profile_url: "https://x.com/BravoTV",
+          source_status: [{ source_scope: "creator" }],
+        });
+      }
+      if (url.includes("/cookies/health")) {
+        return jsonResponse({
+          ...healthyCookieHealth("twitter"),
+          source_kind: "env_json",
+          refresh_target_path:
+            "/Users/thomashulihan/Projects/TRR/TRR-Backend/scripts/socials/twitter/twitter_cookies.json",
+          refresh_sync_mode: "env_json_source",
+          refresh_sync_message:
+            "Refresh writes the cookie file and syncs the active env JSON source so it remains authoritative.",
+        });
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="twitter" handle="bravotv" activeTab="catalog" />);
+
+    expect(await screen.findByText("Local cookies healthy (env JSON)")).toBeInTheDocument();
+    expect(screen.queryByText("⚠ Refresh writes file")).not.toBeInTheDocument();
+  });
+
+  it("does not show checking cookies alongside active Modal comments auth", async () => {
+    const runId = "comments-active-auth-run";
+    let resolveCookieHealth: ((response: Response) => void) | null = null;
+    const cookieHealthPromise = new Promise<Response>((resolve) => {
+      resolveCookieHealth = resolve;
+    });
+    const activeSummary = {
+      ...baseSummary,
+      account_handle: "thetraitorsus",
+      profile_url: "https://www.instagram.com/thetraitorsus/",
+      comments_coverage: {
+        ...baseSummary.comments_coverage,
+        active_run_id: runId,
+        effective_status: "running",
+        last_comments_run_status: "running",
+      },
+    };
+
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/snapshot")) {
+        return jsonResponse({
+          summary: activeSummary,
+          catalog_run_progress: null,
+          generated_at: "2026-05-11T18:00:00.000Z",
+        });
+      }
+      if (url.includes("/summary")) {
+        return jsonResponse(activeSummary);
+      }
+      if (url.includes("/cookies/health")) {
+        return cookieHealthPromise;
+      }
+      if (url.includes(`/comments/runs/${runId}/progress`)) {
+        return jsonResponse({
+          run_id: runId,
+          platform: "instagram",
+          account_handle: "thetraitorsus",
+          run_status: "running",
+          manual_auth_required: false,
+          comments_shard_count: 4,
+          active_comment_jobs: 2,
+          completed_comment_jobs: 2,
+          failed_comment_jobs: 0,
+          post_progress: { completed_posts: 150, total_posts: 230 },
+        });
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="instagram" handle="thetraitorsus" activeTab="catalog" />);
+
+    expect(await screen.findByText("Modal Instagram comments auth active")).toBeInTheDocument();
+    expect(screen.queryByText("Checking cookies…")).not.toBeInTheDocument();
+    resolveCookieHealth?.(jsonResponse(healthyCookieHealth("instagram")));
+  });
+
+  it("does not offer Instagram cookie refresh on the comments surface while Modal comments auth is active", async () => {
+    const runId = "comments-active-auth-run";
+    const activeSummary = {
+      ...baseSummary,
+      account_handle: "thetraitorsus",
+      profile_url: "https://www.instagram.com/thetraitorsus/",
+      comments_coverage: {
+        ...baseSummary.comments_coverage,
+        active_run_id: runId,
+        effective_status: "running",
+        last_comments_run_status: "running",
+      },
+    };
+
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/snapshot")) {
+        return jsonResponse({
+          summary: activeSummary,
+          catalog_run_progress: null,
+          generated_at: "2026-05-11T18:00:00.000Z",
+        });
+      }
+      if (url.includes("/summary")) {
+        return jsonResponse(activeSummary);
+      }
+      if (url.includes("/cookies/health")) {
+        return jsonResponse({
+          ...healthyCookieHealth("instagram"),
+          healthy: false,
+          reason: "request_error",
+        });
+      }
+      if (url.includes("/posts?page=1&page_size=25&comments_only=true")) {
+        return jsonResponse({
+          items: [],
+          pagination: { page: 1, page_size: 25, total: 0, total_pages: 1 },
+        });
+      }
+      if (url.includes(`/comments/runs/${runId}/progress`)) {
+        return jsonResponse({
+          run_id: runId,
+          platform: "instagram",
+          account_handle: "thetraitorsus",
+          run_status: "running",
+          manual_auth_required: false,
+          comments_shard_count: 4,
+          active_comment_jobs: 2,
+          completed_comment_jobs: 2,
+          failed_comment_jobs: 0,
+          post_progress: { completed_posts: 150, total_posts: 230 },
+        });
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="instagram" handle="thetraitorsus" activeTab="comments" />);
+
+    expect(await screen.findByText("Modal Instagram comments auth active")).toBeInTheDocument();
+    expect(await screen.findByText("Comments auth active")).toBeInTheDocument();
+    expect(screen.queryByText(/Cookies expired/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Repair Instagram Auth" })).not.toBeInTheDocument();
+  });
+
+  it("hides cached comments progress rows when the current poll is failing", async () => {
+    const runId = "comments-stale-progress-run";
+    window.localStorage.removeItem(`trr:shared-live:instagram-comments-run:instagram:thetraitorsus:${runId}:lease:v1`);
+    window.localStorage.setItem(
+      `trr:shared-live:instagram-comments-run:instagram:thetraitorsus:${runId}:snapshot:v1`,
+      JSON.stringify({
+        data: {
+          run_id: runId,
+          platform: "instagram",
+          account_handle: "thetraitorsus",
+          run_status: "running",
+          manual_auth_required: false,
+          comments_shard_count: 4,
+          active_comment_jobs: 2,
+          completed_comment_jobs: 0,
+          failed_comment_jobs: 2,
+          comment_shards: [
+            {
+              shard_index: 2,
+              shard_count: 4,
+              job_id: "451cc01e-old",
+              status: "failed",
+              target_count: 58,
+              completed_posts: 2,
+              retry_target_count: 56,
+              comments_processed: 411,
+              error_message: "function max(uuid) does not exist",
+            },
+          ],
+        },
+        error: null,
+        errorDetails: null,
+        lastEventAtMs: Date.now() - 60_000,
+        lastSuccessAtMs: Date.now() - 60_000,
+        connected: true,
+      }),
+    );
+    const activeSummary = {
+      ...baseSummary,
+      account_handle: "thetraitorsus",
+      profile_url: "https://www.instagram.com/thetraitorsus/",
+      comments_coverage: {
+        ...baseSummary.comments_coverage,
+        active_run_id: runId,
+        effective_status: "running",
+        last_comments_run_status: "running",
+      },
+    };
+
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/snapshot")) {
+        return jsonResponse({
+          summary: activeSummary,
+          catalog_run_progress: null,
+          generated_at: "2026-05-11T18:00:00.000Z",
+        });
+      }
+      if (url.includes("/summary")) {
+        return jsonResponse(activeSummary);
+      }
+      if (url.includes("/cookies/health")) {
+        return jsonResponse(healthyCookieHealth("instagram"));
+      }
+      if (url.includes(`/comments/runs/${runId}/progress`)) {
+        return jsonResponse({ error: "Allowlist admin access required" }, 403);
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="instagram" handle="thetraitorsus" activeTab="catalog" />);
+
+    expect(
+      await screen.findByText("Progress poll is retrying: Allowlist admin access required", {}, { timeout: 7_000 }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/451cc01e/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/function max\(uuid\)/)).not.toBeInTheDocument();
+  }, 10_000);
 
   it("routes Fill Missing Posts to sync-newer for head gaps", async () => {
     mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -5438,7 +5709,16 @@ describe("SocialAccountProfilePage", () => {
       }
       if (url.includes("/catalog/backfill")) {
         expect(init?.method).toBe("POST");
-        expect(init?.body).toBe(JSON.stringify({ source_scope: "network", backfill_scope: "full_history" }));
+        const requestBody = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+        expect(requestBody).toMatchObject({
+          source_scope: "network",
+          backfill_scope: "bounded_window",
+        });
+        const dateStart = Date.parse(String(requestBody.date_start));
+        const dateEnd = Date.parse(String(requestBody.date_end));
+        expect(Number.isNaN(dateStart)).toBe(false);
+        expect(Number.isNaN(dateEnd)).toBe(false);
+        expect(dateEnd - dateStart).toBe(365 * 24 * 60 * 60 * 1000);
         return jsonResponse({
           run_id: "catalog-run-twitter-12345678",
           status: "queued",


### PR DESCRIPTION
## Summary
- Refines social account profile/admin surfaces around landing, profile snapshot, cookie health, and Instagram comments controls.
- Updates profile-page runtime coverage for the changed admin behavior.
- Regenerates the admin API reference inventory after route locator changes.

## Verification
- PASS: `pnpm run lint`.
- PASS: `pnpm run typecheck`.
- PASS: `pnpm run test:ci`.
