### PR TITLE
ci: non-blocking full typecheck lane + pre-commit hooks

### DIFF
--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -56,6 +56,13 @@ jobs:
       - name: Run targeted fandom typecheck (Node 24 full lane)
         if: matrix.lane == 'full'
         run: pnpm run typecheck:fandom
+      # Full project typecheck as a non-blocking signal. The repo gates only the
+      # fandom subset today; this surfaces the remaining errors without blocking
+      # merges. Flip to blocking once the full typecheck is green.
+      - name: Run full typecheck (non-blocking)
+        if: matrix.lane == 'full'
+        continue-on-error: true
+        run: pnpm run typecheck
       - name: Install Playwright Chromium (Node 24 full lane)
         if: matrix.lane == 'full'
         run: pnpm exec playwright install chromium

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,48 @@
+# Pre-commit hooks for TRR-APP.
+#
+# One-time setup:
+#   uv tool install pre-commit   # or: pipx install pre-commit
+#   pre-commit install                       # commit-stage hooks
+#   pre-commit install --hook-type pre-push  # enables the eslint pre-push gate
+#
+# Commit-stage hooks (gitleaks, ruff) run only on STAGED files and stay fast.
+# The eslint hook runs at PRE-PUSH (not per-commit) because the Next.js lint
+# pass is heavy; it only runs when apps/web TypeScript changed.
+#
+# gitleaks auto-discovers .gitleaks.toml if present; ruff reuses ./ruff.toml
+# (TRR-APP's Python is the repo-map generator scripts only).
+minimum_pre_commit_version: "3.5.0"
+
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.4
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: \.py$
+      - id: ruff-format
+        files: \.py$
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+        exclude: '^apps/web/(\.next|coverage|node_modules)/'
+      - id: trailing-whitespace
+        exclude: '^apps/web/(\.next|coverage|node_modules)/'
+
+  - repo: local
+    hooks:
+      - id: eslint-web
+        name: eslint (apps/web)
+        language: system
+        entry: pnpm -C apps/web run lint
+        pass_filenames: false
+        files: '^apps/web/.*\.(ts|tsx)$'
+        stages: [pre-push]


### PR DESCRIPTION
## What
Phase 1 (app side) of the tooling upgrade.

- `web-tests.yml`: adds a **non-blocking** full `pnpm typecheck` step (the blocking gate still runs `typecheck:fandom`). Surfaces the full-typecheck backlog without blocking merges; flip to blocking once green.
- `.pre-commit-config.yaml`: gitleaks + ruff (for the Python repo-map scripts) on commit; eslint at pre-push (kept off per-commit since the Next lint pass is heavy).

## Notes
Pure CI/config; no `apps/web` source changes. Branched from `origin/main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with comprehensive TypeScript type checking
  * Implemented pre-commit hooks for code quality assurance, including secret scanning, linting, and code formatting validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->