### PR TITLE
Admin social load-time instrumentation

### DIFF
--- a/apps/web/src/app/admin/social/page.tsx
+++ b/apps/web/src/app/admin/social/page.tsx
@@ -362,7 +362,10 @@ const coerceSocialProgressStatus = (
   value: Partial<SocialLandingProgressStatus> | null | undefined,
 ): SocialLandingProgressStatus => {
   const source =
-    value?.source === "backend" || value?.source === "fallback" || value?.source === "none"
+    value?.source === "backend" ||
+    value?.source === "fallback" ||
+    value?.source === "none" ||
+    value?.source === "unavailable"
       ? value.source
       : "none";
   return {
@@ -696,7 +699,9 @@ const SocialProgressStatusBadge = ({
       ? status.cache_status
         ? `backend ${status.cache_status}`
         : "backend"
-      : "local fallback";
+      : status.source === "unavailable"
+        ? "backend unavailable"
+        : "local fallback";
   return (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -1042,7 +1047,7 @@ const loadLandingData = async (
     throw new Error(data?.error || "Failed to load social landing data");
   }
   return {
-    payload: coerceLandingPayload(data, { progressStale: cacheStatus === "stale" }),
+    payload: coerceLandingPayload(data, { progressStale: cacheStatus?.includes("stale") ?? false }),
     cacheable: response.headers.get("x-trr-cacheable") !== "0",
   };
 };

--- a/apps/web/src/app/admin/social/page.tsx
+++ b/apps/web/src/app/admin/social/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import type { Route } from "next";
 import Image from "next/image";
 import type { User } from "firebase/auth";
@@ -75,6 +75,7 @@ import type {
   SocialHandleSummary,
   SocialLandingPlatform,
   SocialLandingPayload,
+  SocialLandingProgressStatus,
 } from "@/lib/admin/social-landing";
 import {
   buildSocialAccountProfileUrl,
@@ -84,6 +85,7 @@ import {
 import { normalizePersonExternalIdValue } from "@/lib/admin/person-external-ids";
 import { resolvePreferredShowRouteSlug } from "@/lib/admin/show-route-slug";
 import { fetchAdminWithAuth } from "@/lib/admin/client-auth";
+import { recordAdminLoadSample } from "@/lib/admin/admin-load-samples";
 import { useAdminGuard } from "@/lib/admin/useAdminGuard";
 
 const sectionEyebrowClass =
@@ -91,6 +93,10 @@ const sectionEyebrowClass =
 const SOCIAL_LANDING_CACHE_KEY = "trr-admin-social-landing:v7";
 const BRAVO_SHARED_SOURCES_RAW_URL =
   "/api/admin/trr-api/social/shared/sources?source_scope=network&include_inactive=true";
+const nowMs = (): number =>
+  typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
 const DEFAULT_SCRAPE_JOB_HEALTH: ScrapeJobHealthSummary = {
   window_hours: 8,
   window_started_at: null,
@@ -352,8 +358,25 @@ const coerceSharedSourceStatus = (
   return statuses;
 };
 
+const coerceSocialProgressStatus = (
+  value: Partial<SocialLandingProgressStatus> | null | undefined,
+): SocialLandingProgressStatus => {
+  const source =
+    value?.source === "backend" || value?.source === "fallback" || value?.source === "none"
+      ? value.source
+      : "none";
+  return {
+    source,
+    cache_status: typeof value?.cache_status === "string" ? value.cache_status : null,
+    generated_at: typeof value?.generated_at === "string" ? value.generated_at : null,
+    stale: Boolean(value?.stale),
+    warning: typeof value?.warning === "string" ? value.warning : null,
+  };
+};
+
 const coerceLandingPayload = (
   data: Partial<SocialLandingPayload> | undefined,
+  options: { progressStale?: boolean } = {},
 ): SocialLandingPayload => ({
   network_sets: Array.isArray(data?.network_sets) ? data.network_sets : [],
   show_sets: Array.isArray(data?.show_sets) ? data.show_sets : [],
@@ -385,6 +408,12 @@ const coerceLandingPayload = (
       : [],
   },
   shared_source_status: coerceSharedSourceStatus(data?.shared_source_status),
+  social_progress_status: {
+    ...coerceSocialProgressStatus(data?.social_progress_status),
+    stale:
+      Boolean(options.progressStale) ||
+      Boolean(data?.social_progress_status?.stale),
+  },
   scrape_job_health: {
     ...DEFAULT_SCRAPE_JOB_HEALTH,
     ...(data?.scrape_job_health ?? {}),
@@ -646,6 +675,42 @@ const ScrapeJobHealthBadge = ({
       </TooltipTrigger>
       <TooltipContent>
         Post-deploy watch for recent social scrape job failures and InFailedSqlTransaction hits.
+      </TooltipContent>
+    </Tooltip>
+  );
+};
+
+const SocialProgressStatusBadge = ({
+  status,
+}: {
+  status: SocialLandingProgressStatus | null | undefined;
+}) => {
+  if (!status || status.source === "none") return null;
+  const stale = status.stale || status.cache_status === "stale";
+  const toneClassName = stale
+    ? "border-amber-300 bg-amber-50 text-amber-900"
+    : "border-sky-200 bg-sky-50 text-sky-800";
+  const label = stale ? "Progress stale" : "Progress live";
+  const detail =
+    status.source === "backend"
+      ? status.cache_status
+        ? `backend ${status.cache_status}`
+        : "backend"
+      : "local fallback";
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-semibold ${toneClassName}`}>
+          {stale ? <AlertTriangle aria-hidden="true" className="h-3.5 w-3.5" /> : <CircleCheck aria-hidden="true" className="h-3.5 w-3.5" />}
+          <span>{label}</span>
+          <span className="text-current/70">{detail}</span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>
+        {status.warning ||
+          (status.generated_at
+            ? `Progress generated ${formatCompactTimestamp(status.generated_at) || status.generated_at}.`
+            : "Progress freshness for the social landing rollup.")}
       </TooltipContent>
     </Tooltip>
   );
@@ -955,9 +1020,20 @@ const loadLandingData = async (
   const url = options.refresh
     ? "/api/admin/social/landing?refresh=1"
     : "/api/admin/social/landing";
+  const startedAt = nowMs();
   const response = await fetchAdminWithAuth(url, undefined, {
     allowDevAdminBypass: true,
     preferredUser: currentUser,
+  });
+  const durationMs = nowMs() - startedAt;
+  const cacheStatus = response.headers.get("x-trr-cache");
+  recordAdminLoadSample({
+    surface: "admin-social-landing-api",
+    path: "/admin/social",
+    source: "api",
+    duration_ms: durationMs,
+    cache_status: cacheStatus,
+    server_timing: response.headers.get("server-timing"),
   });
   const data = (await response.json().catch(() => ({}))) as
     | ({ error?: string } & Partial<SocialLandingPayload>)
@@ -966,7 +1042,7 @@ const loadLandingData = async (
     throw new Error(data?.error || "Failed to load social landing data");
   }
   return {
-    payload: coerceLandingPayload(data),
+    payload: coerceLandingPayload(data, { progressStale: cacheStatus === "stale" }),
     cacheable: response.headers.get("x-trr-cacheable") !== "0",
   };
 };
@@ -2015,6 +2091,8 @@ const NetworkSourceGroupCard = ({
 export default function AdminSocialMediaPage() {
   const { user, checking, hasAccess } = useAdminGuard();
   const [landing, setLanding] = useState<SocialLandingPayload | null>(null);
+  const landingLoadStartedAtRef = useRef<number>(nowMs());
+  const landingNavigationSampleRecordedRef = useRef(false);
   const [landingFreshnessAt, setLandingFreshnessAt] = useState<string | null>(null);
   const [loadingLanding, setLoadingLanding] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -2028,6 +2106,18 @@ export default function AdminSocialMediaPage() {
   const [savingHandle, setSavingHandle] = useState(false);
   const [addHandleMessage, setAddHandleMessage] = useState<string | null>(null);
   const [addHandleError, setAddHandleError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!landing || landingNavigationSampleRecordedRef.current) return;
+    landingNavigationSampleRecordedRef.current = true;
+    recordAdminLoadSample({
+      surface: "admin-social-landing",
+      path: "/admin/social",
+      source: "navigation",
+      duration_ms: nowMs() - landingLoadStartedAtRef.current,
+      cache_status: landing.social_progress_status?.cache_status ?? null,
+    });
+  }, [landing]);
 
   useEffect(() => {
     if (checking || !user || !hasAccess) return;
@@ -2386,8 +2476,9 @@ export default function AdminSocialMediaPage() {
                 handles already stored in TRR.
               </p>
               {landing ? (
-                <div className="mt-3">
+                <div className="mt-3 flex flex-wrap items-center gap-2">
                   <ScrapeJobHealthBadge health={scrapeJobHealth} />
+                  <SocialProgressStatusBadge status={landing.social_progress_status} />
                 </div>
               ) : null}
             </div>

--- a/apps/web/src/app/api/admin/social/landing/route.ts
+++ b/apps/web/src/app/api/admin/social/landing/route.ts
@@ -25,6 +25,7 @@ import {
   getSocialLandingPayloadResult,
   type SocialLandingPayloadResult,
 } from "@/lib/server/admin/social-landing-repository";
+import { attachAdminRouteTiming } from "@/lib/server/admin/admin-route-timing";
 import { normalizePersonExternalIdValue, type PersonExternalIdInput } from "@/lib/admin/person-external-ids";
 import { normalizeSocialAccountProfileHandle } from "@/lib/admin/show-admin-routes";
 import { fetchSocialBackendJson } from "@/lib/server/trr-api/social-admin-proxy";
@@ -364,6 +365,17 @@ const upsertSharedSource = async ({
 };
 
 export async function GET(request: NextRequest) {
+  const routeStartedAt = performance.now();
+  let backendMs = 0;
+  let databaseMs = 0;
+  const timingCollector = {
+    recordBackendMs(durationMs: number) {
+      backendMs += durationMs;
+    },
+    recordDbMs(durationMs: number) {
+      databaseMs += durationMs;
+    },
+  };
   try {
     const user = await requireAdmin(request);
     const adminContext = toVerifiedAdminContext(user);
@@ -380,7 +392,15 @@ export async function GET(request: NextRequest) {
       cacheKey,
     );
     if (cached && !shouldRefresh) {
-      return NextResponse.json(cached, { headers: { "x-trr-cache": "hit" } });
+      return attachAdminRouteTiming(
+        NextResponse.json(cached, { headers: { "x-trr-cache": "hit" } }),
+        {
+          routeFamily: "admin-social-landing",
+          routeName: "GET /api/admin/social/landing",
+          cacheStatus: "hit",
+          startedAt: routeStartedAt,
+        },
+      );
     }
     const staleCached = shouldRefresh
       ? null
@@ -396,7 +416,7 @@ export async function GET(request: NextRequest) {
         cacheKey,
         async () => {
           const cacheVersion = getSocialLandingRouteCacheVersion(user.uid);
-          const nextResult = await getSocialLandingPayloadResult(adminContext);
+          const nextResult = await getSocialLandingPayloadResult(adminContext, timingCollector);
           if (
             nextResult.cacheable &&
             isSocialLandingRouteCacheVersionCurrent(user.uid, cacheVersion)
@@ -415,9 +435,19 @@ export async function GET(request: NextRequest) {
     } catch (error) {
       if (staleCached && !shouldRefresh) {
         console.warn("[api] Failed to rebuild social landing payload; serving stale cache", error);
-        return NextResponse.json(staleCached, {
-          headers: { "x-trr-cache": "stale", "x-trr-cacheable": "0" },
-        });
+        return attachAdminRouteTiming(
+          NextResponse.json(staleCached, {
+            headers: { "x-trr-cache": "stale", "x-trr-cacheable": "0" },
+          }),
+          {
+            routeFamily: "admin-social-landing",
+            routeName: "GET /api/admin/social/landing",
+            cacheStatus: "stale",
+            startedAt: routeStartedAt,
+            backendMs,
+            databaseMs,
+          },
+        );
       }
       throw error;
     }
@@ -427,9 +457,19 @@ export async function GET(request: NextRequest) {
       !shouldRefresh &&
       !hasSharedSourceFallbackStatus(result.payload)
     ) {
-      return NextResponse.json(staleCached, {
-        headers: { "x-trr-cache": "stale", "x-trr-cacheable": "0" },
-      });
+      return attachAdminRouteTiming(
+        NextResponse.json(staleCached, {
+          headers: { "x-trr-cache": "stale", "x-trr-cacheable": "0" },
+        }),
+        {
+          routeFamily: "admin-social-landing",
+          routeName: "GET /api/admin/social/landing",
+          cacheStatus: "stale",
+          startedAt: routeStartedAt,
+          backendMs,
+          databaseMs,
+        },
+      );
     }
     const headers: Record<string, string> = {};
     if (shouldRefresh) {
@@ -438,17 +478,42 @@ export async function GET(request: NextRequest) {
     if (!result.cacheable) {
       headers["x-trr-cacheable"] = "0";
     }
-    return NextResponse.json(result.payload, { headers });
+    return attachAdminRouteTiming(NextResponse.json(result.payload, { headers }), {
+      routeFamily: "admin-social-landing",
+      routeName: "GET /api/admin/social/landing",
+      cacheStatus: headers["x-trr-cache"] ?? (result.cacheable ? "miss" : "uncacheable"),
+      startedAt: routeStartedAt,
+      backendMs,
+      databaseMs,
+    });
   } catch (error) {
     console.error("[api] Failed to load social landing payload", error);
     const message = error instanceof Error ? error.message : "Failed to load social landing payload";
     const status =
       message === "unauthorized" ? 401 : message === "forbidden" ? 403 : 500;
-    return NextResponse.json({ error: message }, { status });
+    return attachAdminRouteTiming(NextResponse.json({ error: message }, { status }), {
+      routeFamily: "admin-social-landing",
+      routeName: "GET /api/admin/social/landing",
+      cacheStatus: "error",
+      startedAt: routeStartedAt,
+      backendMs,
+      databaseMs,
+    });
   }
 }
 
 export async function POST(request: NextRequest) {
+  const routeStartedAt = performance.now();
+  let backendMs = 0;
+  let databaseMs = 0;
+  const timingCollector = {
+    recordBackendMs(durationMs: number) {
+      backendMs += durationMs;
+    },
+    recordDbMs(durationMs: number) {
+      databaseMs += durationMs;
+    },
+  };
   try {
     const user = await requireAdmin(request);
     const adminContext = toVerifiedAdminContext(user);
@@ -627,7 +692,7 @@ export async function POST(request: NextRequest) {
 
     invalidateSocialLandingRouteCacheForUser(user.uid);
     const cacheVersion = getSocialLandingRouteCacheVersion(user.uid);
-    const result = await getSocialLandingPayloadResult(adminContext);
+    const result = await getSocialLandingPayloadResult(adminContext, timingCollector);
     if (
       result.cacheable &&
       isSocialLandingRouteCacheVersionCurrent(user.uid, cacheVersion)
@@ -640,9 +705,19 @@ export async function POST(request: NextRequest) {
         SOCIAL_LANDING_STALE_CACHE_TTL_MS,
       );
     }
-    return NextResponse.json(result.payload, {
-      headers: result.cacheable ? undefined : { "x-trr-cacheable": "0" },
-    });
+    return attachAdminRouteTiming(
+      NextResponse.json(result.payload, {
+        headers: result.cacheable ? undefined : { "x-trr-cacheable": "0" },
+      }),
+      {
+        routeFamily: "admin-social-landing",
+        routeName: "POST /api/admin/social/landing",
+        cacheStatus: result.cacheable ? "miss" : "uncacheable",
+        startedAt: routeStartedAt,
+        backendMs,
+        databaseMs,
+      },
+    );
   } catch (error) {
     console.error("[api] Failed to update social landing handle", error);
     const message = error instanceof Error ? error.message : "Failed to update social landing handle";
@@ -654,6 +729,13 @@ export async function POST(request: NextRequest) {
           : message === "Person not found"
             ? 404
             : 500;
-    return NextResponse.json({ error: message }, { status });
+    return attachAdminRouteTiming(NextResponse.json({ error: message }, { status }), {
+      routeFamily: "admin-social-landing",
+      routeName: "POST /api/admin/social/landing",
+      cacheStatus: "error",
+      startedAt: routeStartedAt,
+      backendMs,
+      databaseMs,
+    });
   }
 }

--- a/apps/web/src/app/api/admin/social/landing/route.ts
+++ b/apps/web/src/app/api/admin/social/landing/route.ts
@@ -514,6 +514,19 @@ export async function POST(request: NextRequest) {
       databaseMs += durationMs;
     },
   };
+  const timedJson = (
+    body: Record<string, unknown>,
+    init: ResponseInit,
+    cacheStatus: string | null = "error",
+  ): NextResponse =>
+    attachAdminRouteTiming(NextResponse.json(body, init), {
+      routeFamily: "admin-social-landing",
+      routeName: "POST /api/admin/social/landing",
+      cacheStatus,
+      startedAt: routeStartedAt,
+      backendMs,
+      databaseMs,
+    });
   try {
     const user = await requireAdmin(request);
     const adminContext = toVerifiedAdminContext(user);
@@ -526,21 +539,21 @@ export async function POST(request: NextRequest) {
     const displayName = typeof body?.display_name === "string" ? body.display_name.trim() : "";
 
     if (!isLandingTargetType(targetType)) {
-      return NextResponse.json({ error: "target_type is required" }, { status: 400 });
+      return timedJson({ error: "target_type is required" }, { status: 400 });
     }
     if (!targetId) {
-      return NextResponse.json({ error: "target_id is required" }, { status: 400 });
+      return timedJson({ error: "target_id is required" }, { status: 400 });
     }
     if (!isLandingPlatform(platform)) {
-      return NextResponse.json({ error: "platform is required" }, { status: 400 });
+      return timedJson({ error: "platform is required" }, { status: 400 });
     }
     if (!rawValue) {
-      return NextResponse.json({ error: "value is required" }, { status: 400 });
+      return timedJson({ error: "value is required" }, { status: 400 });
     }
 
     if (targetType === "shared_source") {
       if (!isSharedSourceTargetScope(sourceScope)) {
-        return NextResponse.json({ error: "source_scope must be news or creator" }, { status: 400 });
+        return timedJson({ error: "source_scope must be news or creator" }, { status: 400 });
       }
       const sourceInput = normalizeSocialSourceInput(platform, rawValue);
       await upsertSharedSource({
@@ -565,7 +578,7 @@ export async function POST(request: NextRequest) {
     if (targetType === "network") {
       const sourceScope = NETWORK_SOURCE_SCOPE_BY_KEY[targetId as keyof typeof NETWORK_SOURCE_SCOPE_BY_KEY];
       if (!sourceScope) {
-        return NextResponse.json({ error: "Network target not found" }, { status: 404 });
+        return timedJson({ error: "Network target not found" }, { status: 404 });
       }
       const sourceInput = normalizeSocialSourceInput(platform, rawValue);
       const current = (await fetchSocialBackendJson("/shared/sources", {
@@ -631,7 +644,7 @@ export async function POST(request: NextRequest) {
     if (targetType === "show") {
       const currentShow = await getShowById(targetId);
       if (!currentShow) {
-        return NextResponse.json({ error: "Show not found" }, { status: 404 });
+        return timedJson({ error: "Show not found" }, { status: 404 });
       }
       const sourceInput = normalizeSocialSourceInput(platform, rawValue);
       const existingExternalIds =

--- a/apps/web/src/app/api/admin/trr-api/social/ingest/queue-status/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/social/ingest/queue-status/route.ts
@@ -5,10 +5,12 @@ import {
   SOCIAL_PROXY_DEFAULT_TIMEOUT_MS,
   socialProxyErrorResponse,
 } from "@/lib/server/trr-api/social-admin-proxy";
+import { attachAdminRouteTiming } from "@/lib/server/admin/admin-route-timing";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(request: NextRequest) {
+  const routeStartedAt = performance.now();
   try {
     await requireAdmin(request);
     const forwardedSearchParams = new URLSearchParams(request.nextUrl.searchParams.toString());
@@ -19,8 +21,21 @@ export async function GET(request: NextRequest) {
       retries: 0,
       timeoutMs: SOCIAL_PROXY_DEFAULT_TIMEOUT_MS,
     });
-    return NextResponse.json(data);
+    return attachAdminRouteTiming(NextResponse.json(data), {
+      routeFamily: "admin-social-profile",
+      routeName: "GET /api/admin/trr-api/social/ingest/queue-status",
+      cacheStatus: "miss",
+      startedAt: routeStartedAt,
+    });
   } catch (error) {
-    return socialProxyErrorResponse(error, "[api] Failed to fetch queue status");
+    return attachAdminRouteTiming(
+      socialProxyErrorResponse(error, "[api] Failed to fetch queue status"),
+      {
+        routeFamily: "admin-social-profile",
+        routeName: "GET /api/admin/trr-api/social/ingest/queue-status",
+        cacheStatus: "error",
+        startedAt: routeStartedAt,
+      },
+    );
   }
 }

--- a/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/posts/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/posts/route.ts
@@ -5,6 +5,7 @@ import {
   buildAdminSnapshotCacheKey,
   getOrCreateAdminSnapshot,
 } from "@/lib/server/admin/admin-snapshot-cache";
+import { attachAdminRouteTiming } from "@/lib/server/admin/admin-route-timing";
 import { buildAdminReadResponseHeaders } from "@/lib/server/trr-api/admin-read-proxy";
 import {
   fetchSocialBackendJson,
@@ -21,6 +22,7 @@ const CATALOG_POSTS_TTL_MS = 5 * 60_000;
 const CATALOG_POSTS_STALE_MS = 15 * 60_000;
 
 export async function GET(request: NextRequest, context: RouteContext) {
+  const routeStartedAt = performance.now();
   try {
     const user = await requireAdmin(request);
     const { platform, handle } = await context.params;
@@ -49,10 +51,26 @@ export async function GET(request: NextRequest, context: RouteContext) {
           },
         ),
     });
-    return NextResponse.json(snapshot.data, {
-      headers: buildAdminReadResponseHeaders({ cacheStatus: snapshot.meta.cacheStatus }),
-    });
+    return attachAdminRouteTiming(
+      NextResponse.json(snapshot.data, {
+        headers: buildAdminReadResponseHeaders({ cacheStatus: snapshot.meta.cacheStatus }),
+      }),
+      {
+        routeFamily: "admin-social-profile",
+        routeName: "GET catalog/posts",
+        cacheStatus: snapshot.meta.cacheStatus,
+        startedAt: routeStartedAt,
+      },
+    );
   } catch (error) {
-    return socialProxyErrorResponse(error, "[api] Failed to fetch social account catalog posts");
+    return attachAdminRouteTiming(
+      socialProxyErrorResponse(error, "[api] Failed to fetch social account catalog posts"),
+      {
+        routeFamily: "admin-social-profile",
+        routeName: "GET catalog/posts",
+        cacheStatus: "error",
+        startedAt: routeStartedAt,
+      },
+    );
   }
 }

--- a/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/snapshot/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/snapshot/route.ts
@@ -5,6 +5,7 @@ import {
   buildAdminSnapshotCacheKey,
   getOrCreateAdminSnapshot,
 } from "@/lib/server/admin/admin-snapshot-cache";
+import { attachAdminRouteTiming } from "@/lib/server/admin/admin-route-timing";
 import { buildSnapshotResponse } from "@/lib/server/admin/admin-snapshot-route";
 import {
   fetchSocialBackendJson,
@@ -133,6 +134,7 @@ const logSocialProfileDashboardBudget = (input: {
 };
 
 export async function GET(request: NextRequest, context: RouteContext) {
+  const routeStartedAt = performance.now();
   try {
     const user = await requireAdmin(request);
     const adminContext = toVerifiedAdminContext(user);
@@ -185,7 +187,12 @@ export async function GET(request: NextRequest, context: RouteContext) {
       });
       response.headers.set("x-trr-dashboard-freshness", "degraded");
       response.headers.set("x-trr-dashboard-source", source);
-      return response;
+      return attachAdminRouteTiming(response, {
+        routeFamily: "admin-social-profile",
+        routeName: "GET profile snapshot",
+        cacheStatus: "miss",
+        startedAt: routeStartedAt,
+      });
     }
 
     const cacheKey = buildAdminSnapshotCacheKey({
@@ -287,8 +294,21 @@ export async function GET(request: NextRequest, context: RouteContext) {
     });
     response.headers.set("x-trr-dashboard-freshness", freshnessStatus);
     response.headers.set("x-trr-dashboard-source", freshnessSource);
-    return response;
+    return attachAdminRouteTiming(response, {
+      routeFamily: "admin-social-profile",
+      routeName: "GET profile snapshot",
+      cacheStatus: snapshot.meta.cacheStatus,
+      startedAt: routeStartedAt,
+    });
   } catch (error) {
-    return socialProxyErrorResponse(error, "[api] Failed to fetch social account profile snapshot");
+    return attachAdminRouteTiming(
+      socialProxyErrorResponse(error, "[api] Failed to fetch social account profile snapshot"),
+      {
+        routeFamily: "admin-social-profile",
+        routeName: "GET profile snapshot",
+        cacheStatus: "error",
+        startedAt: routeStartedAt,
+      },
+    );
   }
 }

--- a/apps/web/src/components/admin/SocialAccountProfilePage.tsx
+++ b/apps/web/src/components/admin/SocialAccountProfilePage.tsx
@@ -3318,23 +3318,18 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   );
   const shouldShowCatalogRunProgressCard = selectedTab !== "comments";
   const hasSummary = summary !== null;
+  const summaryMatchesCurrentRoute =
+    normalizeComparable(summary?.platform) === normalizeComparable(platform) &&
+    normalizeComparable(String(summary?.account_handle || "").replace(/^@+/, "")) ===
+      normalizeComparable(handle.replace(/^@+/, ""));
+  const hasCurrentSummary = hasSummary && summaryMatchesCurrentRoute;
   useEffect(() => {
     profileLoadStartedAtRef.current = nowMs();
     profileNavigationSampleRecordedRef.current = false;
   }, [handle, platform]);
   useEffect(() => {
     if (profileNavigationSampleRecordedRef.current) return;
-    if (!hasSummary && !summaryUninitialized) return;
-    if (
-      hasSummary &&
-      (summary?.platform !== platform ||
-        String(summary?.account_handle || "")
-          .trim()
-          .replace(/^@+/, "")
-          .toLowerCase() !== handle.trim().replace(/^@+/, "").toLowerCase())
-    ) {
-      return;
-    }
+    if (!hasCurrentSummary) return;
     profileNavigationSampleRecordedRef.current = true;
     recordAdminLoadSample({
       surface: "admin-social-profile",
@@ -3343,7 +3338,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       duration_ms: nowMs() - profileLoadStartedAtRef.current,
       cache_status: dashboardFreshness?.status ?? null,
     });
-  }, [dashboardFreshness?.status, handle, hasSummary, platform, summary?.account_handle, summary?.platform, summaryUninitialized]);
+  }, [dashboardFreshness?.status, handle, hasCurrentSummary, platform]);
   const postsSortMetadata = posts?.sort_metadata ?? null;
   const summaryInitialStatePending = !hasSummary && !summaryError && !summaryUninitialized;
   const summarySourceMetadata = useMemo(
@@ -3424,7 +3419,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     (selectedTab === "hashtags" && (hashtagsLoading || hashtagTimelineLoading)) ||
     (selectedTab === "collaborators-tags" && collaboratorsLoading);
   const selectedTabPrimaryReadPending =
-    hasSummary &&
+    hasCurrentSummary &&
     !summaryUninitialized &&
     (
       (selectedTab === "posts" && !posts && !postsError) ||
@@ -3443,9 +3438,9 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     summarySaturationActive ||
     catalogProgressSaturationActive;
   const shouldDeferSecondaryCatalogReads =
-    !hasSummary || summaryLoading || selectedTabPrimaryReadActive || selectedTabPrimaryReadPending || shouldPauseSecondaryReads;
+    !hasCurrentSummary || summaryLoading || selectedTabPrimaryReadActive || selectedTabPrimaryReadPending || shouldPauseSecondaryReads;
   const shouldDeferManualCatalogDiagnostics =
-    !hasSummary ||
+    !hasCurrentSummary ||
     summaryLoading ||
     summarySaturationActive ||
     catalogProgressSaturationActive;
@@ -3549,7 +3544,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   useEffect(() => {
     if (secondaryReadsGateOpen) return;
     if (checking || !user || !hasAccess || summaryLoading) return;
-    if (!hasSummary && !summaryError && !summaryUninitialized) return;
+    if (!hasCurrentSummary && !summaryError && !summaryUninitialized) return;
     if (selectedTabPrimaryReadActive) return;
     const timeoutId = window.setTimeout(() => {
       setSecondaryReadsGateOpen(true);
@@ -3559,7 +3554,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   }, [
     checking,
     hasAccess,
-    hasSummary,
+    hasCurrentSummary,
     secondaryReadsGateOpen,
     selectedTabPrimaryReadActive,
     summaryError,
@@ -4172,7 +4167,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       !hasAccess ||
       platform !== "instagram" ||
       summaryLoading ||
-      !hasSummary ||
+      !hasCurrentSummary ||
       !secondaryReadsGateOpen ||
       Boolean(secondaryReadsPressurePause) ||
       secondaryReadBudgetSlot < 2
@@ -4239,13 +4234,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
           liveProfileTotalProbeKeyRef.current = null;
         }
         const requestError = toSocialAccountRequestError(error, "Failed to load social account live profile total");
-        const requestErrorCode = requestError.code;
-        const requestErrorMessage = requestError.message || "";
-        if (
-          isBackendSaturationError(requestError) ||
-          isBackendPressureCode(requestErrorCode) ||
-          hasBackendSaturationText(requestErrorMessage)
-        ) {
+        if (isBackendPressureError(requestError)) {
           pauseSecondaryReadsForPressure(requestError, "Failed to load social account live profile total");
         }
         // Best-effort only; leave the cached summary values intact.
@@ -4263,7 +4252,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     checking,
     fetchAdminWithAuth,
     handle,
-    hasSummary,
+    hasCurrentSummary,
     hasAccess,
     liveProfileTotalRequestNonce,
     pauseSecondaryReadsForPressure,
@@ -4347,7 +4336,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       !user ||
       !hasAccess ||
       selectedTab !== "posts" ||
-      !hasSummary ||
+      !hasCurrentSummary ||
       summaryUninitialized
     ) {
       return;
@@ -4386,7 +4375,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     fetchAdminWithAuth,
     handle,
     hasAccess,
-    hasSummary,
+    hasCurrentSummary,
     page,
     platform,
     selectedTab,
@@ -4401,7 +4390,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       !hasAccess ||
       selectedTab !== "catalog" ||
       !supportsCatalog ||
-      !hasSummary ||
+      !hasCurrentSummary ||
       summaryUninitialized
     ) {
       return;
@@ -4449,7 +4438,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     fetchAdminWithAuth,
     handle,
     hasAccess,
-    hasSummary,
+    hasCurrentSummary,
     platform,
     selectedTab,
     summaryUninitialized,
@@ -4474,7 +4463,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       !user ||
       !hasAccess ||
       !shouldLoadHashtags ||
-      !hasSummary ||
+      !hasCurrentSummary ||
       summaryUninitialized ||
       (selectedTab !== "hashtags" && shouldDeferSecondaryCatalogReads)
     ) {
@@ -4522,7 +4511,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     checking,
     hashtagWindow,
     hasAccess,
-    hasSummary,
+    hasCurrentSummary,
     hashtagsRequestKey,
     platform,
     pauseSecondaryReadsForPressure,
@@ -4541,7 +4530,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       !hasAccess ||
       selectedTab !== "hashtags" ||
       platform !== "instagram" ||
-      !hasSummary ||
+      !hasCurrentSummary ||
       summaryUninitialized ||
       !secondaryReadsGateOpen ||
       Boolean(secondaryReadsPressurePause)
@@ -4575,7 +4564,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   }, [
     checking,
     hasAccess,
-    hasSummary,
+    hasCurrentSummary,
     platform,
     refreshHashtagTimeline,
     secondaryReadsGateOpen,
@@ -4591,6 +4580,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       !user ||
       !hasAccess ||
       !supportsCatalog ||
+      !hasCurrentSummary ||
       summaryUninitialized ||
       (selectedTab !== "hashtags" && shouldDeferSecondaryCatalogReads) ||
       (selectedTab !== "hashtags" && secondaryReadBudgetSlot < 3) ||
@@ -4633,6 +4623,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     fetchAdminWithAuth,
     handle,
     hasAccess,
+    hasCurrentSummary,
     pendingReviewOpen,
     pauseSecondaryReadsForPressure,
     platform,
@@ -4650,7 +4641,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       !user ||
       !hasAccess ||
       selectedTab !== "collaborators-tags" ||
-      !hasSummary ||
+      !hasCurrentSummary ||
       summaryUninitialized
     ) {
       return;
@@ -4695,7 +4686,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     fetchAdminWithAuth,
     handle,
     hasAccess,
-    hasSummary,
+    hasCurrentSummary,
     platform,
     selectedTab,
     summaryUninitialized,
@@ -7521,6 +7512,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       checking ||
       !user ||
       !hasAccess ||
+      !hasCurrentSummary ||
       !platformRequiresCookies ||
       shouldDeferSecondaryCatalogReads ||
       secondaryReadBudgetSlot < 3 ||
@@ -7543,6 +7535,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     fetchCookieHealth,
     hasAccess,
     handle,
+    hasCurrentSummary,
     platform,
     platformRequiresCookies,
     selectedTab,

--- a/apps/web/src/components/admin/SocialAccountProfilePage.tsx
+++ b/apps/web/src/components/admin/SocialAccountProfilePage.tsx
@@ -77,6 +77,7 @@ import { isLocalDevHostname } from "@/lib/admin/dev-admin-bypass";
 import { buildSocialAccountProfileUrl } from "@/lib/admin/show-admin-routes";
 import { fetchSocialAccountCatalogRunProgressSnapshot } from "@/lib/admin/social-account-catalog-progress";
 import { invalidateAdminSnapshotFamilies } from "@/lib/admin/admin-snapshot-client";
+import { recordAdminLoadSample } from "@/lib/admin/admin-load-samples";
 import { fetchAdminWithAuth as fetchAdminWithAuthBase } from "@/lib/admin/client-auth";
 import { useSharedPollingResource } from "@/lib/admin/shared-live-resource";
 import { useAdminGuard } from "@/lib/admin/useAdminGuard";
@@ -105,6 +106,10 @@ const NYT_DASHBOARD_DANGER_BUTTON_CLASS =
   "rounded-none border-red-900 bg-white px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-red-900 hover:bg-red-900 hover:text-white";
 const NYT_DASHBOARD_ICON_BUTTON_CLASS =
   "rounded-none border-black bg-white px-2 py-1.5 text-black hover:bg-black hover:text-white";
+const nowMs = (): number =>
+  typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
 export const getCatalogRepairAuthEndpointSegment = (repairAction: string | null | undefined): "manual-auth" | "repair-auth" =>
   repairAction === "repair_instagram_auth" ? "manual-auth" : "repair-auth";
 
@@ -3122,6 +3127,8 @@ const buildProvisionalCatalogRunProgress = (input: {
 
 export default function SocialAccountProfilePage({ platform, handle, activeTab }: Props) {
   const { user, checking, hasAccess } = useAdminGuard();
+  const profileLoadStartedAtRef = useRef<number>(nowMs());
+  const profileNavigationSampleRecordedRef = useRef(false);
   const fetchAdminWithAuth = useCallback(
     (
       input: RequestInfo | URL,
@@ -3287,6 +3294,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     reason: string;
     code?: string | null;
   } | null>(null);
+  const [liveProfileTotalRequestNonce, setLiveProfileTotalRequestNonce] = useState(0);
   const pendingCatalogActionAfterCookieRepairRef = useRef<PendingCatalogAction | null>(null);
   const liveProfileTotalProbeKeyRef = useRef<string | null>(null);
   const commentsAuthCookieHealthProbeKeyRef = useRef<string | null>(null);
@@ -3310,6 +3318,22 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   );
   const shouldShowCatalogRunProgressCard = selectedTab !== "comments";
   const hasSummary = summary !== null;
+  useEffect(() => {
+    profileLoadStartedAtRef.current = nowMs();
+    profileNavigationSampleRecordedRef.current = false;
+  }, [handle, platform]);
+  useEffect(() => {
+    if (profileNavigationSampleRecordedRef.current) return;
+    if (!hasSummary && !summaryUninitialized) return;
+    profileNavigationSampleRecordedRef.current = true;
+    recordAdminLoadSample({
+      surface: "admin-social-profile",
+      path: `/social/${platform}/${handle}`,
+      source: "navigation",
+      duration_ms: nowMs() - profileLoadStartedAtRef.current,
+      cache_status: dashboardFreshness?.status ?? null,
+    });
+  }, [dashboardFreshness?.status, handle, hasSummary, platform, summaryUninitialized]);
   const postsSortMetadata = posts?.sort_metadata ?? null;
   const summaryInitialStatePending = !hasSummary && !summaryError && !summaryUninitialized;
   const summarySourceMetadata = useMemo(
@@ -3516,7 +3540,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     if (secondaryReadsGateOpen) return;
     if (checking || !user || !hasAccess || summaryLoading) return;
     if (!hasSummary && !summaryError && !summaryUninitialized) return;
-    if (selectedTabPrimaryReadActive || selectedTabPrimaryReadPending) return;
+    if (selectedTabPrimaryReadActive) return;
     const timeoutId = window.setTimeout(() => {
       setSecondaryReadsGateOpen(true);
       setSecondaryReadBudgetSlot(1);
@@ -3528,7 +3552,6 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     hasSummary,
     secondaryReadsGateOpen,
     selectedTabPrimaryReadActive,
-    selectedTabPrimaryReadPending,
     summaryError,
     summaryLoading,
     summaryUninitialized,
@@ -3554,6 +3577,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     setSummaryError(null);
     setDashboardFreshness(null);
     setSummarySaturationActive(false);
+    setLiveProfileTotalRequestNonce(0);
     setPosts(null);
     setPostsLoading(false);
     setPostsError(null);
@@ -3784,6 +3808,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       if (options?.forceRefresh) {
         params.set("refresh", "1");
       }
+      const requestStartedAt = nowMs();
       const response = await fetchAdminWithAuth(
         `/api/admin/trr-api/social/profiles/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/snapshot${
           params.size > 0 ? `?${params.toString()}` : ""
@@ -3794,6 +3819,14 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
         },
         { preferredUser: user },
       );
+      recordAdminLoadSample({
+        surface: "admin-social-profile-snapshot",
+        path: `/social/${platform}/${handle}`,
+        source: "api",
+        duration_ms: nowMs() - requestStartedAt,
+        cache_status: response.headers.get("x-trr-cache"),
+        server_timing: response.headers.get("server-timing"),
+      });
       const envelope = (await response.json().catch(() => ({}))) as
         | SocialAccountProfileSnapshot
         | ({
@@ -4129,7 +4162,9 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       !hasAccess ||
       platform !== "instagram" ||
       summaryLoading ||
-      !summary
+      !summary ||
+      !secondaryReadsGateOpen ||
+      secondaryReadBudgetSlot < 2
     ) {
       return;
     }
@@ -4148,26 +4183,21 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
 
     const loadLiveProfileTotal = async () => {
       try {
-        const data = await withSocialProfileRequestDedup(
-          `live-profile-total:${probeKey}`,
-          async (): Promise<SocialAccountLiveProfileTotal> => {
-            const response = await fetchAdminWithAuth(
-              `/api/admin/trr-api/social/profiles/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/live-profile-total`,
-              undefined,
-              { preferredUser: user },
-            );
-            const payload = (await response.json().catch(() => ({}))) as
-              | SocialAccountLiveProfileTotal
-              | ProxyErrorPayload;
-            if (!response.ok) {
-              throw buildSocialAccountRequestError(
-                toProxyErrorPayload(payload),
-                "Failed to load social account live profile total",
-              );
-            }
-            return payload as SocialAccountLiveProfileTotal;
-          },
+        const response = await fetchAdminWithAuth(
+          `/api/admin/trr-api/social/profiles/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/live-profile-total`,
+          undefined,
+          { preferredUser: user },
         );
+        const payload = (await response.json().catch(() => ({}))) as
+          | SocialAccountLiveProfileTotal
+          | ProxyErrorPayload;
+        if (!response.ok) {
+          throw buildSocialAccountRequestError(
+            toProxyErrorPayload(payload),
+            "Failed to load social account live profile total",
+          );
+        }
+        const data = payload as SocialAccountLiveProfileTotal;
         const liveTotalFromProfile =
           typeof data.live_total_posts_current === "number" && Number.isFinite(data.live_total_posts_current)
             ? Math.max(0, data.live_total_posts_current)
@@ -4194,7 +4224,6 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
           };
         });
       } catch (error) {
-        pauseSecondaryReadsForPressure(error, "Failed to load social account live profile total");
         if (liveProfileTotalProbeKeyRef.current === pendingProbeKey) {
           liveProfileTotalProbeKeyRef.current = null;
         }
@@ -4211,15 +4240,18 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     };
   }, [
     checking,
+    catalogActionMessage,
     fetchAdminWithAuth,
     handle,
     hasAccess,
     platform,
-    pauseSecondaryReadsForPressure,
+    secondaryReadBudgetSlot,
+    secondaryReadsGateOpen,
     summary,
     summaryLoading,
     summaryUninitialized,
     user,
+    liveProfileTotalRequestNonce,
   ]);
 
   useEffect(() => {
@@ -4289,7 +4321,15 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   ]);
 
   useEffect(() => {
-    if (checking || !user || !hasAccess || selectedTab !== "posts" || summaryUninitialized) return;
+    if (
+      checking ||
+      !user ||
+      !hasAccess ||
+      selectedTab !== "posts" ||
+      summaryUninitialized
+    ) {
+      return;
+    }
     let cancelled = false;
 
     const loadPosts = async () => {
@@ -4319,10 +4359,29 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     return () => {
       cancelled = true;
     };
-  }, [checking, fetchAdminWithAuth, handle, hasAccess, page, platform, selectedTab, summaryUninitialized, user]);
+  }, [
+    checking,
+    fetchAdminWithAuth,
+    handle,
+    hasAccess,
+    page,
+    platform,
+    selectedTab,
+    summaryUninitialized,
+    user,
+  ]);
 
   useEffect(() => {
-    if (checking || !user || !hasAccess || selectedTab !== "catalog" || !supportsCatalog || (summaryUninitialized && !hasSummary)) return;
+    if (
+      checking ||
+      !user ||
+      !hasAccess ||
+      selectedTab !== "catalog" ||
+      !supportsCatalog ||
+      (summaryUninitialized && !hasSummary)
+    ) {
+      return;
+    }
     let cancelled = false;
 
     const loadCatalogPosts = async () => {
@@ -4359,7 +4418,20 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     return () => {
       cancelled = true;
     };
-  }, [catalogFilter, catalogPage, checking, fetchAdminWithAuth, handle, hasAccess, hasSummary, platform, selectedTab, summaryUninitialized, supportsCatalog, user]);
+  }, [
+    catalogFilter,
+    catalogPage,
+    checking,
+    fetchAdminWithAuth,
+    handle,
+    hasAccess,
+    hasSummary,
+    platform,
+    selectedTab,
+    summaryUninitialized,
+    supportsCatalog,
+    user,
+  ]);
 
   const hasLoadedExactHashtagWindow = hashtagsLoadedRequestKey === hashtagsRequestKey;
   const useSummaryTopHashtagsPreview = shouldUseSummaryTopHashtagsPreview({
@@ -4437,7 +4509,16 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   ]);
 
   useEffect(() => {
-    if (checking || !user || !hasAccess || selectedTab !== "hashtags" || platform !== "instagram" || summaryUninitialized) {
+    if (
+      checking ||
+      !user ||
+      !hasAccess ||
+      selectedTab !== "hashtags" ||
+      platform !== "instagram" ||
+      summaryUninitialized ||
+      !secondaryReadsGateOpen ||
+      Boolean(secondaryReadsPressurePause)
+    ) {
       if (platform !== "instagram") {
         setHashtagTimeline(null);
         setHashtagTimelineError(null);
@@ -4464,7 +4545,17 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     return () => {
       cancelled = true;
     };
-  }, [checking, hasAccess, platform, refreshHashtagTimeline, selectedTab, summaryUninitialized, user]);
+  }, [
+    checking,
+    hasAccess,
+    platform,
+    refreshHashtagTimeline,
+    secondaryReadsGateOpen,
+    secondaryReadsPressurePause,
+    selectedTab,
+    summaryUninitialized,
+    user,
+  ]);
 
   useEffect(() => {
     if (
@@ -4526,7 +4617,15 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   ]);
 
   useEffect(() => {
-    if (checking || !user || !hasAccess || selectedTab !== "collaborators-tags" || summaryUninitialized) return;
+    if (
+      checking ||
+      !user ||
+      !hasAccess ||
+      selectedTab !== "collaborators-tags" ||
+      summaryUninitialized
+    ) {
+      return;
+    }
     let cancelled = false;
 
     const loadCollaboratorsTags = async () => {
@@ -4561,7 +4660,17 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     return () => {
       cancelled = true;
     };
-  }, [checking, collaboratorsRequestKey, fetchAdminWithAuth, handle, hasAccess, platform, selectedTab, summaryUninitialized, user]);
+  }, [
+    checking,
+    collaboratorsRequestKey,
+    fetchAdminWithAuth,
+    handle,
+    hasAccess,
+    platform,
+    selectedTab,
+    summaryUninitialized,
+    user,
+  ]);
 
   const displayCatalogTotalPosts = useMemo(() => {
     if (supportsCatalog && Number(summary?.live_catalog_total_posts ?? 0) > 0) {
@@ -5257,6 +5366,22 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     }
     return "";
   }, [summary?.comments_coverage]);
+
+  const fetchActiveCommentsRunProgressNow = useCallback(
+    async (runId: string): Promise<SocialAccountCommentsRunProgress> => {
+      const response = await fetchAdminWithAuth(
+        `/api/admin/trr-api/social/profiles/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/comments/runs/${encodeURIComponent(runId)}/progress`,
+        undefined,
+        { preferredUser: user },
+      );
+      const data = (await response.json().catch(() => ({}))) as SocialAccountCommentsRunProgress & ProxyErrorPayload;
+      if (!response.ok) {
+        throw buildSocialAccountRequestError(data, "Failed to load comments run progress");
+      }
+      return data;
+    },
+    [fetchAdminWithAuth, handle, platform, user],
+  );
 
   const activeCommentsRunProgress = useSharedPollingResource<SocialAccountCommentsRunProgress>({
     key: `instagram-comments-run:${platform}:${handle}:${activeCommentsRunId ?? "none"}`,
@@ -7368,7 +7493,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       !hasAccess ||
       !platformRequiresCookies ||
       shouldDeferSecondaryCatalogReads ||
-      secondaryReadBudgetSlot < 2 ||
+      secondaryReadBudgetSlot < 3 ||
       (commentsAuthProbeMissing && commentsAuthProbeAlreadyRequested) ||
       (cookieHealth && !commentsAuthProbeMissing) ||
       cookieHealthLoading
@@ -7736,6 +7861,8 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
           );
         }
         setRunningCatalogAction(null);
+        liveProfileTotalProbeKeyRef.current = null;
+        setLiveProfileTotalRequestNonce((nonce) => nonce + 1);
         void refreshProfileSnapshotNow({ runId: catalogRunId || queuedRunId }).catch(() => {});
       } catch (error) {
         const requestError = toSocialAccountRequestError(
@@ -8382,7 +8509,15 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   const restartActiveCommentsRun = async () => {
     const runId = String(activeCommentsRunId || "").trim();
     if (!user || !runId || !activeCommentsRunCanRestart) return;
-    const { dateStart, dateEnd } = activeCommentsRunDateWindow;
+    let { dateStart, dateEnd } = activeCommentsRunDateWindow;
+    if (!dateStart && !dateEnd) {
+      try {
+        const progress = await fetchActiveCommentsRunProgressNow(runId);
+        ({ dateStart, dateEnd } = readCommentsRunDateWindow(progress));
+      } catch {
+        // Preserve restart behavior; the backend can still reject an incomplete window.
+      }
+    }
     const confirmed =
       typeof window === "undefined" ||
       window.confirm(

--- a/apps/web/src/components/admin/SocialAccountProfilePage.tsx
+++ b/apps/web/src/components/admin/SocialAccountProfilePage.tsx
@@ -3325,6 +3325,16 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   useEffect(() => {
     if (profileNavigationSampleRecordedRef.current) return;
     if (!hasSummary && !summaryUninitialized) return;
+    if (
+      hasSummary &&
+      (summary?.platform !== platform ||
+        String(summary?.account_handle || "")
+          .trim()
+          .replace(/^@+/, "")
+          .toLowerCase() !== handle.trim().replace(/^@+/, "").toLowerCase())
+    ) {
+      return;
+    }
     profileNavigationSampleRecordedRef.current = true;
     recordAdminLoadSample({
       surface: "admin-social-profile",
@@ -3333,7 +3343,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       duration_ms: nowMs() - profileLoadStartedAtRef.current,
       cache_status: dashboardFreshness?.status ?? null,
     });
-  }, [dashboardFreshness?.status, handle, hasSummary, platform, summaryUninitialized]);
+  }, [dashboardFreshness?.status, handle, hasSummary, platform, summary?.account_handle, summary?.platform, summaryUninitialized]);
   const postsSortMetadata = posts?.sort_metadata ?? null;
   const summaryInitialStatePending = !hasSummary && !summaryError && !summaryUninitialized;
   const summarySourceMetadata = useMemo(
@@ -4162,8 +4172,9 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       !hasAccess ||
       platform !== "instagram" ||
       summaryLoading ||
-      !summary ||
+      !hasSummary ||
       !secondaryReadsGateOpen ||
+      Boolean(secondaryReadsPressurePause) ||
       secondaryReadBudgetSlot < 2
     ) {
       return;
@@ -4227,6 +4238,16 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
         if (liveProfileTotalProbeKeyRef.current === pendingProbeKey) {
           liveProfileTotalProbeKeyRef.current = null;
         }
+        const requestError = toSocialAccountRequestError(error, "Failed to load social account live profile total");
+        const requestErrorCode = requestError.code;
+        const requestErrorMessage = requestError.message || "";
+        if (
+          isBackendSaturationError(requestError) ||
+          isBackendPressureCode(requestErrorCode) ||
+          hasBackendSaturationText(requestErrorMessage)
+        ) {
+          pauseSecondaryReadsForPressure(requestError, "Failed to load social account live profile total");
+        }
         // Best-effort only; leave the cached summary values intact.
       }
     };
@@ -4240,18 +4261,18 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     };
   }, [
     checking,
-    catalogActionMessage,
     fetchAdminWithAuth,
     handle,
+    hasSummary,
     hasAccess,
+    liveProfileTotalRequestNonce,
+    pauseSecondaryReadsForPressure,
     platform,
     secondaryReadBudgetSlot,
     secondaryReadsGateOpen,
-    summary,
+    secondaryReadsPressurePause,
     summaryLoading,
-    summaryUninitialized,
     user,
-    liveProfileTotalRequestNonce,
   ]);
 
   useEffect(() => {
@@ -4326,6 +4347,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       !user ||
       !hasAccess ||
       selectedTab !== "posts" ||
+      !hasSummary ||
       summaryUninitialized
     ) {
       return;
@@ -4364,6 +4386,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     fetchAdminWithAuth,
     handle,
     hasAccess,
+    hasSummary,
     page,
     platform,
     selectedTab,
@@ -4378,7 +4401,8 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       !hasAccess ||
       selectedTab !== "catalog" ||
       !supportsCatalog ||
-      (summaryUninitialized && !hasSummary)
+      !hasSummary ||
+      summaryUninitialized
     ) {
       return;
     }
@@ -4450,6 +4474,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       !user ||
       !hasAccess ||
       !shouldLoadHashtags ||
+      !hasSummary ||
       summaryUninitialized ||
       (selectedTab !== "hashtags" && shouldDeferSecondaryCatalogReads)
     ) {
@@ -4497,6 +4522,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     checking,
     hashtagWindow,
     hasAccess,
+    hasSummary,
     hashtagsRequestKey,
     platform,
     pauseSecondaryReadsForPressure,
@@ -4515,6 +4541,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       !hasAccess ||
       selectedTab !== "hashtags" ||
       platform !== "instagram" ||
+      !hasSummary ||
       summaryUninitialized ||
       !secondaryReadsGateOpen ||
       Boolean(secondaryReadsPressurePause)
@@ -4548,6 +4575,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   }, [
     checking,
     hasAccess,
+    hasSummary,
     platform,
     refreshHashtagTimeline,
     secondaryReadsGateOpen,
@@ -4622,6 +4650,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       !user ||
       !hasAccess ||
       selectedTab !== "collaborators-tags" ||
+      !hasSummary ||
       summaryUninitialized
     ) {
       return;
@@ -4666,6 +4695,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     fetchAdminWithAuth,
     handle,
     hasAccess,
+    hasSummary,
     platform,
     selectedTab,
     summaryUninitialized,
@@ -8510,7 +8540,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     const runId = String(activeCommentsRunId || "").trim();
     if (!user || !runId || !activeCommentsRunCanRestart) return;
     let { dateStart, dateEnd } = activeCommentsRunDateWindow;
-    if (!dateStart && !dateEnd) {
+    if (!dateStart || !dateEnd) {
       try {
         const progress = await fetchActiveCommentsRunProgressNow(runId);
         ({ dateStart, dateEnd } = readCommentsRunDateWindow(progress));

--- a/apps/web/src/lib/admin/admin-load-samples.ts
+++ b/apps/web/src/lib/admin/admin-load-samples.ts
@@ -88,7 +88,7 @@ export const getAdminLoadSampleSurfaceForPath = (path: string): AdminLoadSampleS
   if (path === "/admin/social" || path.startsWith("/admin/social?")) {
     return "admin-social-landing";
   }
-  if (/^\/social\/[^/]+\/[^/]+/.test(path)) {
+  if (/^(?:\/admin)?\/social\/[^/]+\/[^/]+/.test(path)) {
     return "admin-social-profile";
   }
   return null;

--- a/apps/web/src/lib/admin/admin-load-samples.ts
+++ b/apps/web/src/lib/admin/admin-load-samples.ts
@@ -1,0 +1,95 @@
+"use client";
+
+export type AdminLoadSampleSurface =
+  | "admin-social-landing"
+  | "admin-social-landing-api"
+  | "admin-social-profile"
+  | "admin-social-profile-snapshot";
+
+export type AdminLoadSample = {
+  surface: AdminLoadSampleSurface;
+  path: string;
+  source: "navigation" | "api";
+  duration_ms: number;
+  sampled_at?: string;
+  cache_status?: string | null;
+  server_timing?: string | null;
+};
+
+const STORAGE_KEY = "trr-admin-load-samples:v1";
+const MAX_SAMPLES_PER_SURFACE = 50;
+let storageAvailable: boolean | null = null;
+
+const canUseLocalStorage = (): boolean => {
+  if (typeof window === "undefined") return false;
+  if (storageAvailable !== null) return storageAvailable;
+  try {
+    const testKey = `${STORAGE_KEY}:probe`;
+    window.localStorage.setItem(testKey, "1");
+    window.localStorage.removeItem(testKey);
+    storageAvailable = true;
+  } catch {
+    storageAvailable = false;
+  }
+  return storageAvailable;
+};
+
+const isAdminLoadSampleSurface = (value: unknown): value is AdminLoadSampleSurface =>
+  value === "admin-social-landing" ||
+  value === "admin-social-landing-api" ||
+  value === "admin-social-profile" ||
+  value === "admin-social-profile-snapshot";
+
+const readSamples = (): AdminLoadSample[] => {
+  if (!canUseLocalStorage()) return [];
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "[]") as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((entry): entry is AdminLoadSample => {
+      if (!entry || typeof entry !== "object") return false;
+      const sample = entry as Partial<AdminLoadSample>;
+      return (
+        isAdminLoadSampleSurface(sample.surface) &&
+        typeof sample.path === "string" &&
+        (sample.source === "navigation" || sample.source === "api") &&
+        typeof sample.duration_ms === "number" &&
+        Number.isFinite(sample.duration_ms)
+      );
+    });
+  } catch {
+    return [];
+  }
+};
+
+export const recordAdminLoadSample = (sample: AdminLoadSample): void => {
+  if (!canUseLocalStorage()) return;
+  const durationMs = Math.max(0, Math.round(sample.duration_ms));
+  if (!Number.isFinite(durationMs)) return;
+  const nextSample: AdminLoadSample = {
+    ...sample,
+    duration_ms: durationMs,
+    sampled_at: sample.sampled_at ?? new Date().toISOString(),
+  };
+  const samples = [...readSamples(), nextSample];
+  const grouped = new Map<AdminLoadSampleSurface, AdminLoadSample[]>();
+  for (const entry of samples) {
+    const entries = grouped.get(entry.surface) ?? [];
+    entries.push(entry);
+    grouped.set(entry.surface, entries.slice(-MAX_SAMPLES_PER_SURFACE));
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify([...grouped.values()].flat()));
+  } catch {
+    // Best-effort telemetry for the current browser only.
+  }
+};
+
+export const getAdminLoadSampleSurfaceForPath = (path: string): AdminLoadSampleSurface | null => {
+  if (path === "/admin/social" || path.startsWith("/admin/social?")) {
+    return "admin-social-landing";
+  }
+  if (/^\/social\/[^/]+\/[^/]+/.test(path)) {
+    return "admin-social-profile";
+  }
+  return null;
+};

--- a/apps/web/src/lib/admin/api-references/generated/inventory.ts
+++ b/apps/web/src/lib/admin/api-references/generated/inventory.ts
@@ -3,8 +3,8 @@ import type { AdminApiReferenceInventory } from "@/lib/admin/api-references/type
 export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
   "inventorySchemaVersion": "1.0.0",
   "generatorVersion": "1.0.0",
-  "generatedAt": "2026-06-16T14:31:55.438Z",
-  "sourceCommitSha": "b4198ec471d55204af3f5bbeca194ac0a9706ab7",
+  "generatedAt": "2026-06-18T22:08:52.953Z",
+  "sourceCommitSha": "e0a97252b93da0ce93bfef851e4901682ad8d113",
   "overrideDigest": "1a9e22b4c9b465cc3dab3ee0fcfc469f25b643ecae9e10baf11cdd12f9133e71",
   "nodes": [
     {
@@ -8985,7 +8985,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/social/landing/route.ts",
       "sourceLocator": {
-        "line": 366,
+        "line": 367,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -12374,7 +12374,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/social/ingest/queue-status/route.ts",
       "sourceLocator": {
-        "line": 11,
+        "line": 12,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -12472,7 +12472,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/posts/route.ts",
       "sourceLocator": {
-        "line": 23,
+        "line": 24,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -12708,7 +12708,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/comments/audit-cursor-retries/route.ts",
       "sourceLocator": {
-        "line": 5,
+        "line": 13,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -12721,16 +12721,17 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "polls": false,
       "pollCadenceMs": null,
       "automatic": false,
-      "loadsLargeDatasets": false,
+      "loadsLargeDatasets": true,
       "usesPagination": true,
       "returnsWideRowsOrBlobsOrRawJson": false,
       "fansOutQueries": false,
       "postgresAccess": "none",
       "viewKinds": [
+        "list",
         "detail"
       ],
       "staticOnly": false,
-      "payloadRisk": "low",
+      "payloadRisk": "high",
       "fanoutRisk": "low"
     },
     {
@@ -12976,7 +12977,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/snapshot/route.ts",
       "sourceLocator": {
-        "line": 135,
+        "line": 136,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -14561,7 +14562,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "POST",
       "sourceFile": "src/app/api/admin/social/landing/route.ts",
       "sourceLocator": {
-        "line": 451,
+        "line": 505,
         "symbol": "POST"
       },
       "provenance": "static_scan",
@@ -18064,7 +18065,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "POST",
       "sourceFile": "src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/comments/audit-cursor-retries/route.ts",
       "sourceLocator": {
-        "line": 15,
+        "line": 32,
         "symbol": "POST"
       },
       "provenance": "static_scan",
@@ -18077,16 +18078,17 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "polls": false,
       "pollCadenceMs": null,
       "automatic": false,
-      "loadsLargeDatasets": false,
+      "loadsLargeDatasets": true,
       "usesPagination": true,
       "returnsWideRowsOrBlobsOrRawJson": false,
       "fansOutQueries": false,
       "postgresAccess": "none",
       "viewKinds": [
+        "list",
         "detail"
       ],
       "staticOnly": false,
-      "payloadRisk": "low",
+      "payloadRisk": "high",
       "fanoutRisk": "low"
     },
     {

--- a/apps/web/src/lib/admin/social-landing.ts
+++ b/apps/web/src/lib/admin/social-landing.ts
@@ -6,6 +6,14 @@ export type SocialLandingPlatform =
   | "facebook"
   | "threads";
 
+export type SocialLandingProgressStatus = {
+  source: "backend" | "fallback" | "none";
+  cache_status: string | null;
+  generated_at: string | null;
+  stale: boolean;
+  warning?: string | null;
+};
+
 export interface SocialHandleSummary {
   platform: SocialLandingPlatform;
   handle: string;
@@ -202,6 +210,7 @@ export interface SocialLandingPayload {
   shared_source_sets: SharedAccountSourceSet[];
   shared_pipeline: SharedPipelineSummary;
   shared_source_status?: SharedAccountSourceLoadStatus[];
+  social_progress_status?: SocialLandingProgressStatus;
   scrape_job_health: ScrapeJobHealthSummary;
   reddit_dashboard: RedditDashboardSummary;
 }

--- a/apps/web/src/lib/admin/social-landing.ts
+++ b/apps/web/src/lib/admin/social-landing.ts
@@ -7,7 +7,7 @@ export type SocialLandingPlatform =
   | "threads";
 
 export type SocialLandingProgressStatus = {
-  source: "backend" | "fallback" | "none";
+  source: "backend" | "fallback" | "none" | "unavailable";
   cache_status: string | null;
   generated_at: string | null;
   stale: boolean;

--- a/apps/web/src/lib/server/admin/admin-route-timing.ts
+++ b/apps/web/src/lib/server/admin/admin-route-timing.ts
@@ -1,0 +1,63 @@
+import "server-only";
+
+import type { NextResponse } from "next/server";
+
+type AdminRouteTiming = {
+  routeFamily: string;
+  routeName?: string;
+  cacheStatus?: string | null;
+  startedAt?: number;
+  totalMs?: number;
+  backendMs?: number | null;
+  databaseMs?: number | null;
+};
+
+const normalizeDuration = (value: number | null | undefined): number | null => {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return Math.max(0, Math.round(value));
+};
+
+const timingMetric = (name: string, value: number | null | undefined): string | null => {
+  const duration = normalizeDuration(value);
+  return duration === null ? null : `${name};dur=${duration}`;
+};
+
+export const attachAdminRouteTiming = (
+  response: NextResponse,
+  timing: AdminRouteTiming,
+): NextResponse => {
+  const totalMs =
+    normalizeDuration(timing.totalMs) ??
+    normalizeDuration(
+      typeof timing.startedAt === "number" ? performance.now() - timing.startedAt : null,
+    ) ??
+    0;
+  const backendMs = normalizeDuration(timing.backendMs);
+  const databaseMs = normalizeDuration(timing.databaseMs);
+  const metrics = [
+    timingMetric("trr_admin_route", totalMs),
+    timingMetric("trr_admin_backend", backendMs),
+    timingMetric("trr_admin_db", databaseMs),
+  ].filter((entry): entry is string => Boolean(entry));
+  const existingServerTiming = response.headers.get("Server-Timing");
+  response.headers.set(
+    "Server-Timing",
+    existingServerTiming ? `${existingServerTiming}, ${metrics.join(", ")}` : metrics.join(", "),
+  );
+  response.headers.set("x-trr-admin-route-ms", String(totalMs));
+  if (backendMs !== null) {
+    response.headers.set("x-trr-admin-backend-ms", String(backendMs));
+  }
+  if (databaseMs !== null) {
+    response.headers.set("x-trr-admin-db-ms", String(databaseMs));
+  }
+  console.info("[admin-route-timing]", {
+    route_family: timing.routeFamily,
+    route_name: timing.routeName ?? null,
+    cache_status: timing.cacheStatus ?? null,
+    backend_ms: backendMs,
+    database_ms: databaseMs,
+    total_ms: totalMs,
+  });
+  return response;
+};

--- a/apps/web/src/lib/server/admin/social-landing-repository.ts
+++ b/apps/web/src/lib/server/admin/social-landing-repository.ts
@@ -892,7 +892,7 @@ const safeLoadBackendSocialProgressRollup = async (
     return {
       ...uncacheableValue(new Map()),
       status: {
-        source: "fallback",
+        source: "unavailable",
         cache_status: null,
         generated_at: null,
         stale: true,
@@ -2792,7 +2792,7 @@ export async function getSocialLandingPayloadResult(
       } satisfies SharedPipelineSummary,
       shared_source_status: sharedSourceStatus,
       social_progress_status: progressResult.status ?? {
-        source: "fallback",
+        source: progressResult.cacheable ? "none" : "unavailable",
         cache_status: null,
         generated_at: null,
         stale: !progressResult.cacheable,

--- a/apps/web/src/lib/server/admin/social-landing-repository.ts
+++ b/apps/web/src/lib/server/admin/social-landing-repository.ts
@@ -36,6 +36,7 @@ import type {
   SocialHandleSummary,
   SocialLandingPayload,
   SocialLandingPlatform,
+  SocialLandingProgressStatus,
 } from "@/lib/admin/social-landing";
 import { listRedditCommunities } from "@/lib/server/admin/reddit-sources-repository";
 import { parseCacheTtlMs } from "@/lib/server/admin/route-response-cache";
@@ -113,6 +114,12 @@ type SocialProgressRollupPayload = {
   rows?: SocialProgressRow[];
   cache_status?: string | null;
   generated_at?: string | Date | null;
+  stale?: boolean | null;
+  timing?: {
+    backend_ms?: number | string | null;
+    database_ms?: number | string | null;
+    total_ms?: number | string | null;
+  } | null;
 };
 
 const SCRAPE_JOB_HEALTH_WINDOW_HOURS = 8;
@@ -174,9 +181,18 @@ export type SocialLandingPayloadResult = {
   cacheable: boolean;
 };
 
+export type SocialLandingTimingCollector = {
+  recordBackendMs: (durationMs: number) => void;
+  recordDbMs: (durationMs: number) => void;
+};
+
 type CacheableValue<T> = {
   value: T;
   cacheable: boolean;
+};
+
+type SocialProgressSummaryResult = CacheableValue<ReadonlyMap<string, SocialAccountProgressSummary>> & {
+  status: SocialLandingProgressStatus;
 };
 
 type SharedSourcesResult = CacheableValue<SharedAccountSourceSummary[]> & {
@@ -828,7 +844,8 @@ const buildSocialProgressMap = (
 const safeLoadBackendSocialProgressRollup = async (
   targets: readonly SocialProgressTarget[],
   adminContext: VerifiedAdminContext,
-): Promise<CacheableValue<ReadonlyMap<string, SocialAccountProgressSummary>>> => {
+  timingCollector?: SocialLandingTimingCollector,
+): Promise<SocialProgressSummaryResult> => {
   try {
     const payload = (await fetchSocialBackendJson("/landing-progress-rollup", {
       adminContext,
@@ -842,27 +859,68 @@ const safeLoadBackendSocialProgressRollup = async (
       retries: 0,
       timeoutMs: SOCIAL_PROXY_PROGRESS_TIMEOUT_MS,
     })) as SocialProgressRollupPayload;
+    const backendMs = normalizeNonNegativeInteger(payload.timing?.backend_ms);
+    const databaseMs = normalizeNonNegativeInteger(payload.timing?.database_ms);
+    if (backendMs > 0) timingCollector?.recordBackendMs(backendMs);
+    if (databaseMs > 0) timingCollector?.recordDbMs(databaseMs);
+    const cacheStatus = typeof payload.cache_status === "string" ? payload.cache_status : null;
+    const generatedAt =
+      typeof payload.generated_at === "string"
+        ? payload.generated_at
+        : payload.generated_at instanceof Date
+          ? payload.generated_at.toISOString()
+          : null;
 
     console.info("[social-landing] backend progress rollup", {
-      cache_status: payload.cache_status ?? null,
+      cache_status: cacheStatus,
       row_count: Array.isArray(payload.rows) ? payload.rows.length : 0,
+      backend_ms: backendMs || null,
+      database_ms: databaseMs || null,
     });
 
-    return cacheableValue(buildSocialProgressMap(Array.isArray(payload.rows) ? payload.rows : []));
+    return {
+      ...cacheableValue(buildSocialProgressMap(Array.isArray(payload.rows) ? payload.rows : [])),
+      status: {
+        source: "backend",
+        cache_status: cacheStatus,
+        generated_at: generatedAt,
+        stale: Boolean(payload.stale) || cacheStatus === "stale",
+      },
+    };
   } catch (error) {
     console.warn("[social-landing] Failed to load backend social progress rollup", error);
-    return uncacheableValue(new Map());
+    return {
+      ...uncacheableValue(new Map()),
+      status: {
+        source: "fallback",
+        cache_status: null,
+        generated_at: null,
+        stale: true,
+        warning: error instanceof Error ? error.message : "Failed to load backend social progress rollup",
+      },
+    };
   }
 };
 
 const safeLoadSocialProgressSummaries = async (
   targets: readonly SocialProgressTarget[],
   adminContext?: VerifiedAdminContext,
-): Promise<CacheableValue<ReadonlyMap<string, SocialAccountProgressSummary>>> => {
-  if (targets.length === 0) return cacheableValue(new Map());
+  timingCollector?: SocialLandingTimingCollector,
+): Promise<SocialProgressSummaryResult> => {
+  if (targets.length === 0) {
+    return {
+      ...cacheableValue(new Map()),
+      status: {
+        source: "none",
+        cache_status: null,
+        generated_at: null,
+        stale: false,
+      },
+    };
+  }
 
   if (adminContext) {
-    return safeLoadBackendSocialProgressRollup(targets, adminContext);
+    return safeLoadBackendSocialProgressRollup(targets, adminContext, timingCollector);
   }
 
   const platforms = targets.map((target) => target.platform);
@@ -1102,10 +1160,25 @@ const safeLoadSocialProgressSummaries = async (
     return {
       value: buildSocialProgressMap(result.rows, socialBladeCountsByKey),
       cacheable: socialBladeCountsResult.cacheable,
+      status: {
+        source: "fallback",
+        cache_status: null,
+        generated_at: null,
+        stale: !socialBladeCountsResult.cacheable,
+      },
     };
   } catch (error) {
     console.warn("[social-landing] Failed to load social progress summaries", error);
-    return uncacheableValue(new Map());
+    return {
+      ...uncacheableValue(new Map()),
+      status: {
+        source: "fallback",
+        cache_status: null,
+        generated_at: null,
+        stale: true,
+        warning: error instanceof Error ? error.message : "Failed to load social progress summaries",
+      },
+    };
   }
 };
 
@@ -2578,6 +2651,7 @@ const buildCastSocialBladeShows = async (
 
 export async function getSocialLandingPayloadResult(
   adminContext?: VerifiedAdminContext,
+  timingCollector?: SocialLandingTimingCollector,
 ): Promise<SocialLandingPayloadResult> {
   const { coveredShows, redditDashboard, cacheable: landingSummaryCacheable } =
     await withSocialLandingTiming(
@@ -2684,9 +2758,10 @@ export async function getSocialLandingPayloadResult(
         sharedSourceSets,
       }),
       adminContext,
+      timingCollector,
     ),
     new Map(),
-  );
+  ) as SocialProgressSummaryResult;
   const progressByKey = progressResult.value;
   const hydratedNetworkSets = networkSets.map((set) =>
     hydrateNetworkSetProgress(set, progressByKey),
@@ -2716,6 +2791,12 @@ export async function getSocialLandingPayloadResult(
         review_items: sharedReviewItems,
       } satisfies SharedPipelineSummary,
       shared_source_status: sharedSourceStatus,
+      social_progress_status: progressResult.status ?? {
+        source: "fallback",
+        cache_status: null,
+        generated_at: null,
+        stale: !progressResult.cacheable,
+      },
       scrape_job_health: scrapeJobHealth,
       reddit_dashboard: redditDashboard,
     },

--- a/apps/web/src/lib/server/trr-api/social-profile-route-factory.ts
+++ b/apps/web/src/lib/server/trr-api/social-profile-route-factory.ts
@@ -7,6 +7,7 @@ import {
   buildAdminSnapshotCacheKey,
   getOrCreateAdminSnapshot,
 } from "@/lib/server/admin/admin-snapshot-cache";
+import { attachAdminRouteTiming } from "@/lib/server/admin/admin-route-timing";
 import {
   buildUserScopedRouteCacheKey,
   getOrCreateRouteResponsePromise,
@@ -190,6 +191,29 @@ const socialProfileJsonResponse = (
   return adminJsonResponse(input.request, data, { headers, title: `TRR API ${config.endpoint}` });
 };
 
+const socialProfileTimedJsonResponse = (
+  input: SocialProfileProxyRouteInput,
+  config: SocialProfileProxyRouteConfig,
+  data: Record<string, unknown>,
+  startedAt: number,
+  cacheStatus: string | null,
+  headers: Record<string, string> = {},
+): NextResponse => {
+  const response = socialProfileJsonResponse(input, config, data, {
+    ...headers,
+    ...routeTimingHeaders(config, startedAt),
+  });
+  if (!config.routeTimingHeaders) {
+    return response;
+  }
+  return attachAdminRouteTiming(response, {
+    routeFamily: "admin-social-profile",
+    routeName: config.endpoint,
+    cacheStatus,
+    startedAt,
+  });
+};
+
 const readBody = async (
   request: NextRequest,
   method: string,
@@ -239,9 +263,8 @@ const respondWithRouteResponseCache = async (
   );
   const cachedPayload = getRouteResponseCache<Record<string, unknown>>(cache.namespace, cacheKey);
   if (cachedPayload) {
-    return socialProfileJsonResponse(input, config, cachedPayload, {
+    return socialProfileTimedJsonResponse(input, config, cachedPayload, startedAt, "hit", {
       "x-trr-cache": "hit",
-      ...routeTimingHeaders(config, startedAt),
     });
   }
   const stalePayload = getStaleRouteResponseCache<Record<string, unknown>>(cache.namespace, cacheKey);
@@ -251,16 +274,14 @@ const respondWithRouteResponseCache = async (
       setRouteResponseCache(cache.namespace, cacheKey, payload, cache.ttlMs, cache.staleTtlMs);
       return payload;
     });
-    return socialProfileJsonResponse(input, config, data, {
+    return socialProfileTimedJsonResponse(input, config, data, startedAt, "miss", {
       "x-trr-cache": "miss",
-      ...routeTimingHeaders(config, startedAt),
     });
   } catch (error) {
     if (stalePayload) {
-      return socialProfileJsonResponse(input, config, stalePayload, {
+      return socialProfileTimedJsonResponse(input, config, stalePayload, startedAt, "stale", {
         "x-trr-cache": "stale",
         "x-trr-cacheable": "0",
-        ...routeTimingHeaders(config, startedAt),
       });
     }
     throw error;
@@ -298,14 +319,14 @@ const respondWithAdminSnapshotCache = async (
     forceRefresh: readForceRefresh(input.request.nextUrl.searchParams, cache.forceRefreshParam),
     fetcher: () => fetchProfilePayload(input, config),
   });
-  return socialProfileJsonResponse(input, config, snapshot.data, {
+  return socialProfileTimedJsonResponse(input, config, snapshot.data, startedAt, snapshot.meta.cacheStatus, {
       ...buildAdminReadResponseHeaders({ cacheStatus: snapshot.meta.cacheStatus }),
-      ...routeTimingHeaders(config, startedAt),
   });
 };
 
 export const createSocialProfileProxyRoute = (config: SocialProfileProxyRouteConfig) => {
   return async (request: NextRequest, context: SocialProfileRouteContext): Promise<NextResponse> => {
+    const routeStartedAt = performance.now();
     try {
       const user = await requireAdmin(request);
       const params = await context.params;
@@ -325,12 +346,25 @@ export const createSocialProfileProxyRoute = (config: SocialProfileProxyRouteCon
         return await respondWithAdminSnapshotCache(input, config, config.cache);
       }
 
-      const startedAt = performance.now();
-      return socialProfileJsonResponse(input, config, await fetchProfilePayload(input, config), {
-        ...routeTimingHeaders(config, startedAt),
-      });
+      const startedAt = routeStartedAt;
+      return socialProfileTimedJsonResponse(
+        input,
+        config,
+        await fetchProfilePayload(input, config),
+        startedAt,
+        "miss",
+      );
     } catch (error) {
-      return socialProxyErrorResponse(error, config.logLabel);
+      const response = socialProxyErrorResponse(error, config.logLabel);
+      if (!config.routeTimingHeaders) {
+        return response;
+      }
+      return attachAdminRouteTiming(response, {
+        routeFamily: "admin-social-profile",
+        routeName: config.endpoint,
+        cacheStatus: "error",
+        startedAt: routeStartedAt,
+      });
     }
   };
 };

--- a/apps/web/src/lib/server/trr-api/social-profile-route-factory.ts
+++ b/apps/web/src/lib/server/trr-api/social-profile-route-factory.ts
@@ -254,8 +254,8 @@ const respondWithRouteResponseCache = async (
   input: SocialProfileProxyRouteInput,
   config: SocialProfileProxyRouteConfig,
   cache: RouteResponseCacheConfig,
+  startedAt: number,
 ): Promise<NextResponse> => {
-  const startedAt = performance.now();
   const cacheKey = buildUserScopedRouteCacheKey(
     input.user.uid,
     resolveRouteScope(cache.scope, input.params),
@@ -305,8 +305,8 @@ const respondWithAdminSnapshotCache = async (
   input: SocialProfileProxyRouteInput,
   config: SocialProfileProxyRouteConfig,
   cache: AdminSnapshotCacheConfig,
+  startedAt: number,
 ): Promise<NextResponse> => {
-  const startedAt = performance.now();
   const snapshot = await getOrCreateAdminSnapshot({
     cacheKey: buildAdminSnapshotCacheKey({
       authPartition: buildAdminAuthPartition(input.user),
@@ -340,10 +340,10 @@ export const createSocialProfileProxyRoute = (config: SocialProfileProxyRouteCon
       };
 
       if (config.cache?.kind === "route-response") {
-        return await respondWithRouteResponseCache(input, config, config.cache);
+        return await respondWithRouteResponseCache(input, config, config.cache, routeStartedAt);
       }
       if (config.cache?.kind === "admin-snapshot") {
-        return await respondWithAdminSnapshotCache(input, config, config.cache);
+        return await respondWithAdminSnapshotCache(input, config, config.cache, routeStartedAt);
       }
 
       const startedAt = routeStartedAt;

--- a/apps/web/tests/social-account-profile-page.runtime.test.tsx
+++ b/apps/web/tests/social-account-profile-page.runtime.test.tsx
@@ -6904,9 +6904,11 @@ describe("SocialAccountProfilePage", () => {
     expect(screen.getByRole("heading", { name: "Collaborators", level: 2 })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Tagged Accounts", level: 2 })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Mentions", level: 2 })).toBeInTheDocument();
-    expect(screen.getByText("@bravochatroom")).toBeInTheDocument();
-    expect(screen.getByText("@staciarusch")).toBeInTheDocument();
-    expect(screen.getByText("@peacock")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("@bravochatroom")).toBeInTheDocument();
+      expect(screen.getByText("@staciarusch")).toBeInTheDocument();
+      expect(screen.getByText("@peacock")).toBeInTheDocument();
+    });
   });
 
   it("renders YouTube catalog actions and skips the Instagram-only hashtag timeline fetch", async () => {
@@ -12877,11 +12879,13 @@ it("uses the newest inspected catalog run from the summary when discovery outran
       expect(screen.getByText("Unknown Hashtags")).toBeInTheDocument();
     });
 
-    expect(
-      screen.getByText(
-        `3 uses · First seen ${formatLocalDateTime("2026-03-10T12:00:00.000Z")} · Last seen ${formatLocalDateTime("2026-03-17T12:00:00.000Z")}`,
-      ),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          `3 uses · First seen ${formatLocalDateTime("2026-03-10T12:00:00.000Z")} · Last seen ${formatLocalDateTime("2026-03-17T12:00:00.000Z")}`,
+        ),
+      ).toBeInTheDocument();
+    });
     expect(screen.getByLabelText("Show for #RHOP")).toBeEnabled();
     fireEvent.click(screen.getByRole("button", { name: "Resolve" }));
 

--- a/apps/web/tests/social-account-profile-page.runtime.test.tsx
+++ b/apps/web/tests/social-account-profile-page.runtime.test.tsx
@@ -1306,11 +1306,14 @@ describe("SocialAccountProfilePage", () => {
 
     render(<SocialAccountProfilePage platform="instagram" handle="thetraitorsus" activeTab="stats" />);
 
-    await waitFor(() => {
-      expect(screen.getByText("Saved Posts", { selector: "p" }).parentElement?.textContent?.replace(/\s+/g, " ").trim()).toContain(
-        "431 / 436",
-      );
-    });
+    await waitFor(
+      () => {
+        expect(screen.getByText("Saved Posts", { selector: "p" }).parentElement?.textContent?.replace(/\s+/g, " ").trim()).toContain(
+          "431 / 436",
+        );
+      },
+      { timeout: 5000 },
+    );
     expect(screen.queryByText("431 / 500")).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- Persist local admin load-time samples for the social landing/profile surfaces and API snapshot reads.
- Add Server-Timing/x-trr timing headers on critical admin social routes.
- Defer non-essential social profile reads until after first paint while keeping snapshot as the first-paint profile request.
- Show a stale-progress badge on the social landing page when backend progress data is stale or unavailable.

## Notes
- `apps/web/src/lib/admin/api-references/generated/inventory.ts` was regenerated because `pnpm -C apps/web run validate:quick` requires the generated admin API inventory to match the current scanner output.

## Validation
- `pnpm -C apps/web exec vitest run -c vitest.config.mts tests/social-landing-repository.test.ts tests/social-account-profile-snapshot-route.test.ts tests/social-account-profile-page.runtime.test.tsx tests/social-account-summary-route.test.ts`
- `pnpm -C apps/web run validate:quick`
- `pnpm -C apps/web run typecheck`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a social progress freshness/status badge to the admin social dashboard.

* **Improvements**
  * Expanded admin telemetry with more consistent request timing and clearer cache-status reporting across social landing and profile APIs.
  * Improved landing and profile load signals to more accurately distinguish fresh vs. stale data.
  * Refined secondary-read gating for better responsiveness under load.
  * Polished admin flows including Instagram restart and cookie health preflight.

* **Tests**
  * Reduced runtime test flakiness by waiting for UI updates more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->