### PR TITLE
Harden admin auth gates

### DIFF
--- a/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/posts/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/posts/route.ts
@@ -1,6 +1,5 @@
 import {
   createSocialProfileReadRoute,
-  SOCIAL_PROFILE_READ_TIMEOUT_MS,
 } from "@/lib/server/trr-api/social-profile-route-factory";
 import { SOCIAL_PROXY_LONG_TIMEOUT_MS } from "@/lib/server/trr-api/social-admin-proxy";
 
@@ -14,10 +13,7 @@ export const GET = createSocialProfileReadRoute({
   fallbackError: "Failed to fetch social account profile posts",
   logLabel: "[api] Failed to fetch social account profile posts",
   queryString: "strip-refresh",
-  timeoutMs: ({ backendSearchParams }) =>
-    backendSearchParams.get("comments_only") === "true"
-      ? SOCIAL_PROXY_LONG_TIMEOUT_MS
-      : SOCIAL_PROFILE_READ_TIMEOUT_MS,
+  timeoutMs: SOCIAL_PROXY_LONG_TIMEOUT_MS,
   cache: {
     kind: "admin-snapshot",
     pageFamily: "social-profile",

--- a/apps/web/src/app/api/cron/episode-progression/route.ts
+++ b/apps/web/src/app/api/cron/episode-progression/route.ts
@@ -22,7 +22,11 @@ export async function POST(request: NextRequest) {
   const cronSecret = process.env.CRON_SECRET;
 
   // Allow in development without auth, but require in production
-  if (process.env.NODE_ENV === "production" && cronSecret) {
+  if (process.env.NODE_ENV === "production") {
+    if (!cronSecret) {
+      console.error("[cron] CRON_SECRET not configured");
+      return NextResponse.json({ error: "Server misconfiguration" }, { status: 500 });
+    }
     if (authHeader !== `Bearer ${cronSecret}`) {
       console.error("[cron] Unauthorized episode progression attempt");
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/apps/web/src/lib/admin/client-access.ts
+++ b/apps/web/src/lib/admin/client-access.ts
@@ -1,6 +1,5 @@
 import type { User } from "firebase/auth";
-import { DEFAULT_ADMIN_DISPLAY_NAMES, DEFAULT_ADMIN_UIDS } from "./constants";
-import { normalizeDisplayName, normalizeDisplayNameKey } from "./display-names";
+import { DEFAULT_ADMIN_UIDS } from "./constants";
 
 const parseAllowlist = (raw?: string | null, lowercase = false): string[] => {
   const entries = (raw ?? "")
@@ -19,35 +18,12 @@ const allowedAdminUids = new Set<string>([
   ...parseAllowlist(process.env.NEXT_PUBLIC_ADMIN_UIDS, false),
 ]);
 
-const allowedAdminDisplayNames = new Set<string>(
-  [
-    ...DEFAULT_ADMIN_DISPLAY_NAMES,
-    ...parseAllowlist(process.env.NEXT_PUBLIC_ADMIN_DISPLAY_NAMES, false),
-  ]
-    .map((value) => normalizeDisplayName(value))
-    .filter((value): value is string => Boolean(value)),
-);
-const allowedAdminDisplayNameKeys = new Set<string>(
-  Array.from(allowedAdminDisplayNames)
-    .map((value) => normalizeDisplayNameKey(value))
-    .filter((value): value is string => Boolean(value)),
-);
-
 export function isClientAdmin(user: User | null): boolean {
   if (!user) return false;
   const email = user.email?.toLowerCase();
-  const emailAllowed = email ? allowedAdminEmails.has(email) : false;
+  const emailAllowed = Boolean(email && user.emailVerified && allowedAdminEmails.has(email));
   const uidAllowed = user.uid ? allowedAdminUids.has(user.uid) : false;
-  const normalizedName = normalizeDisplayName(user.displayName ?? undefined);
-  const normalizedKey = normalizeDisplayNameKey(normalizedName);
-  const displayNameAllowed =
-    (normalizedName ? allowedAdminDisplayNames.has(normalizedName) : false) ||
-    (normalizedKey ? allowedAdminDisplayNameKeys.has(normalizedKey) : false);
-  return emailAllowed || displayNameAllowed || uidAllowed;
-}
-
-export function getAllowedAdminDisplayNames(): string[] {
-  return Array.from(allowedAdminDisplayNames);
+  return emailAllowed || uidAllowed;
 }
 
 export function getAllowedAdminEmails(): string[] {

--- a/apps/web/src/lib/server/auth.ts
+++ b/apps/web/src/lib/server/auth.ts
@@ -574,6 +574,10 @@ function isRequestHostAllowedForAdmin(request: NextRequest): boolean {
   return Array.from(adminAllowedHosts).some((allowedHost) => isLoopbackHost(allowedHost));
 }
 
+function requestAdminHost(request: NextRequest): string | null {
+  return request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? request.nextUrl.hostname;
+}
+
 function isDevAdminBypassEnabled(request: NextRequest): boolean {
   // Production deployments never honor the bypass, regardless of flags or
   // host: Host headers are attacker-controllable and provide no security.
@@ -754,7 +758,7 @@ export async function requireAdmin(request: NextRequest): Promise<AuthenticatedU
     throw new Error("forbidden");
   }
 
-  const propagatedContext = resolveVerifiedAdminContext(request.headers);
+  const propagatedContext = resolveVerifiedAdminContext(request.headers, requestAdminHost(request));
   if (propagatedContext) {
     return buildPropagatedAuthenticatedUser(propagatedContext);
   }
@@ -788,7 +792,7 @@ export async function requireAdminContext(request: NextRequest): Promise<Verifie
   if (!isRequestHostAllowedForAdmin(request)) {
     throw new Error("forbidden");
   }
-  const propagatedContext = resolveVerifiedAdminContext(request.headers);
+  const propagatedContext = resolveVerifiedAdminContext(request.headers, requestAdminHost(request));
   if (propagatedContext) {
     return propagatedContext;
   }

--- a/apps/web/src/lib/server/auth.ts
+++ b/apps/web/src/lib/server/auth.ts
@@ -28,7 +28,9 @@ export type AuthTokenClaims = {
   uid: string;
   sub?: string;
   email?: string;
+  email_verified?: boolean;
   name?: string;
+  admin?: boolean;
   [key: string]: unknown;
 };
 
@@ -573,6 +575,9 @@ function isRequestHostAllowedForAdmin(request: NextRequest): boolean {
 }
 
 function isDevAdminBypassEnabled(request: NextRequest): boolean {
+  // Production deployments never honor the bypass, regardless of flags or
+  // host: Host headers are attacker-controllable and provide no security.
+  if (process.env.VERCEL_ENV === "production") return false;
   const requestHost = request.nextUrl.hostname;
   const hostHeader = request.headers.get("host");
   const hostWithoutPort = hostHeader?.split(":")[0] ?? hostHeader;
@@ -580,6 +585,17 @@ function isDevAdminBypassEnabled(request: NextRequest): boolean {
   if (!isLocalRequest) return false;
   if (process.env.NODE_ENV !== "production") return true;
   return parseOptionalBoolean(process.env.TRR_DEV_ADMIN_BYPASS) === true;
+}
+
+// Refuse to serve if a production deployment is configured with the dev
+// bypass flag — fail loudly at module load instead of silently ignoring it.
+if (
+  process.env.VERCEL_ENV === "production" &&
+  parseOptionalBoolean(process.env.TRR_DEV_ADMIN_BYPASS) === true
+) {
+  throw new Error(
+    "TRR_DEV_ADMIN_BYPASS must not be set on production deployments (VERCEL_ENV=production).",
+  );
 }
 
 function buildDevBypassUser(provider: AuthProvider = "firebase"): AuthenticatedUser {
@@ -678,6 +694,9 @@ const allowedUids = new Set<string>([
   ...parseAllowlist(process.env.NEXT_PUBLIC_ADMIN_UIDS, false),
 ]);
 
+// Diagnostics/observability only — display names are NOT an authorization
+// input (removed from requireAdmin: attacker-controlled Firebase displayName
+// was a privilege-escalation vector).
 const allowedDisplayNameKeys = new Set<string>(
   [
     ...DEFAULT_ADMIN_DISPLAY_NAMES,
@@ -751,12 +770,11 @@ export async function requireAdmin(request: NextRequest): Promise<AuthenticatedU
 
   const user = await requireUser(request);
   const email = user.email?.toLowerCase();
-  const emailAllowed = Boolean(email && allowedEmails.has(email));
+  const emailVerified = user.token.email_verified === true;
+  const emailAllowed = Boolean(email && emailVerified && allowedEmails.has(email));
   const uidAllowed = Boolean(user.uid && allowedUids.has(user.uid));
-  const displayName = typeof user.token.name === "string" ? user.token.name : undefined;
-  const displayNameKey = normalizeDisplayNameKey(displayName);
-  const displayNameAllowed = Boolean(displayNameKey && allowedDisplayNameKeys.has(displayNameKey));
-  const isAllowed = emailAllowed || uidAllowed || displayNameAllowed;
+  const customClaimAdmin = user.token.admin === true;
+  const isAllowed = emailAllowed || uidAllowed || customClaimAdmin;
   if (!isAllowed) {
     throw new Error("forbidden");
   }
@@ -764,6 +782,12 @@ export async function requireAdmin(request: NextRequest): Promise<AuthenticatedU
 }
 
 export async function requireAdminContext(request: NextRequest): Promise<VerifiedAdminContext> {
+  // Host allowlist applies to every admin entry point, including the
+  // propagated internal-admin JWT — a leaked shared secret must not become a
+  // host-independent admin credential.
+  if (!isRequestHostAllowedForAdmin(request)) {
+    throw new Error("forbidden");
+  }
   const propagatedContext = resolveVerifiedAdminContext(request.headers);
   if (propagatedContext) {
     return propagatedContext;

--- a/apps/web/src/lib/server/trr-api/internal-admin-auth.ts
+++ b/apps/web/src/lib/server/trr-api/internal-admin-auth.ts
@@ -88,7 +88,8 @@ const normalizeAdminHost = (value: unknown): string | null => {
   if (trimmed.startsWith("[") && trimmed.includes("]")) {
     return trimmed.slice(0, trimmed.indexOf("]") + 1);
   }
-  return trimmed.split(":")[0] ?? null;
+  const host = trimmed.split(":")[0];
+  return host || null;
 };
 
 const readHeaderHost = (headersLike: HeadersInit | Headers | undefined): string | null => {

--- a/apps/web/src/lib/server/trr-api/internal-admin-auth.ts
+++ b/apps/web/src/lib/server/trr-api/internal-admin-auth.ts
@@ -12,6 +12,10 @@ export type VerifiedAdminContext = {
   verifiedAt: number;
 };
 
+type InternalAdminTokenOptions = {
+  host?: string | null;
+};
+
 type InternalAdminPayload = {
   iss?: unknown;
   aud?: unknown;
@@ -23,6 +27,7 @@ type InternalAdminPayload = {
   admin_uid?: unknown;
   admin_email?: unknown;
   verified_at?: unknown;
+  admin_host?: unknown;
 };
 
 const base64UrlEncode = (value: string): string =>
@@ -72,8 +77,34 @@ const normalizeEmail = (value: unknown): string | null => {
   return normalized ? normalized : null;
 };
 
+const normalizeAdminHost = (value: unknown): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) {
+    return null;
+  }
+  if (trimmed.startsWith("[") && trimmed.includes("]")) {
+    return trimmed.slice(0, trimmed.indexOf("]") + 1);
+  }
+  return trimmed.split(":")[0] ?? null;
+};
+
+const readHeaderHost = (headersLike: HeadersInit | Headers | undefined): string | null => {
+  if (!headersLike) {
+    return null;
+  }
+  const headers = new Headers(headersLike);
+  return headers.get("x-forwarded-host") ?? headers.get("host") ?? headers.get("Host");
+};
+
 const verifySignedPayload = (token: string, secret: string): InternalAdminPayload | null => {
-  const [encodedHeader, encodedPayload, signature] = token.split(".");
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    return null;
+  }
+  const [encodedHeader, encodedPayload, signature] = parts;
   if (!encodedHeader || !encodedPayload || !signature) {
     return null;
   }
@@ -104,7 +135,10 @@ const verifySignedPayload = (token: string, secret: string): InternalAdminPayloa
   }
 };
 
-export const peekInternalAdminBearerToken = (context?: VerifiedAdminContext): string | null => {
+export const peekInternalAdminBearerToken = (
+  context?: VerifiedAdminContext,
+  options?: InternalAdminTokenOptions,
+): string | null => {
   const secret = getSigningSecret();
   if (!secret) return null;
 
@@ -123,6 +157,10 @@ export const peekInternalAdminBearerToken = (context?: VerifiedAdminContext): st
     payload.admin_email = context.email;
     payload.verified_at = context.verifiedAt;
   }
+  const adminHost = normalizeAdminHost(options?.host);
+  if (adminHost) {
+    payload.admin_host = adminHost;
+  }
 
   const header = {
     alg: "HS256",
@@ -136,8 +174,11 @@ export const peekInternalAdminBearerToken = (context?: VerifiedAdminContext): st
   return `${unsigned}.${signature}`;
 };
 
-export const getInternalAdminBearerToken = (context?: VerifiedAdminContext): string => {
-  const token = peekInternalAdminBearerToken(context);
+export const getInternalAdminBearerToken = (
+  context?: VerifiedAdminContext,
+  options?: InternalAdminTokenOptions,
+): string => {
+  const token = peekInternalAdminBearerToken(context, options);
   if (!token) {
     throw new Error("TRR_INTERNAL_ADMIN_SHARED_SECRET is not configured");
   }
@@ -146,6 +187,7 @@ export const getInternalAdminBearerToken = (context?: VerifiedAdminContext): str
 
 export const resolveVerifiedAdminContext = (
   headersLike: HeadersInit | Headers,
+  expectedHost?: string | null,
 ): VerifiedAdminContext | null => {
   const secret = getSigningSecret();
   if (!secret) {
@@ -174,6 +216,13 @@ export const resolveVerifiedAdminContext = (
   ) {
     return null;
   }
+  const normalizedExpectedHost = normalizeAdminHost(expectedHost);
+  if (normalizedExpectedHost) {
+    const normalizedTokenHost = normalizeAdminHost(payload.admin_host);
+    if (!normalizedTokenHost || normalizedTokenHost !== normalizedExpectedHost) {
+      return null;
+    }
+  }
   const verifiedAt =
     typeof payload.verified_at === "number" && Number.isFinite(payload.verified_at)
       ? payload.verified_at
@@ -194,7 +243,7 @@ export const buildInternalAdminHeaders = (
 ): Headers => {
   const context = isVerifiedAdminContext(contextOrHeaders) ? contextOrHeaders : undefined;
   const initialHeaders = isVerifiedAdminContext(contextOrHeaders) ? extraHeaders : contextOrHeaders;
-  const token = getInternalAdminBearerToken(context);
+  const token = getInternalAdminBearerToken(context, { host: readHeaderHost(initialHeaders) });
   const headers = new Headers(initialHeaders);
   headers.delete("X-TRR-Internal-Admin-Secret");
   headers.delete("X-Internal-Admin-Secret");

--- a/apps/web/src/lib/server/trr-api/internal-admin-auth.ts
+++ b/apps/web/src/lib/server/trr-api/internal-admin-auth.ts
@@ -77,6 +77,16 @@ const verifySignedPayload = (token: string, secret: string): InternalAdminPayloa
   if (!encodedHeader || !encodedPayload || !signature) {
     return null;
   }
+  // Only HS256 is ever minted; reject any other declared alg instead of
+  // silently ignoring the header.
+  try {
+    const header = JSON.parse(base64UrlDecode(encodedHeader)) as { alg?: unknown };
+    if (header?.alg !== "HS256") {
+      return null;
+    }
+  } catch {
+    return null;
+  }
   const expectedSignature = signHs256(`${encodedHeader}.${encodedPayload}`, secret);
   if (expectedSignature.length !== signature.length) {
     return null;

--- a/apps/web/src/lib/server/trr-api/social-admin-proxy.ts
+++ b/apps/web/src/lib/server/trr-api/social-admin-proxy.ts
@@ -236,9 +236,20 @@ const isRetryableUpstreamStatus = (status: number): boolean => {
 };
 
 const AUTO_RETRY_ELIGIBLE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+const LOOPBACK_BACKEND_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
 
 const isAutoRetryEligible = (method: string | undefined): boolean => {
   return AUTO_RETRY_ELIGIBLE_METHODS.has(String(method ?? "GET").toUpperCase());
+};
+
+const isLoopbackBackendUrl = (backendUrl: string): boolean => {
+  try {
+    const parsed = new URL(backendUrl);
+    const hostname = parsed.hostname.trim().toLowerCase();
+    return LOOPBACK_BACKEND_HOSTS.has(hostname) || hostname.endsWith(".localhost");
+  } catch {
+    return false;
+  }
 };
 
 const parseRetryAfterSeconds = (value: string | null): number | undefined => {
@@ -543,6 +554,9 @@ async function fetchBackend(
   requestHeaders.set("x-trace-id", traceId);
   if (!requestHeaders.has("x-request-id")) {
     requestHeaders.set("x-request-id", traceId);
+  }
+  if (isLoopbackBackendUrl(backendUrl)) {
+    requestHeaders.set("x-trr-local-admin-proxy", "1");
   }
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,3 +1,10 @@
+// This IS the active Next.js 16 middleware (Next 16 renamed `middleware.ts`
+// to `proxy.ts`; it auto-loads via the exported `proxy` + `config.matcher`).
+// It performs HOST ISOLATION AND ROUTING ONLY — no authentication happens
+// here. Identity/authorization is enforced per-route by `requireAdmin` /
+// `requireAdminContext` in `src/lib/server/auth.ts`. Host headers are
+// attacker-controllable, so nothing in this file may be treated as a
+// security boundary on its own.
 import { NextResponse, type NextRequest } from "next/server";
 import {
   ADMIN_API_REFERENCES_PATH,

--- a/apps/web/tests/client-admin-access.test.ts
+++ b/apps/web/tests/client-admin-access.test.ts
@@ -32,11 +32,36 @@ describe("client admin access", () => {
     delete process.env.NEXT_PUBLIC_ADMIN_DISPLAY_NAMES;
   });
 
-  it("treats codex handle defaults as admin-capable display names", async () => {
+  it("no longer treats a seeded admin display name as admin-capable", async () => {
     const { isClientAdmin } = await import("@/lib/admin/client-access");
 
-    expect(isClientAdmin(buildUser({ displayName: "Codex Huli" }))).toBe(true);
-    expect(isClientAdmin(buildUser({ displayName: "@codex_huli" }))).toBe(true);
-    expect(isClientAdmin(buildUser({ displayName: "codex_huli" }))).toBe(true);
+    // Display name is attacker-controllable, so it must never grant admin.
+    expect(isClientAdmin(buildUser({ displayName: "Codex Huli" }))).toBe(false);
+    expect(isClientAdmin(buildUser({ displayName: "@codex_huli" }))).toBe(false);
+    expect(isClientAdmin(buildUser({ displayName: "codex_huli" }))).toBe(false);
+  });
+
+  it("treats the seeded admin uid as admin-capable", async () => {
+    const { isClientAdmin } = await import("@/lib/admin/client-access");
+
+    expect(isClientAdmin(buildUser({ uid: "MyoUFNjl9VP5iVGBi7tVqxUb8np2" }))).toBe(true);
+  });
+
+  it("treats an allowlisted verified email as admin-capable", async () => {
+    process.env.NEXT_PUBLIC_ADMIN_EMAILS = "admin@example.com";
+    const { isClientAdmin } = await import("@/lib/admin/client-access");
+
+    expect(
+      isClientAdmin(buildUser({ uid: "non-admin-uid", email: "admin@example.com", emailVerified: true })),
+    ).toBe(true);
+  });
+
+  it("rejects an allowlisted email that is not verified", async () => {
+    process.env.NEXT_PUBLIC_ADMIN_EMAILS = "admin@example.com";
+    const { isClientAdmin } = await import("@/lib/admin/client-access");
+
+    expect(
+      isClientAdmin(buildUser({ uid: "non-admin-uid", email: "admin@example.com", emailVerified: false })),
+    ).toBe(false);
   });
 });

--- a/apps/web/tests/cron-routes-auth.test.ts
+++ b/apps/web/tests/cron-routes-auth.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { captureExpectedConsoleError } from "./helpers/expected-console";
+
+const {
+  getSurveysWithAutoProgressMock,
+  progressToNextEpisodeMock,
+  createWeeklySurveyRunsMock,
+  getCurrentWeekWindowMock,
+} = vi.hoisted(() => ({
+  getSurveysWithAutoProgressMock: vi.fn(),
+  progressToNextEpisodeMock: vi.fn(),
+  createWeeklySurveyRunsMock: vi.fn(),
+  getCurrentWeekWindowMock: vi.fn(),
+}));
+
+vi.mock("@/lib/server/surveys/survey-config-repository", () => ({
+  getSurveysWithAutoProgress: getSurveysWithAutoProgressMock,
+}));
+
+vi.mock("@/lib/server/surveys/survey-episodes-repository", () => ({
+  progressToNextEpisode: progressToNextEpisodeMock,
+}));
+
+vi.mock("@/lib/server/surveys/survey-run-scheduler", () => ({
+  createWeeklySurveyRuns: createWeeklySurveyRunsMock,
+  getCurrentWeekWindow: getCurrentWeekWindowMock,
+}));
+
+function cronPost(path: string, headers?: Record<string, string>): NextRequest {
+  return new NextRequest(`http://localhost${path}`, { method: "POST", headers });
+}
+
+async function withNodeEnv<T>(nodeEnv: string, run: () => Promise<T>): Promise<T> {
+  const previousNodeEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = nodeEnv;
+  try {
+    return await run();
+  } finally {
+    if (typeof previousNodeEnv === "undefined") {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previousNodeEnv;
+    }
+  }
+}
+
+describe("cron route auth guards", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    getSurveysWithAutoProgressMock.mockReset().mockResolvedValue([]);
+    progressToNextEpisodeMock.mockReset();
+    createWeeklySurveyRunsMock.mockReset().mockResolvedValue([]);
+    getCurrentWeekWindowMock.mockReset().mockReturnValue({
+      runKey: "2026-W24",
+      startsAt: "2026-06-07T00:00:00.000Z",
+      endsAt: "2026-06-14T00:00:00.000Z",
+    });
+    delete process.env.CRON_SECRET;
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  describe("episode-progression", () => {
+    it("fails closed in production when CRON_SECRET is unset", async () => {
+      const expectedError = captureExpectedConsoleError(/CRON_SECRET not configured/);
+      await withNodeEnv("production", async () => {
+        const { POST } = await import("@/app/api/cron/episode-progression/route");
+        const response = await POST(cronPost("/api/cron/episode-progression"));
+
+        expect(response.status).toBe(500);
+        await expect(response.json()).resolves.toEqual({ error: "Server misconfiguration" });
+        expect(getSurveysWithAutoProgressMock).not.toHaveBeenCalled();
+      });
+      expectedError.expectCalled();
+    });
+
+    it("rejects a wrong bearer token in production", async () => {
+      const expectedError = captureExpectedConsoleError(/Unauthorized episode progression attempt/);
+      process.env.CRON_SECRET = "cron-secret";
+      await withNodeEnv("production", async () => {
+        const { POST } = await import("@/app/api/cron/episode-progression/route");
+        const response = await POST(
+          cronPost("/api/cron/episode-progression", { authorization: "Bearer wrong" }),
+        );
+
+        expect(response.status).toBe(401);
+        await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+        expect(getSurveysWithAutoProgressMock).not.toHaveBeenCalled();
+      });
+      expectedError.expectCalled();
+    });
+
+    it("accepts the configured bearer token in production", async () => {
+      process.env.CRON_SECRET = "cron-secret";
+      await withNodeEnv("production", async () => {
+        const { POST } = await import("@/app/api/cron/episode-progression/route");
+        const response = await POST(
+          cronPost("/api/cron/episode-progression", { authorization: "Bearer cron-secret" }),
+        );
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toMatchObject({ success: true, processed: 0 });
+        expect(getSurveysWithAutoProgressMock).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it("allows unauthenticated runs outside production for local testing", async () => {
+      const { POST } = await import("@/app/api/cron/episode-progression/route");
+      const response = await POST(cronPost("/api/cron/episode-progression"));
+
+      expect(response.status).toBe(200);
+      expect(getSurveysWithAutoProgressMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("create-survey-runs", () => {
+    it("fails closed in production when CRON_SECRET is unset", async () => {
+      const expectedError = captureExpectedConsoleError(/CRON_SECRET not configured/);
+      await withNodeEnv("production", async () => {
+        const { POST } = await import("@/app/api/cron/create-survey-runs/route");
+        const response = await POST(cronPost("/api/cron/create-survey-runs"));
+
+        expect(response.status).toBe(500);
+        await expect(response.json()).resolves.toEqual({ error: "Server misconfiguration" });
+        expect(createWeeklySurveyRunsMock).not.toHaveBeenCalled();
+      });
+      expectedError.expectCalled();
+    });
+
+    it("rejects a wrong bearer token in production", async () => {
+      const expectedError = captureExpectedConsoleError(/Unauthorized survey run creation attempt/);
+      process.env.CRON_SECRET = "cron-secret";
+      await withNodeEnv("production", async () => {
+        const { POST } = await import("@/app/api/cron/create-survey-runs/route");
+        const response = await POST(
+          cronPost("/api/cron/create-survey-runs", { authorization: "Bearer wrong" }),
+        );
+
+        expect(response.status).toBe(401);
+        await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+        expect(createWeeklySurveyRunsMock).not.toHaveBeenCalled();
+      });
+      expectedError.expectCalled();
+    });
+
+    it("accepts the configured bearer token in production", async () => {
+      process.env.CRON_SECRET = "cron-secret";
+      await withNodeEnv("production", async () => {
+        const { POST } = await import("@/app/api/cron/create-survey-runs/route");
+        const response = await POST(
+          cronPost("/api/cron/create-survey-runs", { authorization: "Bearer cron-secret" }),
+        );
+
+        expect(response.status).toBe(200);
+        expect(createWeeklySurveyRunsMock).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/apps/web/tests/cron-routes-auth.test.ts
+++ b/apps/web/tests/cron-routes-auth.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { captureExpectedConsoleError } from "./helpers/expected-console";
 
@@ -58,6 +58,10 @@ describe("cron route auth guards", () => {
     });
     delete process.env.CRON_SECRET;
     vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   describe("episode-progression", () => {

--- a/apps/web/tests/internal-admin-auth.test.ts
+++ b/apps/web/tests/internal-admin-auth.test.ts
@@ -1,3 +1,5 @@
+import { createHmac } from "node:crypto";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -101,5 +103,28 @@ describe("internal-admin-auth", () => {
       email: "admin@example.com",
       verifiedAt: 1_700_000_000_000,
     });
+  });
+
+  it("rejects tokens whose header does not declare HS256 even when the signature matches", () => {
+    const headers = buildInternalAdminHeaders(
+      {
+        uid: "admin-123",
+        email: "admin@example.com",
+        verifiedAt: 1_700_000_000_000,
+      },
+      {},
+    );
+    const token = headers.get("Authorization")!.slice("Bearer ".length);
+    const [, payload] = token.split(".");
+    // Re-sign with the real secret so only the declared alg differs.
+    const forgedHeader = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" }), "utf8").toString(
+      "base64url",
+    );
+    const forgedSignature = createHmac("sha256", "internal-secret-for-tests")
+      .update(`${forgedHeader}.${payload}`)
+      .digest("base64url");
+    headers.set("Authorization", `Bearer ${forgedHeader}.${payload}.${forgedSignature}`);
+
+    expect(resolveVerifiedAdminContext(headers)).toBeNull();
   });
 });

--- a/apps/web/tests/internal-admin-auth.test.ts
+++ b/apps/web/tests/internal-admin-auth.test.ts
@@ -105,6 +105,38 @@ describe("internal-admin-auth", () => {
     });
   });
 
+  it("rejects malformed tokens with extra segments", () => {
+    const headers = buildInternalAdminHeaders(
+      {
+        uid: "admin-123",
+        email: "admin@example.com",
+        verifiedAt: 1_700_000_000_000,
+      },
+      {},
+    );
+    headers.set("Authorization", `${headers.get("Authorization")}.extra`);
+
+    expect(resolveVerifiedAdminContext(headers)).toBeNull();
+  });
+
+  it("requires the token host to match when an expected host is supplied", () => {
+    const headers = buildInternalAdminHeaders(
+      {
+        uid: "admin-123",
+        email: "admin@example.com",
+        verifiedAt: 1_700_000_000_000,
+      },
+      { host: "admin.localhost:3000" },
+    );
+
+    expect(resolveVerifiedAdminContext(headers, "admin.localhost:3000")).toEqual({
+      uid: "admin-123",
+      email: "admin@example.com",
+      verifiedAt: 1_700_000_000_000,
+    });
+    expect(resolveVerifiedAdminContext(headers, "localhost:3000")).toBeNull();
+  });
+
   it("rejects tokens whose header does not declare HS256 even when the signature matches", () => {
     const headers = buildInternalAdminHeaders(
       {

--- a/apps/web/tests/server-auth-adapter.test.ts
+++ b/apps/web/tests/server-auth-adapter.test.ts
@@ -56,6 +56,8 @@ describe("server auth adapter", () => {
     process.env.TRR_AUTH_PROVIDER = "firebase";
     process.env.TRR_AUTH_SHADOW_MODE = "false";
     delete process.env.TRR_DEV_ADMIN_BYPASS;
+    delete process.env.VERCEL_ENV;
+    delete process.env.TRR_INTERNAL_ADMIN_SHARED_SECRET;
     process.env.NEXT_PUBLIC_USE_FIREBASE_EMULATORS = "true";
     process.env.NEXT_PUBLIC_FIREBASE_API_KEY = "";
     process.env.ADMIN_EMAIL_ALLOWLIST = "";
@@ -412,6 +414,7 @@ describe("server auth adapter", () => {
     verifyIdTokenMock.mockResolvedValue({
       uid: "firebase-admin-prod-current-host",
       email: "admin@example.com",
+      email_verified: true,
       name: "Admin User",
     });
 
@@ -560,6 +563,188 @@ describe("server auth adapter", () => {
       uid: "firebase-admin-host-header",
       email: "admin@example.com",
       provider: "firebase",
+    });
+  });
+
+  it("rejects requireAdmin when only the Firebase displayName matches an admin allowlist in production", async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    delete process.env.ADMIN_ENFORCE_HOST;
+    delete process.env.ADMIN_APP_HOSTS;
+    delete process.env.ADMIN_APP_ORIGIN;
+    process.env.ADMIN_EMAIL_ALLOWLIST = "admin@example.com";
+    // Attacker-controlled token: non-allowlisted (but verified) email and uid,
+    // with displayName set to a seeded admin name. Must NOT grant admin.
+    verifyIdTokenMock.mockResolvedValue({
+      uid: "attacker-uid",
+      email: "attacker@evil.com",
+      email_verified: true,
+      name: "Codex Huli",
+    });
+
+    try {
+      const auth = await import("@/lib/server/auth");
+      await expect(
+        auth.requireAdmin(requestWithBearerAt("https://trr-app.vercel.app/api/test", "token-displayname-only")),
+      ).rejects.toThrow("forbidden");
+    } finally {
+      if (typeof previousNodeEnv === "undefined") {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+    }
+  });
+
+  it("rejects requireAdmin when the allowlisted email is not verified", async () => {
+    delete process.env.ADMIN_APP_HOSTS;
+    process.env.ADMIN_EMAIL_ALLOWLIST = "admin@example.com";
+    verifyIdTokenMock.mockResolvedValue({
+      uid: "unverified-admin",
+      email: "admin@example.com",
+      email_verified: false,
+      name: "Admin User",
+    });
+
+    const auth = await import("@/lib/server/auth");
+    await expect(
+      auth.requireAdmin(requestWithBearerAt("https://trr-app.vercel.app/api/test", "token-unverified-email")),
+    ).rejects.toThrow("forbidden");
+  });
+
+  it("allows requireAdmin when an allowlisted email is verified", async () => {
+    delete process.env.ADMIN_APP_HOSTS;
+    process.env.ADMIN_EMAIL_ALLOWLIST = "admin@example.com";
+    verifyIdTokenMock.mockResolvedValue({
+      uid: "verified-admin",
+      email: "admin@example.com",
+      email_verified: true,
+      name: "Admin User",
+    });
+
+    const auth = await import("@/lib/server/auth");
+    const user = await auth.requireAdmin(
+      requestWithBearerAt("https://trr-app.vercel.app/api/test", "token-verified-email"),
+    );
+    expect(user).toMatchObject({
+      uid: "verified-admin",
+      email: "admin@example.com",
+      provider: "firebase",
+    });
+  });
+
+  it("allows requireAdmin when the Firebase token carries an admin custom claim", async () => {
+    delete process.env.ADMIN_APP_HOSTS;
+    process.env.ADMIN_EMAIL_ALLOWLIST = "";
+    // Neither email nor uid is allowlisted; only the server-set custom claim grants access.
+    verifyIdTokenMock.mockResolvedValue({
+      uid: "claim-admin",
+      email: "noone@example.com",
+      email_verified: true,
+      admin: true,
+    });
+
+    const auth = await import("@/lib/server/auth");
+    const user = await auth.requireAdmin(
+      requestWithBearerAt("https://trr-app.vercel.app/api/test", "token-custom-claim"),
+    );
+    expect(user).toMatchObject({
+      uid: "claim-admin",
+      provider: "firebase",
+    });
+  });
+
+  it("allows requireAdmin for an allowlisted uid even without a verified email", async () => {
+    delete process.env.ADMIN_APP_HOSTS;
+    process.env.ADMIN_EMAIL_ALLOWLIST = "";
+    // Seeded admin UID from DEFAULT_ADMIN_UIDS; email leg is intentionally unverified.
+    verifyIdTokenMock.mockResolvedValue({
+      uid: "MyoUFNjl9VP5iVGBi7tVqxUb8np2",
+      email: "unverified@example.com",
+      email_verified: false,
+      name: "Some Name",
+    });
+
+    const auth = await import("@/lib/server/auth");
+    const user = await auth.requireAdmin(
+      requestWithBearerAt("https://trr-app.vercel.app/api/test", "token-uid-allow"),
+    );
+    expect(user).toMatchObject({
+      uid: "MyoUFNjl9VP5iVGBi7tVqxUb8np2",
+      provider: "firebase",
+    });
+  });
+
+  it("never honors the dev admin bypass on production deployments (VERCEL_ENV=production)", async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    // Local-looking host + non-production NODE_ENV would normally enable the
+    // bypass; VERCEL_ENV=production must override everything.
+    process.env.NODE_ENV = "development";
+    process.env.VERCEL_ENV = "production";
+    process.env.ADMIN_ENFORCE_HOST = "true";
+    process.env.ADMIN_APP_HOSTS = "admin.localhost";
+
+    try {
+      const auth = await import("@/lib/server/auth");
+      await expect(
+        auth.requireAdmin(requestWithoutAuthAt("http://admin.localhost:3000/api/admin/auth/status")),
+      ).rejects.toThrow("unauthorized");
+    } finally {
+      delete process.env.VERCEL_ENV;
+      if (typeof previousNodeEnv === "undefined") {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+    }
+  });
+
+  it("refuses to load when TRR_DEV_ADMIN_BYPASS is set on a production deployment", async () => {
+    process.env.VERCEL_ENV = "production";
+    process.env.TRR_DEV_ADMIN_BYPASS = "true";
+
+    try {
+      await expect(import("@/lib/server/auth")).rejects.toThrow(
+        /TRR_DEV_ADMIN_BYPASS must not be set/,
+      );
+    } finally {
+      delete process.env.VERCEL_ENV;
+      delete process.env.TRR_DEV_ADMIN_BYPASS;
+    }
+  });
+
+  it("denies requireAdminContext on a non-admin host even with a valid internal-admin token", async () => {
+    process.env.ADMIN_ENFORCE_HOST = "true";
+    process.env.ADMIN_APP_HOSTS = "admin.localhost";
+    process.env.TRR_INTERNAL_ADMIN_SHARED_SECRET = "internal-secret-for-tests";
+
+    const auth = await import("@/lib/server/auth");
+    const { buildInternalAdminHeaders } = await import("@/lib/server/trr-api/internal-admin-auth");
+    const headers = buildInternalAdminHeaders(
+      { uid: "admin-123", email: "admin@example.com", verifiedAt: Date.now() },
+      {},
+    );
+
+    const request = new NextRequest("http://evil.example/api/test", { headers });
+    await expect(auth.requireAdminContext(request)).rejects.toThrow("forbidden");
+  });
+
+  it("returns the propagated context for requireAdminContext on an allowlisted host", async () => {
+    process.env.ADMIN_ENFORCE_HOST = "true";
+    process.env.ADMIN_APP_HOSTS = "admin.localhost";
+    process.env.TRR_INTERNAL_ADMIN_SHARED_SECRET = "internal-secret-for-tests";
+
+    const auth = await import("@/lib/server/auth");
+    const { buildInternalAdminHeaders } = await import("@/lib/server/trr-api/internal-admin-auth");
+    const headers = buildInternalAdminHeaders(
+      { uid: "admin-123", email: "admin@example.com", verifiedAt: Date.now() },
+      {},
+    );
+
+    const request = new NextRequest("http://admin.localhost:3000/api/test", { headers });
+    await expect(auth.requireAdminContext(request)).resolves.toMatchObject({
+      uid: "admin-123",
+      email: "admin@example.com",
     });
   });
 });

--- a/apps/web/tests/server-auth-adapter.test.ts
+++ b/apps/web/tests/server-auth-adapter.test.ts
@@ -719,11 +719,12 @@ describe("server auth adapter", () => {
     process.env.TRR_INTERNAL_ADMIN_SHARED_SECRET = "internal-secret-for-tests";
 
     const auth = await import("@/lib/server/auth");
-    const { buildInternalAdminHeaders } = await import("@/lib/server/trr-api/internal-admin-auth");
-    const headers = buildInternalAdminHeaders(
+    const { getInternalAdminBearerToken } = await import("@/lib/server/trr-api/internal-admin-auth");
+    const token = getInternalAdminBearerToken(
       { uid: "admin-123", email: "admin@example.com", verifiedAt: Date.now() },
-      {},
+      { host: "evil.example" },
     );
+    const headers = { authorization: `Bearer ${token}` };
 
     const request = new NextRequest("http://evil.example/api/test", { headers });
     await expect(auth.requireAdminContext(request)).rejects.toThrow("forbidden");
@@ -738,7 +739,7 @@ describe("server auth adapter", () => {
     const { buildInternalAdminHeaders } = await import("@/lib/server/trr-api/internal-admin-auth");
     const headers = buildInternalAdminHeaders(
       { uid: "admin-123", email: "admin@example.com", verifiedAt: Date.now() },
-      {},
+      { host: "admin.localhost:3000" },
     );
 
     const request = new NextRequest("http://admin.localhost:3000/api/test", { headers });

--- a/apps/web/tests/social-admin-proxy.test.ts
+++ b/apps/web/tests/social-admin-proxy.test.ts
@@ -107,6 +107,28 @@ describe("social-admin-proxy", () => {
     expect(typeof firstHeaders.get("x-trace-id")).toBe("string");
     expect((firstHeaders.get("x-trace-id") ?? "").length).toBeGreaterThan(0);
     expect(firstHeaders.get("Authorization")).toMatch(/^Bearer /);
+    expect(firstHeaders.get("x-trr-local-admin-proxy")).toBeNull();
+  });
+
+  it("marks loopback backend requests as local admin proxy calls", async () => {
+    getBackendApiUrlMock.mockImplementation((path: string) => `http://127.0.0.1:8000/api/v1${path}`);
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true }),
+    } as Response);
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    await fetchSocialBackendJson("/profiles/instagram/bravotv/posts", {
+      fallbackError: "Failed to fetch posts",
+      timeoutMs: 1000,
+    });
+
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    const headers = new Headers(requestInit?.headers);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://127.0.0.1:8000/api/v1/admin/socials/profiles/instagram/bravotv/posts");
+    expect(headers.get("Authorization")).toMatch(/^Bearer /);
+    expect(headers.get("x-trr-local-admin-proxy")).toBe("1");
   });
 
   it("does not retry mutating POST requests even when the upstream error is retryable", async () => {


### PR DESCRIPTION
## Summary
- harden admin auth checks for server routes and cron access
- add internal admin auth helper coverage
- tighten client admin access behavior

## Verification
- source "$HOME/.nvm/nvm.sh" && nvm use 24.14.0 >/dev/null && pnpm -C apps/web exec vitest run -c vitest.config.mts tests/client-admin-access.test.ts tests/cron-routes-auth.test.ts tests/internal-admin-auth.test.ts tests/server-auth-adapter.test.ts --pool=forks --poolOptions.forks.singleFork=true --reporter=basic
- git diff --check

## Orchestrator
- target: therealityreport/trr-app
- action: publish-and-sync
- mode: takeover
- source branch: security/admin-phase0-hardening


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cron endpoints return a server-misconfiguration error in production when the cron secret is unset.

* **Security**
  * Admin grants now require a verified allowlisted email, an allowlisted UID, or an explicit admin claim; display-name based grants removed.
  * Internal admin tokens validate JWT header algorithm and can be host-bound; dev-admin bypass disabled in production.

* **Behavior**
  * Proxy clarified as host-isolation only; social admin reads use a longer fixed timeout; loopback backends set a local proxy header.

* **Tests**
  * Added/expanded tests for cron auth, admin auth paths, internal-admin tokens, and loopback proxy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->