### PR TITLE
Improve social catalog operator workflows

### DIFF
--- a/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/social/targets/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/social/targets/route.ts
@@ -16,19 +16,24 @@ interface RouteParams {
 const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((entry) => typeof entry === "string");
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
 const isValidTargetsPayload = (value: unknown): value is Record<string, unknown> => {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  if (!isRecord(value)) return false;
   const payload = value as Record<string, unknown>;
   if (payload.targets === undefined) return true;
   if (!Array.isArray(payload.targets)) return false;
   return payload.targets.every((entry) => {
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return false;
+    if (!isRecord(entry)) return false;
     const target = entry as Record<string, unknown>;
     if (typeof target.platform !== "string" || target.platform.trim().length === 0) return false;
     if (target.accounts !== undefined && !isStringArray(target.accounts)) return false;
     if (target.hashtags !== undefined && !isStringArray(target.hashtags)) return false;
     if (target.keywords !== undefined && !isStringArray(target.keywords)) return false;
+    if (target.timezone !== undefined && typeof target.timezone !== "string") return false;
     if (target.is_active !== undefined && typeof target.is_active !== "boolean") return false;
+    if (target.config !== undefined && !isRecord(target.config)) return false;
     return true;
   });
 };

--- a/apps/web/src/app/api/admin/trr-api/social-growth/cookies/health/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/social-growth/cookies/health/route.ts
@@ -10,6 +10,7 @@ import {
   buildSocialBladeBackendErrorPayload,
   buildSocialBladeTimeoutResponse,
 } from "@/lib/server/trr-api/socialblade-proxy";
+import { normalizeSocialBladeCookieHealth } from "@/lib/admin/socialblade-cookie-health";
 
 export const dynamic = "force-dynamic";
 
@@ -49,7 +50,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    return NextResponse.json(data);
+    return NextResponse.json(normalizeSocialBladeCookieHealth(data));
   } catch (error) {
     if (isTimeoutSafeFetchTimeoutError(error)) {
       return buildSocialBladeTimeoutResponse(error, SOCIALBLADE_COOKIE_HEALTH_TIMEOUT_MS);

--- a/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/capacity/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/capacity/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/server/auth";
+import {
+  fetchSocialBackendJson,
+  socialProxyErrorResponse,
+} from "@/lib/server/trr-api/social-admin-proxy";
+
+export const dynamic = "force-dynamic";
+
+type RouteContext = {
+  params: Promise<{ platform: string; handle: string }>;
+};
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  try {
+    await requireAdmin(request);
+    const { platform, handle } = await context.params;
+    const data = await fetchSocialBackendJson(
+      `/profiles/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/catalog/capacity`,
+      {
+        method: "GET",
+        queryString: request.nextUrl.searchParams.toString(),
+        fallbackError: "Failed to fetch social account catalog capacity",
+        retries: 0,
+        timeoutMs: 30_000,
+      },
+    );
+    return NextResponse.json(data, { headers: { "Cache-Control": "no-store" } });
+  } catch (error) {
+    return socialProxyErrorResponse(error, "[api] Failed to fetch social account catalog capacity");
+  }
+}

--- a/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/posts/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/posts/route.ts
@@ -46,7 +46,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
           {
             queryString,
             fallbackError: "Failed to fetch social account catalog posts",
-            retries: 0,
+            retries: 1,
             timeoutMs: 30_000,
           },
         ),

--- a/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/runs/[runId]/progress/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/runs/[runId]/progress/route.ts
@@ -60,6 +60,17 @@ const buildDegradedProgressPayload = (runId: string, reason: string): Record<str
   progress_authoritative: false,
 });
 
+const markProgressAuthoritative = (value: unknown): unknown => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return value;
+  }
+  const progress = value as Record<string, unknown>;
+  return {
+    ...progress,
+    progress_authoritative: progress.progress_authoritative !== false,
+  };
+};
+
 const isFastProgressRequest = (request: NextRequest): boolean => {
   const fast = request.nextUrl.searchParams.get("fast");
   return fast === "true" || fast === "1";
@@ -109,7 +120,9 @@ export async function GET(request: NextRequest, context: RouteContext) {
           retries: 0,
           timeoutMs,
         });
-      data = await getOrCreateRouteResponsePromise(PROGRESS_CACHE_NAMESPACE, cacheKey, fetchProgress);
+      data = markProgressAuthoritative(
+        await getOrCreateRouteResponsePromise(PROGRESS_CACHE_NAMESPACE, cacheKey, fetchProgress),
+      );
       setRouteResponseCache(
         PROGRESS_CACHE_NAMESPACE,
         cacheKey,

--- a/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/runs/recent/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/runs/recent/route.ts
@@ -9,6 +9,7 @@ import {
   setRouteResponseCache,
 } from "@/lib/server/admin/route-response-cache";
 import { query } from "@/lib/server/postgres";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 import { socialProxyErrorResponse } from "@/lib/server/trr-api/social-admin-proxy";
 import type { SocialAccountCatalogRun } from "@/lib/admin/social-account-profile";
 
@@ -55,10 +56,13 @@ const TERMINAL_PARENT_STATUSES = new Set(["cancelled", "failed"]);
 const normalizeHandle = (value: string): string =>
   value.trim().toLowerCase().replace(/^@+/, "");
 
-const readLimit = (request: NextRequest): number => {
-  const parsed = Number(request.nextUrl.searchParams.get("limit") ?? "10");
-  return Number.isInteger(parsed) ? Math.max(1, Math.min(parsed, 25)) : 10;
-};
+const readLimit = (request: NextRequest) =>
+  parseBoundedIntegerParam(request.nextUrl.searchParams.get("limit"), {
+    name: "limit",
+    defaultValue: 10,
+    min: 1,
+    max: 25,
+  });
 
 const readRecord = (value: unknown): Record<string, unknown> =>
   value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
@@ -311,7 +315,11 @@ export async function GET(request: NextRequest, context: RouteContext) {
     if (normalizedPlatform !== "instagram" || !normalizedHandle) {
       return NextResponse.json({ error: "unsupported_profile" }, { status: 400 });
     }
-    const limit = readLimit(request);
+    const limitResult = readLimit(request);
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
     const cacheKey = buildUserScopedRouteCacheKey(
       String(user?.uid ?? "admin"),
       `${normalizedPlatform}:${normalizedHandle}:catalog-runs-recent`,

--- a/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/completion-summary/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/completion-summary/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireAdmin } from "@/lib/server/auth";
+import { requireAdmin, toVerifiedAdminContext } from "@/lib/server/auth";
+import { attachAdminRouteTiming } from "@/lib/server/admin/admin-route-timing";
 import {
   buildUserScopedRouteCacheKey,
   getOrCreateRouteResponsePromise,
@@ -8,29 +9,15 @@ import {
   parseCacheTtlMs,
   setRouteResponseCache,
 } from "@/lib/server/admin/route-response-cache";
-import { query } from "@/lib/server/postgres";
-import { socialProxyErrorResponse } from "@/lib/server/trr-api/social-admin-proxy";
+import {
+  fetchSocialBackendJson,
+  socialProxyErrorResponse,
+} from "@/lib/server/trr-api/social-admin-proxy";
 
 export const dynamic = "force-dynamic";
 
 type RouteContext = {
   params: Promise<{ platform: string; handle: string }>;
-};
-
-type CompletionRow = {
-  total_posts: number | string | null;
-  total_reported_comments: number | string | null;
-  saved_comments: number | string | null;
-  missing_comments: number | string | null;
-  accounted_comments: number | string | null;
-  comments_finished: number | string | null;
-  comments_in_progress: number | string | null;
-  comments_not_started: number | string | null;
-  details_finished: number | string | null;
-  details_not_started: number | string | null;
-  media_finished: number | string | null;
-  media_in_progress: number | string | null;
-  media_not_started: number | string | null;
 };
 
 const COMPLETION_SUMMARY_CACHE_NAMESPACE = "social-account-profile-completion-summary";
@@ -42,11 +29,10 @@ const COMPLETION_SUMMARY_STALE_CACHE_TTL_MS = parseCacheTtlMs(
   process.env.TRR_ADMIN_SOCIAL_PROFILE_COMPLETION_SUMMARY_STALE_CACHE_TTL_MS,
   10 * 60_000,
 );
-
-const readCount = (value: number | string | null | undefined): number => {
-  const parsed = Number(value ?? 0);
-  return Number.isFinite(parsed) ? parsed : 0;
-};
+const COMPLETION_SUMMARY_BACKEND_TIMEOUT_MS = parseCacheTtlMs(
+  process.env.TRR_ADMIN_SOCIAL_PROFILE_COMPLETION_SUMMARY_BACKEND_TIMEOUT_MS,
+  30_000,
+);
 
 const getDefaultYear = (): number => new Date().getUTCFullYear();
 
@@ -56,310 +42,125 @@ const readYear = (request: NextRequest): number => {
   return Number.isInteger(parsed) && parsed >= 2000 && parsed <= 2100 ? parsed : fallbackYear;
 };
 
-const sqlJsonTextNonNegativeInt = (expr: string): string =>
-  `coalesce(nullif(regexp_replace(coalesce(${expr}, ''), '[^0-9]', '', 'g'), '')::bigint, 0)`;
-
-const instagramRawReportedCommentsSql = (alias: string): string => {
-  const safeAlias = alias.trim() || "p";
-  const raw = `coalesce(${safeAlias}.raw_data, '{}'::jsonb)`;
-  return `greatest(${[
-    `${raw} ->> 'comments_count'`,
-    `${raw} ->> 'comments'`,
-    `${raw} ->> 'comment_count'`,
-    `${raw} ->> 'commentsCount'`,
-    `${raw} -> 'edge_media_to_comment' ->> 'count'`,
-    `${raw} -> 'edge_media_to_parent_comment' ->> 'count'`,
-    `${raw} -> 'edge_media_preview_comment' ->> 'count'`,
-    `${raw} -> 'media' ->> 'comments_count'`,
-    `${raw} -> 'media' ->> 'comments'`,
-    `${raw} -> 'media' ->> 'comment_count'`,
-    `${raw} -> 'media' ->> 'commentsCount'`,
-    `${raw} -> 'metrics' ->> 'comments_count'`,
-    `${raw} -> 'metrics' ->> 'comments'`,
-  ]
-    .map(sqlJsonTextNonNegativeInt)
-    .join(", ")}, 0)`;
-};
-
 export async function GET(request: NextRequest, context: RouteContext) {
+  const routeStartedAt = performance.now();
+  let cacheStatus = "error";
+  let backendMs: number | null = null;
   try {
     const user = await requireAdmin(request);
+    const adminContext = toVerifiedAdminContext(user);
     const { platform, handle } = await context.params;
     const normalizedPlatform = platform.trim().toLowerCase();
     const normalizedHandle = handle.trim().toLowerCase().replace(/^@/, "");
     if (normalizedPlatform !== "instagram" || !normalizedHandle) {
-      return NextResponse.json({ error: "unsupported_profile" }, { status: 400 });
+      cacheStatus = "bypass";
+      return attachAdminRouteTiming(
+        NextResponse.json({ error: "unsupported_profile" }, { status: 400 }),
+        {
+          routeFamily: "admin-social-profile",
+          routeName: "GET completion-summary",
+          cacheStatus,
+          startedAt: routeStartedAt,
+        },
+      );
     }
+
     const year = readYear(request);
     const cacheKey = buildUserScopedRouteCacheKey(
-      String(user?.uid ?? "admin"),
+      user.uid,
       `${normalizedPlatform}:${normalizedHandle}:completion-summary`,
       new URLSearchParams([["year", String(year)]]),
     );
-    const cached = getRouteResponseCache(COMPLETION_SUMMARY_CACHE_NAMESPACE, cacheKey);
-    if (cached) {
-      return NextResponse.json(cached, { headers: { "x-trr-cache": "hit" } });
-    }
-    const stale = getStaleRouteResponseCache(COMPLETION_SUMMARY_CACHE_NAMESPACE, cacheKey);
-    const loadPayload = async () => {
-    const instagramPostReportedCommentsSql = instagramRawReportedCommentsSql("p");
-    const result = await query<CompletionRow>(
-      `
-      with target as (
-        select
-          $1::text as handle,
-          make_timestamptz($2, 1, 1, 0, 0, 0) as start_at,
-          make_timestamptz($2 + 1, 1, 1, 0, 0, 0) as end_at
-      ),
-      catalog_candidates as materialized (
-        select
-          cp.source_id as shortcode,
-          cp.posted_at,
-          coalesce(cp.comments_count, 0)::bigint as catalog_comments_count
-        from social.instagram_account_catalog_posts cp
-        cross join target t
-        where cp.posted_at >= t.start_at
-          and cp.posted_at < t.end_at
-          and nullif(cp.source_id, '') is not null
-          and (
-            nullif(regexp_replace(lower(regexp_replace(coalesce(cp.source_account, ''), '^@+', '')), '[^a-z0-9._-]+', '', 'g'), '') = t.handle
-            or nullif(regexp_replace(lower(regexp_replace(coalesce(cp.owner_username, ''), '^@+', '')), '[^a-z0-9._-]+', '', 'g'), '') = t.handle
-            or nullif(
-              regexp_replace(
-                lower(
-                  regexp_replace(
-                    coalesce(
-                      cp.raw_data ->> 'username',
-                      cp.raw_data ->> 'ownerUsername',
-                      cp.raw_data -> 'owner' ->> 'username',
-                      cp.raw_data -> 'user' ->> 'username',
-                      ''
-                    ),
-                    '^@+',
-                    ''
-                  )
-                ),
-                '[^a-z0-9._-]+',
-                '',
-                'g'
-              ),
-              ''
-            ) = t.handle
-            or exists (
-              select 1
-              from jsonb_array_elements_text(coalesce(cp.collaborators, '[]'::jsonb)) collaborator(value)
-              where nullif(
-                regexp_replace(lower(regexp_replace(coalesce(collaborator.value, ''), '^@+', '')), '[^a-z0-9._-]+', '', 'g'),
-                ''
-              ) = t.handle
-            )
-            or exists (
-              select 1
-              from jsonb_array_elements(
-                coalesce(to_jsonb(cp) -> 'collaborators_detail', cp.raw_data -> 'collaborators_detail', '[]'::jsonb)
-              ) collaborator(detail)
-              where nullif(
-                regexp_replace(
-                  lower(regexp_replace(coalesce(collaborator.detail ->> 'username', ''), '^@+', '')),
-                  '[^a-z0-9._-]+',
-                  '',
-                  'g'
-                ),
-                ''
-              ) = t.handle
-            )
-          )
-      ),
-      post_candidates as materialized (
-        select
-          p.shortcode,
-          p.id as post_id,
-          p.posted_at,
-          (${instagramPostReportedCommentsSql})::bigint as detail_comments_count,
-          lower(coalesce(p.media_mirror_status, '')) as media_mirror_status,
-          greatest(coalesce(ch.saved_comment_count, r.active_comment_count, 0), 0)::bigint as saved_comments,
-          greatest(coalesce(ch.instagram_reported_comments, (${instagramPostReportedCommentsSql}), 0), 0)::bigint as health_reported_comments,
-          greatest(
-            coalesce(
-              r.missing_comment_count,
-              greatest(
-                coalesce(ch.instagram_reported_comments, (${instagramPostReportedCommentsSql}), 0)::bigint
-                  - coalesce(ch.saved_comment_count, r.active_comment_count, 0)::bigint,
-                0
-              ),
-              0
-            ),
-            0
-          )::bigint as missing_comments
-        from social.instagram_posts p
-        left join social.instagram_post_comment_rollups r on r.post_id = p.id
-        left join social.comment_capture_health ch on ch.post_id = p.id
-        cross join target t
-        where p.posted_at >= t.start_at
-          and p.posted_at < t.end_at
-          and nullif(p.shortcode, '') is not null
-          and (
-            nullif(regexp_replace(lower(regexp_replace(coalesce(p.source_account, ''), '^@+', '')), '[^a-z0-9._-]+', '', 'g'), '') = t.handle
-            or nullif(regexp_replace(lower(regexp_replace(coalesce(p.owner_username, ''), '^@+', '')), '[^a-z0-9._-]+', '', 'g'), '') = t.handle
-            or nullif(regexp_replace(lower(regexp_replace(coalesce(p.username, ''), '^@+', '')), '[^a-z0-9._-]+', '', 'g'), '') = t.handle
-            or exists (
-              select 1
-              from jsonb_array_elements_text(coalesce(p.collaborators, '[]'::jsonb)) collaborator(value)
-              where nullif(
-                regexp_replace(lower(regexp_replace(coalesce(collaborator.value, ''), '^@+', '')), '[^a-z0-9._-]+', '', 'g'),
-                ''
-              ) = t.handle
-            )
-            or exists (
-              select 1
-              from jsonb_array_elements(
-                coalesce(to_jsonb(p) -> 'collaborators_detail', p.raw_data -> 'collaborators_detail', '[]'::jsonb)
-              ) collaborator(detail)
-              where nullif(
-                regexp_replace(
-                  lower(regexp_replace(coalesce(collaborator.detail ->> 'username', ''), '^@+', '')),
-                  '[^a-z0-9._-]+',
-                  '',
-                  'g'
-                ),
-                ''
-              ) = t.handle
-            )
-          )
-      ),
-      matched_shortcodes as materialized (
-        select shortcode from catalog_candidates
-        union
-        select shortcode from post_candidates
-      ),
-      catalog as materialized (
-        select
-          matched.shortcode,
-          max(c.catalog_comments_count)::bigint as catalog_comments_count
-        from matched_shortcodes matched
-        left join catalog_candidates c on c.shortcode = matched.shortcode
-        group by matched.shortcode
-      ),
-      latest_post as materialized (
-        select distinct on (p.shortcode)
-          p.shortcode,
-          p.post_id,
-          coalesce(p.detail_comments_count, 0)::bigint as detail_comments_count,
-          lower(coalesce(p.media_mirror_status, '')) as media_mirror_status,
-          p.saved_comments,
-          p.health_reported_comments,
-          p.missing_comments,
-          p.posted_at
-        from post_candidates p
-        order by p.shortcode, p.posted_at desc nulls last, p.post_id desc
-      ),
-      scored as (
-        select
-          matched.shortcode,
-          lp.post_id,
-          greatest(
-            coalesce(c.catalog_comments_count, 0),
-            coalesce(lp.health_reported_comments, 0),
-            coalesce(lp.detail_comments_count, 0)
-          )::bigint as reported_comments,
-          coalesce(lp.saved_comments, 0)::bigint as saved_comments,
-          greatest(
-            coalesce(
-              lp.missing_comments,
-              greatest(
-                greatest(
-                  coalesce(c.catalog_comments_count, 0),
-                  coalesce(lp.health_reported_comments, 0),
-                  coalesce(lp.detail_comments_count, 0)
-                ) - coalesce(lp.saved_comments, 0),
-                0
-              ),
-              0
-            ),
-            0
-          )::bigint as missing_comments,
-          lp.media_mirror_status
-        from matched_shortcodes matched
-        left join catalog c on c.shortcode = matched.shortcode
-        left join latest_post lp on lp.shortcode = matched.shortcode
-      )
-      select
-        count(*)::bigint as total_posts,
-        coalesce(sum(reported_comments), 0)::bigint as total_reported_comments,
-        coalesce(sum(saved_comments), 0)::bigint as saved_comments,
-        coalesce(sum(missing_comments), 0)::bigint as missing_comments,
-        coalesce(sum(saved_comments + missing_comments), 0)::bigint as accounted_comments,
-        count(*) filter (
-          where reported_comments = 0
-             or (reported_comments > 0 and missing_comments = 0 and reported_comments <= saved_comments)
-        )::bigint as comments_finished,
-        count(*) filter (
-          where reported_comments > 0 and saved_comments > 0 and missing_comments > 0
-        )::bigint as comments_in_progress,
-        count(*) filter (where reported_comments > 0 and saved_comments = 0)::bigint as comments_not_started,
-        count(*) filter (where post_id is not null)::bigint as details_finished,
-        count(*) filter (where post_id is null)::bigint as details_not_started,
-        count(*) filter (where media_mirror_status in ('complete', 'completed', 'mirrored', 'up_to_date'))::bigint as media_finished,
-        count(*) filter (where media_mirror_status in ('pending', 'partial', 'queued', 'retrying', 'running', 'failed'))::bigint as media_in_progress,
-        count(*) filter (
-          where post_id is null
-             or coalesce(media_mirror_status, '') not in ('complete', 'completed', 'mirrored', 'up_to_date', 'pending', 'partial', 'queued', 'retrying', 'running', 'failed')
-        )::bigint as media_not_started
-      from scored
-      `,
-      [normalizedHandle, year],
+    const cached = getRouteResponseCache<Record<string, unknown>>(
+      COMPLETION_SUMMARY_CACHE_NAMESPACE,
+      cacheKey,
     );
-    const row = result.rows[0] ?? ({} as CompletionRow);
-    return {
-      platform: normalizedPlatform,
-      handle: normalizedHandle,
-      year,
-      total_posts: readCount(row.total_posts),
-      total_reported_comments: readCount(row.total_reported_comments),
-      saved_comments: readCount(row.saved_comments),
-      missing_comments: readCount(row.missing_comments),
-      accounted_comments: readCount(row.accounted_comments),
-      lanes: {
-        comments: {
-          finished: readCount(row.comments_finished),
-          in_progress: readCount(row.comments_in_progress),
-          not_started: readCount(row.comments_not_started),
+    if (cached) {
+      cacheStatus = "hit";
+      return attachAdminRouteTiming(
+        NextResponse.json(cached, { headers: { "x-trr-cache": cacheStatus } }),
+        {
+          routeFamily: "admin-social-profile",
+          routeName: "GET completion-summary",
+          cacheStatus,
+          startedAt: routeStartedAt,
         },
-        details: {
-          finished: readCount(row.details_finished),
-          in_progress: 0,
-          not_started: readCount(row.details_not_started),
-        },
-        media: {
-          finished: readCount(row.media_finished),
-          in_progress: readCount(row.media_in_progress),
-          not_started: readCount(row.media_not_started),
-        },
-      },
-    };
-    };
+      );
+    }
+
+    const stale = getStaleRouteResponseCache<Record<string, unknown>>(
+      COMPLETION_SUMMARY_CACHE_NAMESPACE,
+      cacheKey,
+    );
     try {
-      const payload = await getOrCreateRouteResponsePromise(COMPLETION_SUMMARY_CACHE_NAMESPACE, cacheKey, async () => {
-        const nextPayload = await loadPayload();
-        setRouteResponseCache(
-          COMPLETION_SUMMARY_CACHE_NAMESPACE,
-          cacheKey,
-          nextPayload,
-          COMPLETION_SUMMARY_CACHE_TTL_MS,
-          COMPLETION_SUMMARY_STALE_CACHE_TTL_MS,
-        );
-        return nextPayload;
-      });
-      return NextResponse.json(payload, { headers: { "x-trr-cache": "miss" } });
+      const payload = await getOrCreateRouteResponsePromise(
+        COMPLETION_SUMMARY_CACHE_NAMESPACE,
+        cacheKey,
+        async () => {
+          const backendStartedAt = performance.now();
+          try {
+            const nextPayload = await fetchSocialBackendJson(
+              `/profiles/${encodeURIComponent(normalizedPlatform)}/${encodeURIComponent(normalizedHandle)}/completion-summary`,
+              {
+                adminContext,
+                queryString: new URLSearchParams([["year", String(year)]]).toString(),
+                fallbackError: "Failed to load social completion summary",
+                retries: 0,
+                timeoutMs: COMPLETION_SUMMARY_BACKEND_TIMEOUT_MS,
+              },
+            );
+            setRouteResponseCache(
+              COMPLETION_SUMMARY_CACHE_NAMESPACE,
+              cacheKey,
+              nextPayload,
+              COMPLETION_SUMMARY_CACHE_TTL_MS,
+              COMPLETION_SUMMARY_STALE_CACHE_TTL_MS,
+            );
+            return nextPayload;
+          } finally {
+            backendMs = performance.now() - backendStartedAt;
+          }
+        },
+      );
+      cacheStatus = "miss";
+      return attachAdminRouteTiming(
+        NextResponse.json(payload, { headers: { "x-trr-cache": cacheStatus } }),
+        {
+          routeFamily: "admin-social-profile",
+          routeName: "GET completion-summary",
+          cacheStatus,
+          backendMs,
+          startedAt: routeStartedAt,
+        },
+      );
     } catch (error) {
       if (stale) {
-        return NextResponse.json(stale, {
-          headers: { "x-trr-cache": "stale", "x-trr-cacheable": "0" },
-        });
+        cacheStatus = "stale";
+        return attachAdminRouteTiming(
+          NextResponse.json(stale, {
+            headers: { "x-trr-cache": cacheStatus, "x-trr-cacheable": "0" },
+          }),
+          {
+            routeFamily: "admin-social-profile",
+            routeName: "GET completion-summary",
+            cacheStatus,
+            backendMs,
+            startedAt: routeStartedAt,
+          },
+        );
       }
       throw error;
     }
   } catch (error) {
-    return socialProxyErrorResponse(error, "[api] Failed to load social completion summary");
+    return attachAdminRouteTiming(
+      socialProxyErrorResponse(error, "[api] Failed to load social completion summary"),
+      {
+        routeFamily: "admin-social-profile",
+        routeName: "GET completion-summary",
+        cacheStatus,
+        backendMs,
+        startedAt: routeStartedAt,
+      },
+    );
   }
 }

--- a/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/completion-summary/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/completion-summary/route.ts
@@ -51,7 +51,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
     const adminContext = toVerifiedAdminContext(user);
     const { platform, handle } = await context.params;
     const normalizedPlatform = platform.trim().toLowerCase();
-    const normalizedHandle = handle.trim().toLowerCase().replace(/^@/, "");
+    const normalizedHandle = handle.trim().toLowerCase().replace(/^@+/, "");
     if (normalizedPlatform !== "instagram" || !normalizedHandle) {
       cacheStatus = "bypass";
       return attachAdminRouteTiming(

--- a/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/cookies/health/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/cookies/health/route.ts
@@ -5,6 +5,7 @@ import {
   SocialProxyError,
   socialProxyErrorResponse,
 } from "@/lib/server/trr-api/social-admin-proxy";
+import { normalizeSocialBladeCookieHealth } from "@/lib/admin/socialblade-cookie-health";
 
 export const dynamic = "force-dynamic";
 
@@ -53,7 +54,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
         timeoutMs: includePostsAuth || includeCommentsAuth ? 60_000 : 15_000,
       },
     );
-    return NextResponse.json(data);
+    return NextResponse.json(normalizeSocialBladeCookieHealth(data));
   } catch (error) {
     const { platform, handle } = await context.params;
     if (
@@ -61,7 +62,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
       request.nextUrl.searchParams.get("comments_auth") !== "true" &&
       isDegradableCookieHealthError(error)
     ) {
-      return NextResponse.json(buildDegradedCookieHealthPayload(platform, handle), {
+      return NextResponse.json(normalizeSocialBladeCookieHealth(buildDegradedCookieHealthPayload(platform, handle)), {
         headers: { "x-trr-cookie-health-source": "backend-timeout-degraded" },
       });
     }

--- a/apps/web/src/components/admin/SocialAccountProfilePage.tsx
+++ b/apps/web/src/components/admin/SocialAccountProfilePage.tsx
@@ -131,6 +131,7 @@ type InstagramCommentsGapDisplayRow = {
 };
 
 type InstagramCommentsStreamingBanner = {
+  titleLabel: string;
   stateLabel: string;
   detail: string;
   runLabel: string | null;
@@ -194,6 +195,32 @@ type CatalogPostsResponse = {
     total: number;
     total_pages: number;
   };
+};
+
+export type InstagramCatalogCapacitySnapshot = {
+  available: boolean;
+  blocked: boolean;
+  safe_combined_worker_limit: number;
+  remaining_workers: number;
+  raw_requested_workers: number;
+  backend_effective_requested_workers: number;
+  effective_details_worker_count: number;
+  effective_comments_worker_count: number;
+  active_db_jobs: number;
+  dispatched_unclaimed_jobs: number;
+  nonterminal_remote_call_ids: string[];
+};
+
+export const buildInstagramCatalogCapacityQuery = (input: {
+  selectedTasks: CatalogBackfillSelectedTask[];
+  detailWorkerCount: number;
+  commentsWorkerCount: number;
+}): URLSearchParams => {
+  return new URLSearchParams({
+    selected_tasks: input.selectedTasks.join(","),
+    detail_worker_count: String(Math.max(1, input.detailWorkerCount)),
+    comments_worker_count: String(Math.max(1, input.commentsWorkerCount)),
+  });
 };
 
 const normalizeCatalogPostsResponse = (
@@ -678,6 +705,66 @@ const readNonNegativeInteger = (value: unknown): number | null => {
   return numeric === null ? null : Math.max(0, Math.trunc(numeric));
 };
 
+export const normalizeInstagramCatalogCapacity = (payload: unknown): InstagramCatalogCapacitySnapshot | null => {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
+  const record = payload as Record<string, unknown>;
+  if (typeof record.available !== "boolean" || typeof record.blocked !== "boolean") return null;
+  const readCount = (key: keyof InstagramCatalogCapacitySnapshot): number => readNonNegativeInteger(record[key]) ?? 0;
+  return {
+    available: record.available,
+    blocked: record.blocked,
+    safe_combined_worker_limit: readCount("safe_combined_worker_limit"),
+    remaining_workers: readCount("remaining_workers"),
+    raw_requested_workers: readCount("raw_requested_workers"),
+    backend_effective_requested_workers: readCount("backend_effective_requested_workers"),
+    effective_details_worker_count: readCount("effective_details_worker_count"),
+    effective_comments_worker_count: readCount("effective_comments_worker_count"),
+    active_db_jobs: readCount("active_db_jobs"),
+    dispatched_unclaimed_jobs: readCount("dispatched_unclaimed_jobs"),
+    nonterminal_remote_call_ids: Array.isArray(record.nonterminal_remote_call_ids)
+      ? record.nonterminal_remote_call_ids.map((value) => String(value || "").trim()).filter(Boolean)
+      : [],
+  };
+};
+
+export const describeInstagramCatalogCapacity = (
+  snapshot: InstagramCatalogCapacitySnapshot | null,
+  unavailable = false,
+): { blocked: boolean; summary: string | null; warning: string | null } => {
+  if (!snapshot && !unavailable) return { blocked: false, summary: null, warning: null };
+  if (unavailable || !snapshot) {
+    return {
+      blocked: false,
+      summary: null,
+      warning: "Current capacity is unavailable. Start remains available; the backend will make the final safety decision.",
+    };
+  }
+  const summary = [
+    `Backend-effective ${formatInteger(snapshot.effective_details_worker_count)} detail + ${formatInteger(snapshot.effective_comments_worker_count)} comments (${formatInteger(snapshot.backend_effective_requested_workers)} combined)`,
+    `${formatInteger(snapshot.raw_requested_workers)} raw requested`,
+    `${formatInteger(snapshot.remaining_workers)} of ${formatInteger(snapshot.safe_combined_worker_limit)} slots remain`,
+  ].join(" · ");
+  if (snapshot.blocked) {
+    return {
+      blocked: true,
+      summary,
+      warning: `Start is blocked: ${formatInteger(snapshot.backend_effective_requested_workers)} workers were requested but only ${formatInteger(snapshot.remaining_workers)} safe slots remain.`,
+    };
+  }
+  if (!snapshot.available) {
+    return {
+      blocked: false,
+      summary,
+      warning: "Current capacity is unavailable. Start remains available; the backend will make the final safety decision.",
+    };
+  }
+  return {
+    blocked: false,
+    summary,
+    warning: null,
+  };
+};
+
 const asRecord = (value: unknown): Record<string, unknown> | null => {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   return value as Record<string, unknown>;
@@ -986,6 +1073,23 @@ const formatDiagnosticToken = (value?: string | null): string => {
   return normalized.replace(/_/g, " ");
 };
 
+const CATALOG_OPERATOR_REASON_LABELS: Record<string, string> = {
+  instagram_graphql_cursor_unauthorized: "Instagram login expired; complete manual auth",
+  instagram_graphql_cursor_forbidden: "Instagram blocked the saved cursor; complete manual auth",
+  instagram_graphql_checkpoint_required: "Instagram checkpoint required before this run can resume",
+  instagram_graphql_cursor_auth_repair_required: "Instagram cursor needs manual auth repair",
+  frontier_auth_blocked: "Instagram blocked frontier resume until auth is fixed",
+  run_deadline_exceeded: "Run timed out before recovery finished",
+};
+
+const CATALOG_REPAIRABLE_OPERATOR_REASON_CODES = new Set(Object.keys(CATALOG_OPERATOR_REASON_LABELS));
+
+const formatCatalogOperatorReasonLabel = (value?: string | null): string => {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!normalized) return "";
+  return CATALOG_OPERATOR_REASON_LABELS[normalized] ?? formatDiagnosticToken(normalized);
+};
+
 const COMMENTS_SKIP_REASON_LABELS: Record<string, string> = {
   comments_not_selected: "Comments lane not selected",
   posts_auth_blocked: "Posts auth blocked",
@@ -1067,9 +1171,10 @@ const buildInstagramCommentsStreamingBanner = (
   streaming: SocialAccountCatalogCommentsStreaming | null | undefined,
   fallbackRunId?: string | null,
 ): InstagramCommentsStreamingBanner | null => {
-  if (!streaming?.enabled) return null;
+  const commentsRunId = readString(streaming?.comments_run_id) || readString(fallbackRunId);
+  if (!streaming || (!streaming.enabled && !commentsRunId)) return null;
+  const isDirectRunHandoff = !streaming.enabled && Boolean(commentsRunId);
   const state = readString(streaming.state) || "started";
-  const commentsRunId = readString(streaming.comments_run_id) || readString(fallbackRunId);
   const enqueued = readNonNegativeInteger(streaming.targets_enqueued);
   const seen = readNonNegativeInteger(streaming.targets_seen);
   const skippedDuplicate = readNonNegativeInteger(streaming.targets_skipped_duplicate);
@@ -1124,11 +1229,18 @@ const buildInstagramCommentsStreamingBanner = (
     attemptCount !== null && attemptCount > 0 ? `${formatInteger(attemptCount)} enqueue attempts` : null,
   ].filter((item): item is string => Boolean(item));
   return {
+    titleLabel: isDirectRunHandoff
+      ? "Comments Moved To A Direct Run"
+      : "Comments Are Streaming From Saved Catalog Posts",
     stateLabel: formatRunStatusLabel(state),
     runLabel: commentsRunId ? `run ${shortRunId(commentsRunId)}` : null,
-    detail: `Saved catalog batches are feeding comments immediately through ${sourceLabel}. Public-first recovery remains the default; account-backed follow-up stays last resort.`,
-    nextActionLabel,
-    nextActionDetail,
+    detail: isDirectRunHandoff
+      ? `Catalog streaming handed off to a direct comments run through ${sourceLabel}. Watch the attached run for post and comment completion.`
+      : `Saved catalog batches are feeding comments immediately through ${sourceLabel}. Public-first recovery remains the default; account-backed follow-up stays last resort.`,
+    nextActionLabel: isDirectRunHandoff ? "Watch the attached comments run" : nextActionLabel,
+    nextActionDetail: isDirectRunHandoff
+      ? "The catalog run is no longer appending streamed targets, but the attached comments run remains active for completion tracking."
+      : nextActionDetail,
     metricItems,
     historyItems,
   };
@@ -1244,6 +1356,17 @@ const getNumberFromRecord = (record: unknown, keys: string[]): number | null => 
   return null;
 };
 
+const getInstagramDbSessionCapacity = (
+  progress?: SocialAccountCatalogRunProgressSnapshot | null,
+): JsonRecord | null => {
+  const direct = progress?.db_session_capacity;
+  if (direct && typeof direct === "object") return direct as JsonRecord;
+  const budgetDecision = progress?.budget_decision;
+  if (!budgetDecision || typeof budgetDecision !== "object") return null;
+  const nested = (budgetDecision as JsonRecord).db_session_capacity;
+  return nested && typeof nested === "object" ? (nested as JsonRecord) : null;
+};
+
 const formatCoverageMetric = (metric: unknown): string | null => {
   const covered = getNumberFromRecord(metric, ["present_count", "covered_count", "saved_count", "count"]);
   const total = getNumberFromRecord(metric, ["total_count", "total_posts", "eligible_count", "available_posts"]);
@@ -1332,6 +1455,27 @@ export const buildCatalogProgressDiagnosticRows = (
       budgetLimits?.cap4_canary_active ||
       canaryMetadata?.active,
   );
+  const dbSessionCapacity = getInstagramDbSessionCapacity(progress);
+  const dbSessionWorkerBudget = getNumberFromRecord(dbSessionCapacity, [
+    "safe_combined_worker_limit",
+    "worker_budget",
+  ]);
+  const dbSessionActiveWorkers = getNumberFromRecord(dbSessionCapacity, ["active_workers"]);
+  const dbSessionRemainingWorkers = getNumberFromRecord(dbSessionCapacity, ["remaining_workers"]);
+  if (dbSessionWorkerBudget != null) {
+    rows.push({
+      key: "db-session-worker-capacity",
+      label: "DB-safe Combined Workers",
+      value: [
+        `${formatInteger(dbSessionWorkerBudget)} max`,
+        dbSessionActiveWorkers != null ? `${formatInteger(dbSessionActiveWorkers)} active` : null,
+        dbSessionRemainingWorkers != null ? `${formatInteger(dbSessionRemainingWorkers)} remaining` : null,
+      ]
+        .filter(Boolean)
+        .join(" · "),
+      detail: "This combined limit covers Instagram detail, shared-post, comments, and recovery workers.",
+    });
+  }
   if (budgetState || effectiveBudgetCap != null || bindingBudgetCap != null) {
     const budgetParts = [
       budgetState ? formatDiagnosticToken(budgetState) : null,
@@ -2056,7 +2200,7 @@ const formatHashtagConflictLegacyAssignments = (
     .join("; ");
 };
 
-const resolveCatalogGapAnalysisBackoffMs = (
+const resolveCatalogRequestBackoffMs = (
   error: SocialAccountRequestError | null,
   saturationAttempt: number,
 ): number => {
@@ -2122,11 +2266,11 @@ const getCatalogRunDisplayStatusLabel = (
   progress?: SocialAccountCatalogRunProgressSnapshot | null,
 ): string => {
   const normalizedStatus = String(value || "").trim().toLowerCase();
+  const operationalState = String(progress?.operational_state || "").trim().toLowerCase();
+  if (operationalState === "blocked_auth") return "Auth Blocked";
   if (normalizedStatus === "cancelled" || normalizedStatus === "failed" || normalizedStatus === "completed") {
     return formatRunStatusLabel(value);
   }
-  const operationalState = String(progress?.operational_state || "").trim().toLowerCase();
-  if (operationalState === "blocked_auth") return "Auth Blocked";
   const runState = String(progress?.run_state || "").trim().toLowerCase();
   if (runState === "discovering") return "Discovering";
   if (runState === "fetching") return "Fetching";
@@ -3136,17 +3280,35 @@ const getCatalogPhaseLabel = (progress?: SocialAccountCatalogRunProgressSnapshot
   const staleDispatchFailedJobs = Number(progress?.dispatch_health?.stale_dispatch_failed_jobs ?? 0);
   const runStatus = normalizeCatalogRunStatus(progress?.run_status);
   const runState = normalizeCatalogRunState(progress?.run_state);
+  const operationalState = String(progress?.operational_state || "").trim().toLowerCase();
   const recovery = progress?.recovery;
   const recoveryStatus = String(recovery?.status || "").trim().toLowerCase();
   const recoveryReason = String(recovery?.reason || "").trim().toLowerCase();
   const recoveryStage = String(recovery?.stage || "").trim().toLowerCase();
   const completionGapReason = String(progress?.completion_gap_reason || "").trim().toLowerCase();
   const stopReason = String(progress?.stop_reason || progress?.run_diagnostics?.frontier_stop_reason || "").trim().toLowerCase();
+  const repairReasonCode = String(
+    progress?.repairable_reason || progress?.last_error_code || progress?.run_diagnostics?.last_error_code || "",
+  )
+    .trim()
+    .toLowerCase();
   if (runStatus === "cancelled") {
     return "Run cancelled";
   }
-  if (runStatus === "blocked_auth" || stopReason === "checkpoint_required") {
+  if (
+    runStatus === "blocked_auth" ||
+    operationalState === "blocked_auth" ||
+    stopReason === "checkpoint_required" ||
+    repairReasonCode === "instagram_graphql_checkpoint_required" ||
+    repairReasonCode === "instagram_graphql_cursor_auth_repair_required" ||
+    repairReasonCode === "instagram_graphql_cursor_forbidden" ||
+    repairReasonCode === "instagram_graphql_cursor_unauthorized" ||
+    repairReasonCode === "frontier_auth_blocked"
+  ) {
     return "Instagram auth blocked";
+  }
+  if (repairReasonCode === "run_deadline_exceeded") {
+    return "Run timed out";
   }
   if (stopReason === "pagination_doc_id_stale" || progress?.pagination_doc_id_stale) {
     return "Instagram doc ID stale";
@@ -3448,13 +3610,40 @@ const getCatalogLaunchGuardMessage = (
 ): string | null => {
   const operationalState = normalizeCatalogRunState(progress?.operational_state);
   if (operationalState === "blocked_auth") {
-    return null;
+    return "Catalog launch is blocked until the existing run's auth repair is completed or cancelled.";
   }
   const dispatchMessage = getCatalogDispatchStatusMessage(progress);
   if (dispatchMessage?.tone === "red") {
     return `Catalog launch is blocked. ${dispatchMessage.text}`;
   }
   return null;
+};
+
+const isAuthoritativeCatalogProgress = (
+  progress?: SocialAccountCatalogRunProgressSnapshot | null,
+): boolean => progress?.progress_authoritative !== false && progress?.progress_degraded !== true;
+
+const shouldReconcileCatalogLaunchError = (error: SocialAccountRequestError): boolean =>
+  error.retryable === true || [408, 429, 502, 503, 504].includes(error.upstreamStatus ?? 0);
+
+const mergeCatalogProgressUpdate = (
+  current: SocialAccountCatalogRunProgressSnapshot | null,
+  next: SocialAccountCatalogRunProgressSnapshot,
+): SocialAccountCatalogRunProgressSnapshot => {
+  if (
+    !isAuthoritativeCatalogProgress(next) &&
+    current?.run_id === next.run_id &&
+    isAuthoritativeCatalogProgress(current)
+  ) {
+    return {
+      ...current,
+      progress_authoritative: false,
+      progress_degraded: true,
+      progress_degraded_reason: next.progress_degraded_reason ?? "fast_progress_unavailable",
+      progress_degraded_at: next.progress_degraded_at ?? new Date().toISOString(),
+    };
+  }
+  return next;
 };
 
 const formatCookieHealthSourceLabel = (cookieHealth?: SocialProfileCookieHealth | null): string => {
@@ -3702,6 +3891,8 @@ const buildProvisionalCatalogRunProgress = (input: {
   run_status: normalizeCatalogRunStatus(input.status) || "queued",
   launch_group_id: input.launchGroupId ?? null,
   launch_state: input.launchState ?? null,
+  operational_state: input.launchState === "blocked_auth" ? "blocked_auth" : undefined,
+  progress_authoritative: true,
   source_scope: String(input.sourceScope || "network").trim() || "network",
   catalog_action: input.catalogAction ?? "backfill",
   catalog_action_scope: input.catalogActionScope ?? "full_history",
@@ -3765,13 +3956,19 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   const [postSearchLoading, setPostSearchLoading] = useState(false);
   const [postSearchError, setPostSearchError] = useState<string | null>(null);
   const [catalogPosts, setCatalogPosts] = useState<CatalogPostsResponse | null>(null);
+  const [catalogPostsDataRequestKey, setCatalogPostsDataRequestKey] = useState<string | null>(null);
   const [catalogPostsLoading, setCatalogPostsLoading] = useState(false);
   const [catalogPostsError, setCatalogPostsError] = useState<string | null>(null);
+  const [catalogPostsStaleNotice, setCatalogPostsStaleNotice] = useState<string | null>(null);
   const [catalogDetailSourceId, setCatalogDetailSourceId] = useState<string | null>(null);
   const [catalogDetail, setCatalogDetail] = useState<SocialAccountCatalogPostDetail | null>(null);
   const [catalogDetailLoading, setCatalogDetailLoading] = useState(false);
   const [catalogDetailError, setCatalogDetailError] = useState<string | null>(null);
   const catalogDetailRequestKeyRef = useRef<string | null>(null);
+  const catalogPostsDataRef = useRef<{ requestKey: string | null; hasItems: boolean }>({
+    requestKey: null,
+    hasItems: false,
+  });
   const [catalogCardPreview, setCatalogCardPreview] = useState<{
     total: number;
     latestPostedAt: string | null;
@@ -3791,6 +3988,11 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   const [instagramBackfillCommentsWorkerCount, setInstagramBackfillCommentsWorkerCount] = useState(
     INSTAGRAM_BACKFILL_DEFAULT_COMMENTS_WORKER_COUNT,
   );
+  const [instagramBackfillCapacity, setInstagramBackfillCapacity] = useState<InstagramCatalogCapacitySnapshot | null>(
+    null,
+  );
+  const [instagramBackfillCapacityLoading, setInstagramBackfillCapacityLoading] = useState(false);
+  const [instagramBackfillCapacityUnavailable, setInstagramBackfillCapacityUnavailable] = useState(false);
   const [instagramBackfillCommentMediaFollowups, setInstagramBackfillCommentMediaFollowups] = useState(false);
   const [instagramBackfillMonthStart, setInstagramBackfillMonthStart] = useState(
     () => buildInstagramBackfillMonthDefaults().monthStart,
@@ -4029,6 +4231,9 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   const hashtagsRequestKey = `hashtags:${platform}:${handle}:${hashtagWindow}:${hashtagAssignmentStatus}`;
   const hashtagTimelineRequestKey = `hashtags-timeline:${platform}:${handle}:${hashtagWindow}`;
   const collaboratorsRequestKey = `collaborators-tags:${platform}:${handle}`;
+  const activeCatalogPostsRequestKey = `catalog:${platform}:${handle}:${catalogFilter}:${catalogPage}`;
+  const hasActiveCatalogPostsData = catalogPostsDataRequestKey === activeCatalogPostsRequestKey && catalogPosts !== null;
+  const shouldRenderCatalogStaleCards = hasActiveCatalogPostsData && (catalogPosts?.items.length ?? 0) > 0;
   const selectedTabPrimaryReadActive =
     (selectedTab === "posts" && postsLoading) ||
     (selectedTab === "catalog" && catalogPostsLoading) ||
@@ -4039,7 +4244,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     !summaryUninitialized &&
     (
       (selectedTab === "posts" && !posts && !postsError) ||
-      (selectedTab === "catalog" && supportsCatalog && !catalogPosts && !catalogPostsError) ||
+      (selectedTab === "catalog" && supportsCatalog && !hasActiveCatalogPostsData && !catalogPostsError) ||
       (selectedTab === "hashtags" &&
         (
           hashtagsLoadedRequestKey !== hashtagsRequestKey ||
@@ -4204,8 +4409,11 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     setPostsLoading(false);
     setPostsError(null);
     setCatalogPosts(null);
+    setCatalogPostsDataRequestKey(null);
     setCatalogPostsLoading(false);
     setCatalogPostsError(null);
+    setCatalogPostsStaleNotice(null);
+    catalogPostsDataRef.current = { requestKey: null, hasItems: false };
     setCatalogCardPreview(null);
     setReviewQueue([]);
     setReviewQueueLoading(false);
@@ -4556,10 +4764,12 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       });
       applyProfileSnapshotSummary(snapshot.payload);
       if (snapshot.payload.catalog_run_progress) {
-        setCatalogProgressSaturationActive(false);
-        setCatalogRunProgress(snapshot.payload.catalog_run_progress);
+        setCatalogProgressSaturationActive(!isAuthoritativeCatalogProgress(snapshot.payload.catalog_run_progress));
+        setCatalogRunProgress((current) => mergeCatalogProgressUpdate(current, snapshot.payload.catalog_run_progress!));
         setCatalogRunProgressError(null);
-        setCatalogProgressLastSuccessAt(snapshot.payload.generated_at ?? new Date().toISOString());
+        if (isAuthoritativeCatalogProgress(snapshot.payload.catalog_run_progress)) {
+          setCatalogProgressLastSuccessAt(snapshot.payload.generated_at ?? new Date().toISOString());
+        }
         setCatalogRunProgressLoading(false);
       }
       return snapshot;
@@ -4620,7 +4830,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
           preferredUser: user,
           fast: true,
         });
-        setCatalogRunProgress(data);
+        setCatalogRunProgress((current) => mergeCatalogProgressUpdate(current, data));
         setCatalogRunProgressError(null);
         setCatalogProgressLastSuccessAt(new Date().toISOString());
         if (normalizeCatalogRunStatus(data.run_status) === "cancelled") {
@@ -4744,7 +4954,9 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
           }
         }
         if (snapshot.payload.catalog_run_progress) {
-          setCatalogRunProgress(snapshot.payload.catalog_run_progress);
+          setCatalogRunProgress((current) =>
+            mergeCatalogProgressUpdate(current, snapshot.payload.catalog_run_progress!),
+          );
           setCatalogRunProgressError(null);
           setCatalogProgressLastSuccessAt(snapshot.payload.generated_at ?? new Date().toISOString());
         }
@@ -5032,33 +5244,80 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       return;
     }
     let cancelled = false;
+    let retryTimeoutId: number | null = null;
+
+    const clearPendingRetry = () => {
+      if (retryTimeoutId !== null) {
+        window.clearTimeout(retryTimeoutId);
+        retryTimeoutId = null;
+      }
+    };
 
     const loadCatalogPosts = async () => {
+      const maxClientRetries = 1;
       setCatalogPostsLoading(true);
       setCatalogPostsError(null);
+      setCatalogPostsStaleNotice(null);
       try {
-        const query = new URLSearchParams({
-          page: String(catalogPage),
-          page_size: "25",
-        });
-        if (catalogFilter !== "all") {
-          query.set("assignment_status", catalogFilter);
+        let retryAttempt = 0;
+
+        while (!cancelled) {
+          try {
+            const query = new URLSearchParams({
+              page: String(catalogPage),
+              page_size: "25",
+            });
+            if (catalogFilter !== "all") {
+              query.set("assignment_status", catalogFilter);
+            }
+            const response = await fetchAdminWithAuth(
+              `/api/admin/trr-api/social/profiles/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/catalog/posts?${query.toString()}`,
+              undefined,
+              { preferredUser: user },
+            );
+            const data = (await response.json().catch(() => ({}))) as Partial<CatalogPostsResponse> & ProxyErrorPayload;
+            if (!response.ok) {
+              throw buildSocialAccountRequestError(data, "Failed to load social account catalog posts");
+            }
+            if (cancelled) return;
+            const normalized = normalizeCatalogPostsResponse(data, catalogPage, 25);
+            catalogPostsDataRef.current = {
+              requestKey: activeCatalogPostsRequestKey,
+              hasItems: normalized.items.length > 0,
+            };
+            setCatalogPosts(normalized);
+            setCatalogPostsDataRequestKey(activeCatalogPostsRequestKey);
+            setCatalogPostsStaleNotice(null);
+            return;
+          } catch (error) {
+            if (cancelled) return;
+            const requestError = toSocialAccountRequestError(error, "Failed to load social account catalog posts");
+            const canRenderStaleCards =
+              catalogPostsDataRef.current.requestKey === activeCatalogPostsRequestKey && catalogPostsDataRef.current.hasItems;
+            if (requestError.retryable && retryAttempt < maxClientRetries) {
+              retryAttempt += 1;
+              if (canRenderStaleCards) {
+                setCatalogPostsStaleNotice("Catalog refresh is retrying. Showing last saved catalog cards.");
+              }
+              const retryDelayMs = resolveCatalogRequestBackoffMs(requestError, retryAttempt);
+              await new Promise<void>((resolve) => {
+                retryTimeoutId = window.setTimeout(() => {
+                  retryTimeoutId = null;
+                  resolve();
+                }, retryDelayMs);
+              });
+              continue;
+            }
+            if (canRenderStaleCards) {
+              setCatalogPostsStaleNotice("Catalog refresh failed. Showing last saved catalog cards.");
+              return;
+            }
+            setCatalogPostsError(formatCatalogGalleryErrorMessage(requestError));
+            return;
+          }
         }
-        const response = await fetchAdminWithAuth(
-          `/api/admin/trr-api/social/profiles/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/catalog/posts?${query.toString()}`,
-          undefined,
-          { preferredUser: user },
-        );
-        const data = (await response.json().catch(() => ({}))) as Partial<CatalogPostsResponse> & ProxyErrorPayload;
-        if (!response.ok) {
-          throw buildSocialAccountRequestError(data, "Failed to load social account catalog posts");
-        }
-        if (cancelled) return;
-        setCatalogPosts(normalizeCatalogPostsResponse(data, catalogPage, 25));
-      } catch (error) {
-        if (cancelled) return;
-        setCatalogPostsError(formatCatalogGalleryErrorMessage(error));
       } finally {
+        clearPendingRetry();
         if (!cancelled) setCatalogPostsLoading(false);
       }
     };
@@ -5066,8 +5325,10 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     void loadCatalogPosts();
     return () => {
       cancelled = true;
+      clearPendingRetry();
     };
   }, [
+    activeCatalogPostsRequestKey,
     catalogFilter,
     catalogPage,
     checking,
@@ -5819,7 +6080,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
         const requestError = toSocialAccountRequestError(error, "Failed to fetch social account catalog gap analysis");
         if (requestError.retryable) {
           saturationAttempt += 1;
-          scheduleNextPoll(resolveCatalogGapAnalysisBackoffMs(requestError, saturationAttempt));
+          scheduleNextPoll(resolveCatalogRequestBackoffMs(requestError, saturationAttempt));
           return;
         }
         setCatalogGapAnalysisStatus("failed");
@@ -6042,7 +6303,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
         const progress = await fetchCatalogRunProgressSnapshot(normalizedDisplayedRunId);
         if (cancelled) return;
         setCatalogProgressSaturationActive(false);
-        setCatalogRunProgress(progress);
+        setCatalogRunProgress((current) => mergeCatalogProgressUpdate(current, progress));
         setCatalogRunProgressError(null);
         setCatalogProgressLastSuccessAt(new Date().toISOString());
         return;
@@ -6058,7 +6319,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       if (cancelled) return;
       if (!progress) return;
       setCatalogProgressSaturationActive(false);
-      setCatalogRunProgress(progress);
+      setCatalogRunProgress((current) => mergeCatalogProgressUpdate(current, progress));
       setCatalogRunProgressError(null);
       setCatalogProgressLastSuccessAt(snapshot.payload.generated_at ?? new Date().toISOString());
     })()
@@ -6553,9 +6814,19 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     !instagramCookiePayloadStatusCopy;
   const showCookieHealthError = Boolean(cookieHealthError) && !cookieHealth;
 
+  const catalogProgressRequiresReconciliation = useMemo(() => {
+    const trackedRunId = String(backgroundCatalogRunId || "").trim();
+    return Boolean(
+      trackedRunId &&
+        catalogRunProgress?.run_id === trackedRunId &&
+        !isAuthoritativeCatalogProgress(catalogRunProgress),
+    );
+  }, [backgroundCatalogRunId, catalogRunProgress]);
+
   const catalogActionsBlocked =
     runningCatalogAction !== null ||
     cancellingCatalogRun ||
+    catalogProgressRequiresReconciliation ||
     activeCatalogRunBlocksActions ||
     cancellableCatalogRunIsActive ||
     activeCommentsRunBlocksActions;
@@ -6563,6 +6834,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   const catalogLaunchActionsBlocked =
     runningCatalogAction !== null ||
     cancellingCatalogRun ||
+    catalogProgressRequiresReconciliation ||
     activeCatalogRunBlocksActions ||
     cancellableCatalogRunIsActive ||
     activeCommentsRunBlocksActions ||
@@ -6736,16 +7008,32 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     return getCatalogRunDisplayStatusLabel(displayedCatalogRunStatus, catalogRunProgress);
   }, [catalogRunProgress, displayedCatalogRunStatus]);
   const catalogBlockedAuthPresentation = useMemo(() => {
-    if (String(catalogRunProgress?.operational_state || "").trim().toLowerCase() !== "blocked_auth") {
-      return null;
-    }
+    const operationalState = String(catalogRunProgress?.operational_state || "").trim().toLowerCase();
+    const launchState = String(catalogRunProgress?.launch_state || "").trim().toLowerCase();
     const repairAction = catalogRunProgress?.repair_action;
     const repairStatus = String(catalogRunProgress?.repair_status || "").trim().toLowerCase();
     const resumeStage = String(catalogRunProgress?.resume_stage || "").trim().toLowerCase();
-    const repairReason = String(catalogRunProgress?.repairable_reason || "").trim().replaceAll("_", " ");
-    const repairCommand = String(catalogRunProgress?.repair_environment?.repair_command || "").trim();
+    const repairReasonCode = String(catalogRunProgress?.repairable_reason || "").trim().toLowerCase();
+    const fallbackReasonCode = String(
+      catalogRunProgress?.last_error_code || catalogRunProgress?.run_diagnostics?.last_error_code || "",
+    )
+      .trim()
+      .toLowerCase();
+    const presentationReasonCode = repairReasonCode || fallbackReasonCode;
     const liveBlockedRunId = String(catalogRunProgress?.run_id || "").trim();
     const displayedRunId = String(displayedCatalogRunId || "").trim();
+    const displayedRunMatchesLoadedProgress = Boolean(
+      liveBlockedRunId && displayedRunId && displayedRunId === liveBlockedRunId,
+    );
+    const displayedTerminalRepairableRun =
+      displayedRunMatchesLoadedProgress &&
+      TERMINAL_CATALOG_RUN_STATUSES.has(displayedCatalogRunStatus) &&
+      Boolean(repairAction) &&
+      (launchState === "blocked_auth" || CATALOG_REPAIRABLE_OPERATOR_REASON_CODES.has(presentationReasonCode));
+    if (operationalState !== "blocked_auth" && !displayedTerminalRepairableRun) {
+      return null;
+    }
+    const repairCommand = String(catalogRunProgress?.repair_environment?.repair_command || "").trim();
     const displayedRunDiffersFromLiveBlockedRun = Boolean(
       liveBlockedRunId && displayedRunId && displayedRunId !== liveBlockedRunId,
     );
@@ -6754,6 +7042,13 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     const platformLabel = SOCIAL_ACCOUNT_PLATFORM_LABELS[platform];
     const repairRunId = liveBlockedRunId || null;
     const repairButtonLabel = repairAction === "repair_instagram_auth" ? "Sync Validated Cookies" : "Refresh Cookies";
+    const repairReasonLabel = formatCatalogOperatorReasonLabel(presentationReasonCode);
+    const repairReason =
+      repairReasonLabel && presentationReasonCode
+        ? repairReasonLabel === formatDiagnosticToken(presentationReasonCode)
+          ? repairReasonLabel
+          : `${repairReasonLabel} (${presentationReasonCode})`
+        : repairReasonLabel;
     const resumeLabel =
       resumeStage === "posts"
         ? "Manual auth checked, resuming from saved frontier."
@@ -6783,11 +7078,15 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
           resumeLabel
         : canRepair ?
           repairAction === "repair_instagram_auth" ?
-            "Instagram blocked this catalog run before jobs were queued. Complete manual auth first, then sync already validated cookies."
+            presentationReasonCode === "instagram_graphql_checkpoint_required" ?
+              "Finish the Instagram checkpoint first, then sync already validated cookies for this run."
+            : presentationReasonCode === "run_deadline_exceeded" ?
+              "This run timed out while Instagram auth still needed repair. Re-check manual auth, then sync already validated cookies for this run."
+            : "Complete Instagram manual auth first, then sync already validated cookies for this run."
           : `${platformLabel} cookies must be refreshed before this catalog run can continue. A local headed Chrome window will open for confirmation.`
         : `${platformLabel} auth must be completed manually before this catalog run can continue.`,
     };
-  }, [catalogRunProgress, displayedCatalogRunId, platform]);
+  }, [catalogRunProgress, displayedCatalogRunId, displayedCatalogRunStatus, platform]);
   const catalogAlertCodes = useMemo(() => {
     return new Set(
       (catalogRunProgress?.alerts ?? [])
@@ -7069,6 +7368,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
         (
           !catalogRunProgress ||
           catalogRunProgress.run_id !== backgroundCatalogRunId ||
+          !isAuthoritativeCatalogProgress(catalogRunProgress) ||
           ["pending", "finalizing"].includes(String(catalogRunProgress.launch_state || "").trim().toLowerCase())
         )
       ));
@@ -7130,10 +7430,13 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       setDashboardFreshness(payload.dashboard_freshness);
     }
     if (payload.catalog_run_progress) {
-      setCatalogProgressSaturationActive(false);
-      setCatalogRunProgress(payload.catalog_run_progress);
+      const authoritative = isAuthoritativeCatalogProgress(payload.catalog_run_progress);
+      setCatalogProgressSaturationActive(!authoritative);
+      setCatalogRunProgress((current) => mergeCatalogProgressUpdate(current, payload.catalog_run_progress!));
       setCatalogRunProgressError(null);
-      setCatalogProgressLastSuccessAt(payload.generated_at ?? new Date().toISOString());
+      if (authoritative) {
+        setCatalogProgressLastSuccessAt(payload.generated_at ?? new Date().toISOString());
+      }
       setCatalogRunProgressLoading(false);
     }
   }, [applyProfileSnapshotSummary, liveProfileSnapshot.data]);
@@ -7160,7 +7463,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   useEffect(() => {
     const runId = String(catalogRunProgress?.run_id || "").trim();
     const runStatus = String(catalogRunProgress?.run_status || "").trim().toLowerCase();
-    if (catalogProgressSaturationActive) return;
+    if (catalogProgressSaturationActive || !isAuthoritativeCatalogProgress(catalogRunProgress)) return;
     if (!runId || !TERMINAL_CATALOG_RUN_STATUSES.has(runStatus)) return;
     storeCatalogProgressRunId(catalogProgressStorageKey, null);
     if (catalogTerminalSummaryRefreshRunIdRef.current === runId) return;
@@ -7171,6 +7474,8 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     catalogProgressStorageKey,
     catalogRunProgress?.run_id,
     catalogRunProgress?.run_status,
+    catalogRunProgress?.progress_authoritative,
+    catalogRunProgress?.progress_degraded,
     refreshSummary,
   ]);
 
@@ -7424,6 +7729,20 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   );
   const catalogLaneSummaryLabel = getCatalogLaneSummaryLabel(displayedCatalogRunStatus, catalogAllLanesComplete);
   const catalogLaneSummaryTone = getCatalogLaneSummaryTone(displayedCatalogRunStatus, catalogAllLanesComplete);
+  const browserLiveStatusRunIds = useMemo(() => {
+    const seen = new Set<string>();
+    const rows: { key: string; label: string; value: string }[] = [];
+    const append = (key: string, label: string, value?: string | null) => {
+      const normalized = String(value || "").trim();
+      if (!normalized || seen.has(normalized)) return;
+      seen.add(normalized);
+      rows.push({ key, label, value: normalized });
+    };
+    append("catalog-active", "Active catalog run", activeCatalogRunId);
+    append("catalog-displayed", "Displayed catalog run", displayedCatalogRunId);
+    append("comments-active", "Active comments run", activeCommentsRunId);
+    return rows;
+  }, [activeCatalogRunId, activeCommentsRunId, displayedCatalogRunId]);
 
   const catalogTerminalCoverageMessage = useMemo(() => {
     if (catalogProgressMode !== "coverage") return null;
@@ -7529,7 +7848,10 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     }
     const lastErrorCode = String(catalogRunProgress?.last_error_code || catalogRunDiagnostics?.last_error_code || "").trim();
     if (lastErrorCode) {
-      return `Run error code: ${formatDiagnosticToken(lastErrorCode)}.`;
+      const errorLabel = formatCatalogOperatorReasonLabel(lastErrorCode);
+      return errorLabel === formatDiagnosticToken(lastErrorCode)
+        ? `Run error code: ${errorLabel}.`
+        : `Run error: ${errorLabel} (${lastErrorCode}).`;
     }
     return null;
   }, [
@@ -8774,6 +9096,24 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
         const queuedRunId = String(data.run_id || "").trim() || null;
         const catalogRunId = String(data.catalog_run_id || "").trim() || queuedRunId;
         const commentsRunId = String(data.comments_run_id || "").trim() || null;
+        const attachedFollowups = data.attached_followups ?? null;
+        const attachedComments = attachedFollowups?.comments ?? null;
+        const commentsReusedExistingRun =
+          action === "backfill" &&
+          platform === "instagram" &&
+          (Boolean(data.comments_reused_existing_run) || attachedComments?.source === "reused_run");
+        if (commentsReusedExistingRun) {
+          throw buildSocialAccountRequestError(
+            {
+              code: "SOCIAL_ACCOUNT_COMMENTS_RUN_REUSED",
+              error: commentsRunId
+                ? `Backfill reused existing comments run ${shortRunId(commentsRunId)}. Cancel the active run and launch fresh.`
+                : "Backfill reused an existing comments run. Cancel the active run and launch fresh.",
+              retryable: true,
+            },
+            "Backfill reused an existing comments run.",
+          );
+        }
         const commentsDeferredUntilCatalogComplete =
           action === "backfill" &&
           platform === "instagram" &&
@@ -8832,8 +9172,6 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
             Boolean(data.requires_apply_confirmation) &&
             Boolean(liveApplyRunId) &&
             Boolean(requiredLiveApplyConfirmation);
-          const attachedFollowups = data.attached_followups ?? null;
-          const attachedComments = attachedFollowups?.comments ?? null;
           const attachedMedia = attachedFollowups?.media ?? null;
           const commentsSourceLabel = formatAttachedLaneSourceLabel(attachedComments?.source);
           const launchParts = [
@@ -8930,6 +9268,19 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
             : "sync recent catalog content"
           }`,
         );
+        if (
+          requestError.code !== "SOCIAL_ACCOUNT_COMMENTS_RUN_REUSED" &&
+          shouldReconcileCatalogLaunchError(requestError)
+        ) {
+          const snapshot = await refreshProfileSnapshotNow().catch(() => null);
+          const reconciledRunId = String(snapshot?.payload.catalog_run_progress?.run_id || "").trim();
+          if (reconciledRunId) {
+            setCatalogActionMessage(
+              `Launch response was interrupted. Reconciled existing run ${shortRunId(reconciledRunId)}; wait for its status before retrying.`,
+            );
+            return;
+          }
+        }
         setCatalogActionMessage(formatCatalogActionErrorMessage(action, requestError));
       } finally {
         setRunningCatalogAction(null);
@@ -9140,8 +9491,57 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     );
   }, []);
 
+  const refreshInstagramBackfillCapacity = useCallback(
+    async (signal?: AbortSignal): Promise<InstagramCatalogCapacitySnapshot | null> => {
+      setInstagramBackfillCapacity(null);
+      setInstagramBackfillCapacityLoading(true);
+      setInstagramBackfillCapacityUnavailable(false);
+      try {
+        const query = buildInstagramCatalogCapacityQuery({
+          selectedTasks: instagramBackfillSelectedTasks,
+          detailWorkerCount: instagramBackfillDetailWorkerCount,
+          commentsWorkerCount: instagramBackfillCommentsWorkerCount,
+        });
+        const response = await fetchAdminWithAuth(
+          `/api/admin/trr-api/social/profiles/${encodeURIComponent(platform)}/${encodeURIComponent(handle)}/catalog/capacity?${query.toString()}`,
+          { cache: "no-store", signal },
+        );
+        const payload = (await response.json().catch(() => ({}))) as ProxyErrorPayload & Record<string, unknown>;
+        if (!response.ok) throw new Error(payload.error || "Capacity request failed");
+        const snapshot = normalizeInstagramCatalogCapacity(payload);
+        if (!snapshot) throw new Error("Capacity response was incomplete");
+        if (signal?.aborted) return null;
+        setInstagramBackfillCapacity(snapshot);
+        return snapshot;
+      } catch {
+        if (signal?.aborted) return null;
+        setInstagramBackfillCapacityUnavailable(true);
+        return null;
+      } finally {
+        if (!signal?.aborted) setInstagramBackfillCapacityLoading(false);
+      }
+    },
+    [
+      fetchAdminWithAuth,
+      handle,
+      instagramBackfillCommentsWorkerCount,
+      instagramBackfillDetailWorkerCount,
+      instagramBackfillSelectedTasks,
+      platform,
+    ],
+  );
+
+  useEffect(() => {
+    if (!instagramBackfillDialogOpen) return;
+    const controller = new AbortController();
+    void refreshInstagramBackfillCapacity(controller.signal);
+    return () => controller.abort();
+  }, [instagramBackfillDialogOpen, refreshInstagramBackfillCapacity]);
+
   const openInstagramBackfillDialog = useCallback(() => {
     const defaultWindow = buildInstagramBackfillMonthDefaults();
+    setInstagramBackfillCapacity(null);
+    setInstagramBackfillCapacityUnavailable(false);
     setInstagramBackfillSelectedTasks([...INSTAGRAM_BACKFILL_DEFAULT_SELECTED_TASKS]);
     setInstagramBackfillDetailWorkerCount(getDefaultInstagramBackfillDetailWorkerCount(handle));
     setInstagramBackfillCommentsWorkerCount(getDefaultInstagramBackfillCommentsWorkerCount(handle));
@@ -9176,6 +9576,11 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       setCatalogActionMessage("Choose an Instagram backfill end month that is on or after the start month.");
       return;
     }
+    const capacity = await refreshInstagramBackfillCapacity();
+    if (capacity?.blocked) {
+      setCatalogActionMessage(describeInstagramCatalogCapacity(capacity).warning);
+      return;
+    }
     setInstagramBackfillDialogOpen(false);
     await runCatalogAction(
       "backfill",
@@ -9196,6 +9601,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     instagramBackfillMonthStart,
     instagramBackfillDetailWorkerCount,
     instagramBackfillSelectedTasks,
+    refreshInstagramBackfillCapacity,
     runCatalogAction,
   ]);
 
@@ -9516,6 +9922,15 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   const cancelCatalogRun = async (overrideRunId?: string | null) => {
     const runId = String(overrideRunId || cancellableCatalogRunId || "").trim();
     if (!user || !runId) return;
+    const confirmed =
+      typeof window === "undefined" ||
+      window.confirm(
+        [
+          `Cancel catalog run ${shortRunId(runId)}?`,
+          "Queued work will stop. A worker that already claimed a job may finish its current save; wait for cancellation confirmation before starting a new backfill.",
+        ].join("\n\n"),
+      );
+    if (!confirmed) return;
     setCancellingCatalogRun(true);
     setCatalogActionMessage(null);
     try {
@@ -9923,12 +10338,12 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
   );
   const instagramBackfillDetailMinutes = estimateInstagramBackfillMinutes(
     instagramBackfillEstimatedPostTargets || null,
-    instagramBackfillDetailWorkerCount,
+    instagramBackfillCapacity?.effective_details_worker_count ?? instagramBackfillDetailWorkerCount,
     30,
   );
   const instagramBackfillCommentsMinutes = estimateInstagramBackfillMinutes(
     instagramBackfillEstimatedCommentTargets || instagramBackfillEstimatedPostTargets || null,
-    instagramBackfillCommentsWorkerCount,
+    instagramBackfillCapacity?.effective_comments_worker_count ?? instagramBackfillCommentsWorkerCount,
     0.4,
   );
   const instagramBackfillEstimatedWallSeconds =
@@ -9937,16 +10352,43 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       instagramBackfillIncludesComments ? instagramBackfillCommentsMinutes ?? 0 : 0,
     ) * 60;
   const instagramBackfillEstimatedWorkerMinutes =
-    (instagramBackfillIncludesDetails ? (instagramBackfillDetailMinutes ?? 0) * instagramBackfillDetailWorkerCount : 0) +
-    (instagramBackfillIncludesComments ? (instagramBackfillCommentsMinutes ?? 0) * instagramBackfillCommentsWorkerCount : 0);
+    (instagramBackfillIncludesDetails
+      ? (instagramBackfillDetailMinutes ?? 0) *
+        (instagramBackfillCapacity?.effective_details_worker_count ?? instagramBackfillDetailWorkerCount)
+      : 0) +
+    (instagramBackfillIncludesComments
+      ? (instagramBackfillCommentsMinutes ?? 0) *
+        (instagramBackfillCapacity?.effective_comments_worker_count ?? instagramBackfillCommentsWorkerCount)
+      : 0);
+  const instagramBackfillCapacityPresentation = describeInstagramCatalogCapacity(
+    instagramBackfillCapacity,
+    instagramBackfillCapacityUnavailable,
+  );
+  const instagramBackfillDisplayedDetailWorkers = instagramBackfillCapacity?.effective_details_worker_count;
+  const instagramBackfillDisplayedCommentsWorkers = instagramBackfillCapacity?.effective_comments_worker_count;
   const instagramBackfillPreflightItems = [
-    instagramBackfillIncludesDetails ? `${instagramBackfillDetailWorkerCount} detail workers` : "Details skipped",
+    instagramBackfillIncludesDetails
+      ? `${formatInteger(instagramBackfillDisplayedDetailWorkers ?? instagramBackfillDetailWorkerCount)} detail workers${
+          instagramBackfillDisplayedDetailWorkers != null &&
+          instagramBackfillDisplayedDetailWorkers !== instagramBackfillDetailWorkerCount
+            ? ` effective · ${formatInteger(instagramBackfillDetailWorkerCount)} requested`
+            : ""
+        }`
+      : "Details skipped",
     instagramBackfillIncludesComments
-      ? `${instagramBackfillCommentsWorkerCount} comments workers`
+      ? `${formatInteger(instagramBackfillDisplayedCommentsWorkers ?? instagramBackfillCommentsWorkerCount)} comments workers${
+          instagramBackfillDisplayedCommentsWorkers != null &&
+          instagramBackfillDisplayedCommentsWorkers !== instagramBackfillCommentsWorkerCount
+            ? ` effective · ${formatInteger(instagramBackfillCommentsWorkerCount)} requested`
+            : ""
+        }`
       : "Comments skipped",
     instagramBackfillIncludesMedia ? "Post media enabled" : "Post media skipped",
     instagramBackfillCommentMediaEnabled ? "Comment media enabled" : "Comment media skipped",
-  ];
+    instagramBackfillCapacity
+      ? `DB-safe combined limit ${formatInteger(instagramBackfillCapacity.safe_combined_worker_limit)} · ${formatInteger(instagramBackfillCapacity.remaining_workers)} remaining`
+      : null,
+  ].filter((item): item is string => Boolean(item));
   const handleInstagramCommentsCoverageMetricsChange = useCallback(
     (metrics: { availablePosts: number; commentablePosts: number; incompletePosts: number | null }) => {
       setInstagramCommentsCoverageMetrics((current) => {
@@ -10485,7 +10927,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                           <div className="flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between">
                             <div>
                               <p className="text-xs font-semibold uppercase tracking-[0.14em] text-emerald-800">
-                                Comments Are Streaming From Saved Catalog Posts
+                                {commentsStreamingBanner.titleLabel}
                               </p>
                               <p className="mt-1 max-w-3xl text-xs">{commentsStreamingBanner.detail}</p>
                             </div>
@@ -11240,6 +11682,19 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                   @{handle}
                 </span>
               </div>
+              {browserLiveStatusRunIds.length > 0 ? (
+                <div className="mt-4 flex flex-wrap gap-2" aria-label="Active catalog run ids">
+                  {browserLiveStatusRunIds.map((row) => (
+                    <span
+                      key={row.key}
+                      className="inline-flex max-w-full flex-wrap items-center gap-1 rounded-lg border border-zinc-200 bg-zinc-50 px-2.5 py-1 text-xs text-zinc-700"
+                    >
+                      <span className="font-semibold text-zinc-500">{row.label}</span>
+                      <span className="break-all font-mono text-[11px] text-zinc-900">{row.value}</span>
+                    </span>
+                  ))}
+                </div>
+              ) : null}
               {instagramPipelineTruthRows.length > 0 ? (
                 <div className="mt-4 grid gap-3 lg:grid-cols-2">
                   {instagramPipelineTruthRows.map((row) => (
@@ -12038,9 +12493,20 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                       ))}
                     </div>
                   </div>
-                  {catalogPostsLoading ? <p className="mt-4 text-sm text-zinc-500">Loading catalog posts…</p> : null}
-                  {catalogPostsError ? <p className="mt-4 text-sm text-red-700">{catalogPostsError}</p> : null}
-                  {!catalogPostsLoading && !catalogPostsError ? (
+                  {catalogPostsLoading && !hasActiveCatalogPostsData ? (
+                    <p className="mt-4 text-sm text-zinc-500">Loading catalog posts…</p>
+                  ) : null}
+                  {catalogPostsStaleNotice && shouldRenderCatalogStaleCards ? (
+                    <div
+                      className="mt-4 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-medium text-amber-800"
+                      role="status"
+                      aria-live="polite"
+                    >
+                      {catalogPostsStaleNotice}
+                    </div>
+                  ) : null}
+                  {catalogPostsError && !hasActiveCatalogPostsData ? <p className="mt-4 text-sm text-red-700">{catalogPostsError}</p> : null}
+                  {hasActiveCatalogPostsData || (!catalogPostsLoading && !catalogPostsError && catalogPostsDataRequestKey === activeCatalogPostsRequestKey) ? (
                     <>
                       {(catalogPosts?.items ?? []).length === 0 ? (
                         <div className="mt-4 rounded-xl border border-dashed border-zinc-200 bg-zinc-50 px-4 py-6 text-sm text-zinc-500">
@@ -12945,7 +13411,9 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                       <input
                         type="month"
                         value={instagramBackfillMonthStart}
+                        aria-label="Instagram backfill start month"
                         onChange={(event) => setInstagramBackfillMonthStart(event.currentTarget.value)}
+                        onInput={(event) => setInstagramBackfillMonthStart(event.currentTarget.value)}
                         className="mt-1 w-full rounded-xl border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 shadow-sm focus:border-zinc-900 focus:outline-none focus:ring-1 focus:ring-zinc-900"
                       />
                     </label>
@@ -12956,7 +13424,9 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                       <input
                         type="month"
                         value={instagramBackfillMonthEnd}
+                        aria-label="Instagram backfill end month"
                         onChange={(event) => setInstagramBackfillMonthEnd(event.currentTarget.value)}
+                        onInput={(event) => setInstagramBackfillMonthEnd(event.currentTarget.value)}
                         className="mt-1 w-full rounded-xl border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 shadow-sm focus:border-zinc-900 focus:outline-none focus:ring-1 focus:ring-zinc-900"
                       />
                     </label>
@@ -12972,8 +13442,9 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                       <div>
                         <p className="font-semibold text-zinc-900">Detail Workers</p>
                         <p className="mt-1 text-sm text-zinc-500">
-                          {instagramBackfillDetailWorkerCount} parallel detail{" "}
-                          {instagramBackfillDetailWorkerCount === 1 ? "worker" : "workers"}
+                          {instagramBackfillDisplayedDetailWorkers != null
+                            ? `${formatInteger(instagramBackfillDisplayedDetailWorkers)} backend-effective · ${formatInteger(instagramBackfillDetailWorkerCount)} requested`
+                            : `${instagramBackfillDetailWorkerCount} requested detail ${instagramBackfillDetailWorkerCount === 1 ? "worker" : "workers"}`}
                         </p>
                       </div>
                       {normalizeComparable(handle) === "bravotv" ? (
@@ -13017,8 +13488,9 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                       <div>
                         <p className="font-semibold text-zinc-900">Comments Workers</p>
                         <p className="mt-1 text-sm text-zinc-500">
-                          {instagramBackfillCommentsWorkerCount} parallel comments{" "}
-                          {instagramBackfillCommentsWorkerCount === 1 ? "worker" : "workers"}
+                          {instagramBackfillDisplayedCommentsWorkers != null
+                            ? `${formatInteger(instagramBackfillDisplayedCommentsWorkers)} backend-effective · ${formatInteger(instagramBackfillCommentsWorkerCount)} requested`
+                            : `${instagramBackfillCommentsWorkerCount} requested comments ${instagramBackfillCommentsWorkerCount === 1 ? "worker" : "workers"}`}
                         </p>
                       </div>
                       {normalizeComparable(handle) === "bravotv" ? (
@@ -13071,6 +13543,26 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                     </label>
                   </div>
                 ) : null}
+                <div className="mt-4 rounded-2xl border border-zinc-200 bg-white px-4 py-4" aria-live="polite">
+                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-zinc-600">Current Capacity</p>
+                  {instagramBackfillCapacityLoading ? (
+                    <p className="mt-2 text-sm text-zinc-500">Checking current worker capacity…</p>
+                  ) : instagramBackfillCapacityPresentation.summary ? (
+                    <p className="mt-2 text-sm font-semibold text-zinc-900">
+                      {instagramBackfillCapacityPresentation.summary}
+                    </p>
+                  ) : null}
+                  {instagramBackfillCapacityPresentation.warning ? (
+                    <p
+                      className={`mt-2 text-sm font-semibold ${
+                        instagramBackfillCapacityPresentation.blocked ? "text-red-700" : "text-amber-700"
+                      }`}
+                      role={instagramBackfillCapacityPresentation.blocked ? "alert" : "status"}
+                    >
+                      {instagramBackfillCapacityPresentation.warning}
+                    </p>
+                  ) : null}
+                </div>
                 <div className="mt-4 rounded-2xl border border-sky-100 bg-sky-50 px-4 py-4">
                   <p className="text-xs font-semibold uppercase tracking-[0.14em] text-sky-700">
                     Conservative Full-Depth Estimate
@@ -13102,17 +13594,30 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                           instagramBackfillMonthEnd ? formatMonthYear(instagramBackfillMonthEnd) : "open end"
                         } · ${instagramBackfillSelectedTasks.map((task) => formatBackfillTaskLabel(task)).join(", ")}${
                           instagramBackfillSelectedTasks.includes("post_details")
-                            ? ` · ${instagramBackfillDetailWorkerCount} detail workers`
+                            ? ` · ${formatInteger(instagramBackfillDisplayedDetailWorkers ?? instagramBackfillDetailWorkerCount)} detail workers${
+                                instagramBackfillDisplayedDetailWorkers != null &&
+                                instagramBackfillDisplayedDetailWorkers !== instagramBackfillDetailWorkerCount
+                                  ? ` effective (${formatInteger(instagramBackfillDetailWorkerCount)} requested)`
+                                  : ""
+                              }`
                             : ""
                         }${
                           instagramBackfillSelectedTasks.includes("comments")
-                            ? ` · ${instagramBackfillCommentsWorkerCount} comments workers`
+                            ? ` · ${formatInteger(instagramBackfillDisplayedCommentsWorkers ?? instagramBackfillCommentsWorkerCount)} comments workers${
+                                instagramBackfillDisplayedCommentsWorkers != null &&
+                                instagramBackfillDisplayedCommentsWorkers !== instagramBackfillCommentsWorkerCount
+                                  ? ` effective (${formatInteger(instagramBackfillCommentsWorkerCount)} requested)`
+                                  : ""
+                              }`
                             : ""
                         }${
                           instagramBackfillCommentMediaEnabled ? " · comment media on" : ""
                         }`
                       : "Select at least one task to continue."}
                   </p>
+                  {catalogLaunchGuardMessage ? (
+                    <p className="text-xs font-semibold text-red-700 sm:max-w-sm">{catalogLaunchGuardMessage}</p>
+                  ) : null}
                   <div className="flex items-center gap-2">
                     <Button
                       onClick={() => setInstagramBackfillDialogOpen(false)}
@@ -13123,7 +13628,11 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                     </Button>
                     <Button
                       onClick={() => void submitInstagramBackfillDialog()}
-                      disabled={instagramBackfillSelectedTasks.length === 0 || catalogLaunchActionsBlocked}
+                      disabled={
+                        instagramBackfillSelectedTasks.length === 0 ||
+                        catalogLaunchActionsBlocked ||
+                        instagramBackfillCapacityPresentation.blocked
+                      }
                       variant="primary"
                       className={NYT_DASHBOARD_PRIMARY_BUTTON_CLASS}
                     >

--- a/apps/web/src/components/admin/SocialAccountProfilePage.tsx
+++ b/apps/web/src/components/admin/SocialAccountProfilePage.tsx
@@ -2211,6 +2211,29 @@ const resolveCatalogRequestBackoffMs = (
   return Math.max(error?.retryAfterMs ?? 0, exponentialDelayMs);
 };
 
+export const waitForCatalogRetry = (
+  delayMs: number,
+  signal: AbortSignal,
+): Promise<"elapsed" | "cancelled"> => {
+  if (signal.aborted) return Promise.resolve("cancelled");
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: "elapsed" | "cancelled") => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", handleAbort);
+      resolve(result);
+    };
+    const timeoutId = window.setTimeout(() => finish("elapsed"), Math.max(0, delayMs));
+    const handleAbort = () => {
+      window.clearTimeout(timeoutId);
+      finish("cancelled");
+    };
+    signal.addEventListener("abort", handleAbort, { once: true });
+  });
+};
+
 const getPostMatchBadge = (post: Pick<SocialAccountProfilePost, "match_mode" | "source_surface">): {
   label: string;
   tone: string;
@@ -5241,17 +5264,11 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
       !hasCurrentSummary ||
       summaryUninitialized
     ) {
+      setCatalogPostsLoading(false);
       return;
     }
     let cancelled = false;
-    let retryTimeoutId: number | null = null;
-
-    const clearPendingRetry = () => {
-      if (retryTimeoutId !== null) {
-        window.clearTimeout(retryTimeoutId);
-        retryTimeoutId = null;
-      }
-    };
+    const retryAbortController = new AbortController();
 
     const loadCatalogPosts = async () => {
       const maxClientRetries = 1;
@@ -5300,12 +5317,8 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
                 setCatalogPostsStaleNotice("Catalog refresh is retrying. Showing last saved catalog cards.");
               }
               const retryDelayMs = resolveCatalogRequestBackoffMs(requestError, retryAttempt);
-              await new Promise<void>((resolve) => {
-                retryTimeoutId = window.setTimeout(() => {
-                  retryTimeoutId = null;
-                  resolve();
-                }, retryDelayMs);
-              });
+              const retryWaitResult = await waitForCatalogRetry(retryDelayMs, retryAbortController.signal);
+              if (retryWaitResult === "cancelled") return;
               continue;
             }
             if (canRenderStaleCards) {
@@ -5317,7 +5330,6 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
           }
         }
       } finally {
-        clearPendingRetry();
         if (!cancelled) setCatalogPostsLoading(false);
       }
     };
@@ -5325,7 +5337,7 @@ export default function SocialAccountProfilePage({ platform, handle, activeTab }
     void loadCatalogPosts();
     return () => {
       cancelled = true;
-      clearPendingRetry();
+      retryAbortController.abort();
     };
   }, [
     activeCatalogPostsRequestKey,

--- a/apps/web/src/components/admin/cast-socialblade-comparison.tsx
+++ b/apps/web/src/components/admin/cast-socialblade-comparison.tsx
@@ -8,6 +8,10 @@ import {
   type CastComparisonWindow,
   type DailyFollowerPoint,
 } from "@/lib/admin/cast-socialblade-charting";
+import {
+  normalizeSocialBladeCookieHealth,
+  type SocialBladeCookieHealth,
+} from "@/lib/admin/socialblade-cookie-health";
 
 // ============================================================================
 // Types
@@ -131,26 +135,6 @@ interface SocialBladeHistoryItem {
   forced: boolean;
   reason: string | null;
   error: string | null;
-}
-
-interface SocialBladeCookieHealth {
-  healthy: boolean;
-  status: string;
-  reason: string | null;
-  retryable: boolean;
-  cookieNames: string[];
-  cookieFile: {
-    path: string;
-    exists: boolean;
-    modifiedAt: string | null;
-  };
-  validation: {
-    checked: boolean;
-    healthy: boolean | null;
-    reason: string | null;
-    url: string | null;
-  };
-  checkedAt: string;
 }
 
 // ============================================================================
@@ -1301,11 +1285,13 @@ export default function CastSocialBladeComparison({
         { cache: "no-store" },
         { allowDevAdminBypass: true },
       );
-      const payload = (await response.json().catch(() => ({}))) as SocialBladeCookieHealth & { error?: string };
+      const payload = (await response.json().catch(() => ({}))) as Partial<SocialBladeCookieHealth> & {
+        error?: string;
+      };
       if (!response.ok) {
         throw new Error(payload.error ?? `HTTP ${response.status}`);
       }
-      setCookieHealth(payload);
+      setCookieHealth(normalizeSocialBladeCookieHealth(payload));
       setCookieHealthError(null);
     } catch (error) {
       setCookieHealthError(error instanceof Error ? error.message : "Failed to load SocialBlade cookie health");
@@ -1718,10 +1704,20 @@ export default function CastSocialBladeComparison({
     return map;
   }, [entries, historyItems]);
   const recentHistoryItems = useMemo(() => historyItems.slice(0, 8), [historyItems]);
+  const cookieHealthReady = cookieHealth ? cookieHealth.healthy : false;
+  const cookieHealthMessage =
+    cookieHealthError ??
+    (cookieHealth
+      ? cookieHealth.reason ??
+        (cookieHealthReady ? "Authenticated SocialBlade session is usable" : "Not checked yet")
+      : "Not checked yet");
+  const cookieFileModifiedAt = cookieHealth ? cookieHealth.cookieFile.modifiedAt : null;
+  const cookieValidationReason =
+    cookieHealth && cookieHealth.validation.checked ? cookieHealth.validation.reason : null;
   const cookieHealthPanel = (
     <div
       className={`rounded-xl border px-4 py-3 text-xs shadow-sm ${
-        cookieHealth?.healthy
+        cookieHealthReady
           ? "border-emerald-200 bg-emerald-50 text-emerald-800"
           : "border-amber-200 bg-amber-50 text-amber-800"
       }`}
@@ -1731,21 +1727,15 @@ export default function CastSocialBladeComparison({
           <p className="text-[10px] font-bold uppercase tracking-[0.2em] opacity-70">Cookie Health</p>
           <div className="mt-1 flex flex-wrap items-center gap-2">
             <span className="rounded-full border border-current/20 bg-white/60 px-2 py-0.5 font-semibold">
-              {cookieHealthLoading ? "Checking" : cookieHealth?.healthy ? "Ready" : "Needs login"}
+              {cookieHealthLoading ? "Checking" : cookieHealthReady ? "Ready" : "Needs login"}
             </span>
-            <span className="min-w-0 truncate">
-              {cookieHealthError ??
-                cookieHealth?.reason ??
-                (cookieHealth?.healthy ? "Authenticated SocialBlade session is usable" : "Not checked yet")}
-            </span>
+            <span className="min-w-0 truncate">{cookieHealthMessage}</span>
           </div>
           <p className="mt-1 text-[11px] opacity-70">
-            {cookieHealth?.cookieFile.modifiedAt
-              ? `Cookie file: ${formatDateTimeLabel(cookieHealth.cookieFile.modifiedAt)}`
+            {cookieFileModifiedAt
+              ? `Cookie file: ${formatDateTimeLabel(cookieFileModifiedAt)}`
               : "Cookie file not written"}
-            {cookieHealth?.validation.checked && cookieHealth.validation.reason
-              ? ` · Validation: ${cookieHealth.validation.reason}`
-              : ""}
+            {cookieValidationReason ? ` · Validation: ${cookieValidationReason}` : ""}
           </p>
         </div>
         <button

--- a/apps/web/src/components/admin/season-social-analytics-section.tsx
+++ b/apps/web/src/components/admin/season-social-analytics-section.tsx
@@ -157,7 +157,9 @@ export type SocialTarget = {
   accounts?: string[];
   hashtags?: string[];
   keywords?: string[];
+  timezone?: string;
   is_active?: boolean;
+  config?: Record<string, unknown>;
 };
 
 type LinkedAccountProfileSummary = {
@@ -1007,6 +1009,95 @@ const formatDateShort = (value: string | null | undefined): string => {
     year: "2-digit",
     timeZone: SOCIAL_TIME_ZONE,
   });
+};
+
+const SEASON_WINDOW_PRESEASON_CONFIG_KEYS = [
+  "trailer_drop_at",
+  "preseason_start",
+  "preseason_start_at",
+  "week_zero_start",
+] as const;
+const SEASON_WINDOW_POSTSEASON_END_CONFIG_KEYS = [
+  "postseason_end_at",
+  "postseason_end",
+  "postseason_end_date",
+] as const;
+
+type SeasonWindowDraft = {
+  trailerDropAt: string;
+  postseasonEndAt: string;
+};
+
+type SeasonWindowRow = {
+  week_index: number;
+  label: string;
+  start: string;
+  end: string;
+  week_type?: "preseason" | "episode" | "bye" | "postseason";
+  episode_number?: number | null;
+};
+
+const isRecordValue = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+const seasonWindowDateInputFormatter = new Intl.DateTimeFormat("en-CA", {
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  hourCycle: "h23",
+  timeZone: SOCIAL_TIME_ZONE,
+});
+
+const formatDateTimeLocalInput = (value: string | null | undefined): string => {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  const parts = Object.fromEntries(
+    seasonWindowDateInputFormatter
+      .formatToParts(date)
+      .filter((part) => part.type !== "literal")
+      .map((part) => [part.type, part.value]),
+  );
+  if (!parts.year || !parts.month || !parts.day || !parts.hour || !parts.minute) return "";
+  return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}`;
+};
+
+const readSeasonWindowConfigValue = (
+  targets: SocialTarget[],
+  keys: readonly string[],
+): string | null => {
+  for (const target of targets) {
+    const config = isRecordValue(target.config) ? target.config : null;
+    if (!config) continue;
+    for (const key of keys) {
+      const value = config[key];
+      if (typeof value === "string" && value.trim()) {
+        return value.trim();
+      }
+    }
+  }
+  return null;
+};
+
+const deriveSeasonWindowDraft = (targets: SocialTarget[]): SeasonWindowDraft => ({
+  trailerDropAt: formatDateTimeLocalInput(readSeasonWindowConfigValue(targets, SEASON_WINDOW_PRESEASON_CONFIG_KEYS)),
+  postseasonEndAt: formatDateTimeLocalInput(readSeasonWindowConfigValue(targets, SEASON_WINDOW_POSTSEASON_END_CONFIG_KEYS)),
+});
+
+const seasonWindowTypeLabel = (windowType: SeasonWindowRow["week_type"]): string => {
+  if (windowType === "preseason") return "Pre-Season";
+  if (windowType === "postseason") return "Post-Season";
+  if (windowType === "bye") return "Bye Week";
+  return "Episode";
+};
+
+const seasonWindowEpisodeLabel = (window: SeasonWindowRow): string => {
+  if (window.week_type === "preseason") return "Trailer to premiere";
+  if (window.week_type === "postseason") return "After finale";
+  if (window.week_type === "bye") return window.label || "Bye Week";
+  return typeof window.episode_number === "number" ? `Episode ${window.episode_number}` : window.label;
 };
 
 const formatDayScopeLabel = (value: string): string => {
@@ -2214,6 +2305,13 @@ export default function SeasonSocialAnalyticsSection({
   const [dailyRunPlatform, setDailyRunPlatform] = useState<"all" | Platform>("all");
   const [analytics, setAnalytics] = useState<AnalyticsResponse | null>(null);
   const [targets, setTargets] = useState<SocialTarget[]>([]);
+  const [seasonWindowDraft, setSeasonWindowDraft] = useState<SeasonWindowDraft>({
+    trailerDropAt: "",
+    postseasonEndAt: "",
+  });
+  const [seasonWindowSaving, setSeasonWindowSaving] = useState(false);
+  const [seasonWindowMessage, setSeasonWindowMessage] = useState<string | null>(null);
+  const [seasonWindowError, setSeasonWindowError] = useState<string | null>(null);
   const [linkedAccountSummaries, setLinkedAccountSummaries] = useState<Record<string, LinkedAccountProfileSummary>>({});
   const [runs, setRuns] = useState<SocialRun[]>([]);
   const [runSummaries, setRunSummaries] = useState<SocialRunSummary[]>([]);
@@ -2754,6 +2852,13 @@ export default function SeasonSocialAnalyticsSection({
   useEffect(() => {
     onTargetsChange?.(targets);
   }, [onTargetsChange, targets]);
+
+  const savedSeasonWindowDraft = useMemo(() => deriveSeasonWindowDraft(targets), [targets]);
+
+  useEffect(() => {
+    if (seasonWindowSaving) return;
+    setSeasonWindowDraft(savedSeasonWindowDraft);
+  }, [savedSeasonWindowDraft, seasonWindowSaving]);
 
   const fetchAnalytics = useCallback(async () => {
     const existingRequest = inFlightRef.current.analyticsByKey.get(analyticsRequestKey);
@@ -3574,6 +3679,95 @@ export default function SeasonSocialAnalyticsSection({
       // Best-effort only.
     }
   }, [seasonNumber, showId]);
+
+  const seasonWindowDraftChanged =
+    seasonWindowDraft.trailerDropAt !== savedSeasonWindowDraft.trailerDropAt ||
+    seasonWindowDraft.postseasonEndAt !== savedSeasonWindowDraft.postseasonEndAt;
+
+  const saveSeasonWindowSettings = useCallback(async () => {
+    if (targets.length === 0) {
+      setSeasonWindowError("Add at least one social target before saving season windows.");
+      setSeasonWindowMessage(null);
+      return;
+    }
+
+    setSeasonWindowSaving(true);
+    setSeasonWindowError(null);
+    setSeasonWindowMessage(null);
+    try {
+      const trailerDropAt = seasonWindowDraft.trailerDropAt.trim();
+      const postseasonEndAt = seasonWindowDraft.postseasonEndAt.trim();
+      const nextTargets = targets.map((target) => {
+        const nextConfig = isRecordValue(target.config) ? { ...target.config } : {};
+        for (const key of SEASON_WINDOW_PRESEASON_CONFIG_KEYS) {
+          delete nextConfig[key];
+        }
+        for (const key of SEASON_WINDOW_POSTSEASON_END_CONFIG_KEYS) {
+          delete nextConfig[key];
+        }
+        if (trailerDropAt) {
+          for (const key of SEASON_WINDOW_PRESEASON_CONFIG_KEYS) {
+            nextConfig[key] = trailerDropAt;
+          }
+        }
+        if (postseasonEndAt) {
+          nextConfig.postseason_end_at = postseasonEndAt;
+        }
+        return {
+          ...target,
+          timezone: target.timezone || SOCIAL_TIME_ZONE,
+          config: nextConfig,
+        };
+      });
+
+      const authHeaders = await getAuthHeaders();
+      const requestHeaders = new Headers(authHeaders);
+      requestHeaders.set("content-type", "application/json");
+      const response = await fetchAdminWithAuth(
+        `/api/admin/trr-api/shows/${showId}/seasons/${seasonNumber}/social/targets?season_id=${seasonId}`,
+        {
+          method: "PUT",
+          headers: requestHeaders,
+          cache: "no-store",
+          body: JSON.stringify({
+            source_scope: scope,
+            targets: nextTargets,
+          }),
+        },
+        { allowDevAdminBypass: true },
+      );
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response, "Failed to save season windows"));
+      }
+      const payload = await parseResponseJson<{ targets?: SocialTarget[] }>(response, "Failed to save season windows");
+      if (Array.isArray(payload.targets)) {
+        setTargets(payload.targets);
+      }
+      if (typeof window !== "undefined") {
+        window.localStorage.removeItem(cacheKey);
+      }
+      await invalidateSeasonSnapshotFamily();
+      await refreshAll({ forceRefresh: true });
+      setSeasonWindowMessage("Season windows saved.");
+    } catch (error) {
+      setSeasonWindowError(error instanceof Error ? error.message : "Failed to save season windows");
+    } finally {
+      setSeasonWindowSaving(false);
+    }
+  }, [
+    cacheKey,
+    getAuthHeaders,
+    invalidateSeasonSnapshotFamily,
+    readErrorMessage,
+    refreshAll,
+    scope,
+    seasonId,
+    seasonNumber,
+    seasonWindowDraft.postseasonEndAt,
+    seasonWindowDraft.trailerDropAt,
+    showId,
+    targets,
+  ]);
 
   useEffect(() => {
     void refreshAll();
@@ -5069,6 +5263,27 @@ export default function SeasonSocialAnalyticsSection({
     () => [...(analytics?.weekly_platform_posts ?? [])].sort((a, b) => a.week_index - b.week_index),
     [analytics],
   );
+  const officialSeasonWindows = useMemo<SeasonWindowRow[]>(() => {
+    const rows = analytics?.weekly && analytics.weekly.length > 0 ? analytics.weekly : (analytics?.weekly_platform_posts ?? []);
+    const seen = new Set<string>();
+    return rows
+      .filter((row) => typeof row.week_index === "number" && row.start && row.end)
+      .map((row) => ({
+        week_index: row.week_index,
+        label: row.label,
+        start: row.start,
+        end: row.end,
+        week_type: row.week_type,
+        episode_number: row.episode_number,
+      }))
+      .filter((row) => {
+        const key = `${row.week_index}:${row.start}:${row.end}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      })
+      .sort((a, b) => a.week_index - b.week_index);
+  }, [analytics?.weekly, analytics?.weekly_platform_posts]);
   const weeklyPlatformEngagementByWeek = useMemo(() => {
     const map = new Map<number, NonNullable<AnalyticsResponse["weekly_platform_engagement"]>[number]>();
     for (const row of analytics?.weekly_platform_engagement ?? []) {
@@ -6119,6 +6334,102 @@ export default function SeasonSocialAnalyticsSection({
       )}
     </div>
   );
+  const seasonWindowTargetsAvailable = targets.length > 0;
+  const seasonWindowSettingsPanel = (
+    <div className="rounded-2xl border border-zinc-200 bg-white p-5 text-xs text-zinc-600 shadow-sm" data-testid="season-window-settings">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="font-semibold text-zinc-700">Season Windows</p>
+        <span className="rounded-full border border-zinc-200 bg-zinc-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-zinc-600">
+          {officialSeasonWindows.length} official
+        </span>
+      </div>
+      <div className="mt-3 grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
+        <label className="space-y-1">
+          <span className="block text-[10px] font-semibold uppercase tracking-[0.14em] text-zinc-500">Trailer Drop</span>
+          <input
+            type="datetime-local"
+            value={seasonWindowDraft.trailerDropAt}
+            onChange={(event) => {
+              setSeasonWindowDraft((current) => ({ ...current, trailerDropAt: event.target.value }));
+              setSeasonWindowError(null);
+              setSeasonWindowMessage(null);
+            }}
+            className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-900 shadow-sm focus:border-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-200"
+          />
+        </label>
+        <label className="space-y-1">
+          <span className="block text-[10px] font-semibold uppercase tracking-[0.14em] text-zinc-500">
+            Post-Season End Override
+          </span>
+          <input
+            type="datetime-local"
+            value={seasonWindowDraft.postseasonEndAt}
+            onChange={(event) => {
+              setSeasonWindowDraft((current) => ({ ...current, postseasonEndAt: event.target.value }));
+              setSeasonWindowError(null);
+              setSeasonWindowMessage(null);
+            }}
+            className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-900 shadow-sm focus:border-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-200"
+          />
+        </label>
+        <div className="flex items-end">
+          <button
+            type="button"
+            onClick={() => {
+              void saveSeasonWindowSettings();
+            }}
+            disabled={!seasonWindowTargetsAvailable || !seasonWindowDraftChanged || seasonWindowSaving}
+            className="w-full rounded-lg border border-zinc-900 bg-zinc-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-zinc-700 disabled:cursor-not-allowed disabled:border-zinc-200 disabled:bg-zinc-100 disabled:text-zinc-400 md:w-auto"
+          >
+            {seasonWindowSaving ? "Saving..." : "Save Windows"}
+          </button>
+        </div>
+      </div>
+      {seasonWindowError && (
+        <p className="mt-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs font-medium text-red-700">
+          {seasonWindowError}
+        </p>
+      )}
+      {seasonWindowMessage && !seasonWindowError && (
+        <p className="mt-3 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs font-medium text-emerald-700">
+          {seasonWindowMessage}
+        </p>
+      )}
+      <div className="mt-4 overflow-x-auto">
+        <table className="min-w-full border-collapse text-left text-xs">
+          <thead>
+            <tr className="border-b border-zinc-200 text-[10px] uppercase tracking-[0.14em] text-zinc-500">
+              <th className="py-2 pr-4 font-semibold">Window</th>
+              <th className="py-2 pr-4 font-semibold">Type</th>
+              <th className="py-2 pr-4 font-semibold">Dates</th>
+            </tr>
+          </thead>
+          <tbody>
+            {officialSeasonWindows.map((window) => (
+              <tr key={`season-window-${window.week_index}-${window.start}`} className="border-b border-zinc-100 last:border-0">
+                <td className="py-2 pr-4 align-top font-semibold text-zinc-800">
+                  {seasonWindowEpisodeLabel(window)}
+                </td>
+                <td className="py-2 pr-4 align-top text-zinc-600">
+                  {seasonWindowTypeLabel(window.week_type)}
+                </td>
+                <td className="py-2 pr-4 align-top text-zinc-600">
+                  {formatDateTime(window.start)} to {formatDateTime(window.end)}
+                </td>
+              </tr>
+            ))}
+            {officialSeasonWindows.length === 0 && (
+              <tr>
+                <td className="py-3 pr-4 text-zinc-500" colSpan={3}>
+                  No official season windows yet.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
   const classificationRulesPanel = (
     <div className="rounded-2xl border border-zinc-200 bg-white p-5 text-xs text-zinc-600 shadow-sm">
       <p className="font-semibold text-zinc-700">
@@ -6233,9 +6544,12 @@ export default function SeasonSocialAnalyticsSection({
       </div>
     ) : null;
   const socialRulePanels = (
-    <div className={`grid gap-4 ${sharedAsyncPipelinePanel ? "xl:grid-cols-2" : ""}`}>
-      {classificationRulesPanel}
-      {sharedAsyncPipelinePanel}
+    <div className="space-y-4">
+      {seasonWindowSettingsPanel}
+      <div className={`grid gap-4 ${sharedAsyncPipelinePanel ? "xl:grid-cols-2" : ""}`}>
+        {classificationRulesPanel}
+        {sharedAsyncPipelinePanel}
+      </div>
     </div>
   );
   const socialControlsRail = (

--- a/apps/web/src/lib/admin/api-references/generated/inventory.ts
+++ b/apps/web/src/lib/admin/api-references/generated/inventory.ts
@@ -3,8 +3,8 @@ import type { AdminApiReferenceInventory } from "@/lib/admin/api-references/type
 export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
   "inventorySchemaVersion": "1.0.0",
   "generatorVersion": "1.0.0",
-  "generatedAt": "2026-07-13T21:52:10.426Z",
-  "sourceCommitSha": "33a9d40cd3eaa0d4f179ebe01d7cbd1b9ed816e3",
+  "generatedAt": "2026-07-13T21:52:45.109Z",
+  "sourceCommitSha": "25398d0557a6dd73d84af57326a0e8c5003f9d53",
   "overrideDigest": "cd85a76fd2fc977cbc691ccab80ce844f9ea783e118af35eb3d9766e5d61fd36",
   "nodes": [
     {
@@ -859,7 +859,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/social-growth/cookies/health/route.ts",
       "sourceLocator": {
-        "line": 23,
+        "line": 24,
         "matchedText": "`/admin/people/socialblade/cookies/health${query ? `?${query}` : \"\"}`"
       },
       "provenance": "static_scan",
@@ -11858,7 +11858,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/social/targets/route.ts",
       "sourceLocator": {
-        "line": 36,
+        "line": 41,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -12436,7 +12436,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/social-growth/cookies/health/route.ts",
       "sourceLocator": {
-        "line": 18,
+        "line": 19,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -12652,6 +12652,40 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "fanoutRisk": "low"
     },
     {
+      "id": "route:GET:/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/capacity",
+      "kind": "api_route",
+      "title": "GET /api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/capacity",
+      "pathPattern": "/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/capacity",
+      "symbol": "GET",
+      "sourceFile": "src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/capacity/route.ts",
+      "sourceLocator": {
+        "line": 14,
+        "symbol": "GET"
+      },
+      "provenance": "static_scan",
+      "confidence": "high",
+      "verificationStatus": "verified",
+      "basis": [
+        "static_scan:app_api_route"
+      ],
+      "usageTier": "manual",
+      "polls": false,
+      "pollCadenceMs": null,
+      "automatic": false,
+      "loadsLargeDatasets": true,
+      "usesPagination": false,
+      "returnsWideRowsOrBlobsOrRawJson": false,
+      "fansOutQueries": false,
+      "postgresAccess": "none",
+      "viewKinds": [
+        "list",
+        "detail"
+      ],
+      "staticOnly": false,
+      "payloadRisk": "high",
+      "fanoutRisk": "low"
+    },
+    {
       "id": "route:GET:/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/gap-analysis",
       "kind": "api_route",
       "title": "GET /api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/gap-analysis",
@@ -12795,7 +12829,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/runs/[runId]/progress/route.ts",
       "sourceLocator": {
-        "line": 68,
+        "line": 79,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -12829,7 +12863,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/runs/recent/route.ts",
       "sourceLocator": {
-        "line": 305,
+        "line": 309,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -13031,7 +13065,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/completion-summary/route.ts",
       "sourceLocator": {
-        "line": 84,
+        "line": 45,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -13046,7 +13080,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "automatic": false,
       "loadsLargeDatasets": false,
       "usesPagination": false,
-      "returnsWideRowsOrBlobsOrRawJson": false,
+      "returnsWideRowsOrBlobsOrRawJson": true,
       "fansOutQueries": false,
       "postgresAccess": "none",
       "viewKinds": [
@@ -13054,7 +13088,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
         "detail"
       ],
       "staticOnly": false,
-      "payloadRisk": "low",
+      "payloadRisk": "high",
       "fanoutRisk": "low"
     },
     {
@@ -13065,7 +13099,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/cookies/health/route.ts",
       "sourceLocator": {
-        "line": 35,
+        "line": 36,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -19639,7 +19673,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "PUT",
       "sourceFile": "src/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/social/targets/route.ts",
       "sourceLocator": {
-        "line": 80,
+        "line": 85,
         "symbol": "PUT"
       },
       "provenance": "static_scan",
@@ -21915,7 +21949,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/api/admin/trr-api/social-growth/cookies/health/route.ts",
       "sourceLocator": {
-        "line": 23,
+        "line": 24,
         "matchedText": "`/admin/people/socialblade/cookies/health${query ? `?${query}` : \"\"}`"
       },
       "provenance": "static_scan",
@@ -23714,6 +23748,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
         "route:GET:/api/admin/trr-api/social/ingest/live-status/stream",
         "route:GET:/api/admin/trr-api/social/ingest/queue-status",
         "route:GET:/api/admin/trr-api/social/ingest/workers/[workerId]/detail",
+        "route:GET:/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/capacity",
         "route:GET:/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/gap-analysis",
         "route:GET:/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/posts",
         "route:GET:/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/posts/[sourceId]/detail",
@@ -24277,11 +24312,11 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "renders_view": []
     },
     "summary": {
-      "totalNodes": 585,
+      "totalNodes": 586,
       "totalEdges": 204,
       "nodesByKind": {
         "ui_surface": 57,
-        "api_route": 401,
+        "api_route": 402,
         "backend_endpoint": 121,
         "repository_surface": 2,
         "polling_loop": 4

--- a/apps/web/src/lib/admin/social-account-profile.ts
+++ b/apps/web/src/lib/admin/social-account-profile.ts
@@ -1033,6 +1033,7 @@ export type SocialAccountCatalogRun = {
   selected_tasks?: CatalogBackfillSelectedTask[];
   effective_selected_tasks?: CatalogBackfillSelectedTask[];
   comments_run_id?: string | null;
+  comments_reused_existing_run?: boolean | null;
   attached_followups?: SocialAccountCatalogAttachedFollowups | null;
 };
 
@@ -1351,6 +1352,7 @@ export type SocialAccountCatalogRunProgressSnapshot = {
   selected_tasks?: CatalogBackfillSelectedTask[];
   effective_selected_tasks?: CatalogBackfillSelectedTask[];
   budget_decision?: Record<string, unknown> | null;
+  db_session_capacity?: Record<string, unknown> | null;
   adaptive_worker_plan?: Record<string, unknown> | null;
   runbook_state?: Record<string, unknown> | null;
   requires_apply_confirmation?: boolean | null;
@@ -1417,6 +1419,8 @@ export type SocialAccountCatalogRunProgressSnapshot = {
   progress_degraded?: boolean;
   progress_degraded_reason?: string | null;
   progress_degraded_at?: string | null;
+  /** True only when this response came from the live backend progress read. */
+  progress_authoritative?: boolean;
   // Legacy compatibility: preserved while backend rolls out details_refresh_policy / force_network_detail_fetch.
   details_refresh_force_detail_fetch?: boolean;
   details_refresh_policy?: "smart" | "force_metrics" | "force_network_detail" | string | null;
@@ -1440,6 +1444,7 @@ export type SocialAccountCatalogRunProgressSnapshot = {
     | "fetching"
     | "recovering"
     | "classifying"
+    | "degraded"
     | "completed"
     | "failed"
     | "cancelled";
@@ -1639,7 +1644,7 @@ export type CatalogBackfillLaunchResponse = {
   run_id?: string | null;
   status?: string | null;
   launch_group_id?: string | null;
-  launch_state?: "pending" | "pending_apply_confirmation" | "finalizing" | "ready" | "failed" | null;
+  launch_state?: "pending" | "pending_apply_confirmation" | "finalizing" | "ready" | "failed" | "blocked_auth" | null;
   launch_task_resolution_pending?: boolean | null;
   requires_apply_confirmation?: boolean | null;
   apply_required?: boolean | null;
@@ -1647,6 +1652,7 @@ export type CatalogBackfillLaunchResponse = {
   required_confirmation?: string | null;
   runbook_state?: Record<string, unknown> | null;
   budget_decision?: Record<string, unknown> | null;
+  db_session_capacity?: Record<string, unknown> | null;
   adaptive_worker_plan?: Record<string, unknown> | null;
   enable_cap4_canary?: boolean | null;
   selected_tasks?: CatalogBackfillSelectedTask[];
@@ -1654,6 +1660,7 @@ export type CatalogBackfillLaunchResponse = {
   post_details_skipped_reason?: "already_materialized" | null;
   catalog_run_id?: string | null;
   comments_run_id?: string | null;
+  comments_reused_existing_run?: boolean | null;
   attached_followups?: SocialAccountCatalogAttachedFollowups | null;
   catalog_bootstrap_required?: boolean;
   comments_deferred_until_catalog_complete?: boolean;

--- a/apps/web/src/lib/admin/socialblade-cookie-health.ts
+++ b/apps/web/src/lib/admin/socialblade-cookie-health.ts
@@ -1,0 +1,69 @@
+type JsonRecord = Record<string, unknown>;
+
+const isRecord = (value: unknown): value is JsonRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const stringOrNull = (value: unknown): string | null => (typeof value === "string" ? value : null);
+
+const stringOrDefault = (value: unknown, fallback: string): string => (typeof value === "string" ? value : fallback);
+
+export interface SocialBladeCookieHealth {
+  healthy: boolean;
+  status: string;
+  reason: string | null;
+  retryable: boolean;
+  cookieNames: string[];
+  cookieFile: {
+    path: string;
+    exists: boolean;
+    modifiedAt: string | null;
+  } & JsonRecord;
+  validation: {
+    checked: boolean;
+    healthy: boolean | null;
+    reason: string | null;
+    url: string | null;
+  } & JsonRecord;
+  checkedAt: string;
+}
+
+export type NormalizedSocialBladeCookieHealth = SocialBladeCookieHealth & JsonRecord;
+
+export function normalizeSocialBladeCookieHealth(input: unknown): NormalizedSocialBladeCookieHealth {
+  const source = isRecord(input) ? input : {};
+  const healthy = typeof source.healthy === "boolean" ? source.healthy : false;
+  const cookieFileSource = isRecord(source.cookieFile)
+    ? source.cookieFile
+    : isRecord(source.cookie_file)
+      ? source.cookie_file
+      : {};
+  const validationSource = isRecord(source.validation) ? source.validation : {};
+  const cookieNamesSource = Array.isArray(source.cookieNames)
+    ? source.cookieNames
+    : Array.isArray(source.cookie_names)
+      ? source.cookie_names
+      : [];
+
+  return {
+    ...source,
+    healthy,
+    status: stringOrDefault(source.status, healthy ? "ready" : "unknown"),
+    reason: stringOrNull(source.reason),
+    retryable: typeof source.retryable === "boolean" ? source.retryable : false,
+    cookieNames: cookieNamesSource.filter((name): name is string => typeof name === "string"),
+    cookieFile: {
+      ...cookieFileSource,
+      path: stringOrDefault(cookieFileSource.path, ""),
+      exists: typeof cookieFileSource.exists === "boolean" ? cookieFileSource.exists : false,
+      modifiedAt: stringOrNull(cookieFileSource.modifiedAt ?? cookieFileSource.modified_at),
+    },
+    validation: {
+      ...validationSource,
+      checked: typeof validationSource.checked === "boolean" ? validationSource.checked : false,
+      healthy: typeof validationSource.healthy === "boolean" ? validationSource.healthy : null,
+      reason: stringOrNull(validationSource.reason),
+      url: stringOrNull(validationSource.url),
+    },
+    checkedAt: stringOrDefault(source.checkedAt ?? source.checked_at, new Date().toISOString()),
+  };
+}

--- a/apps/web/src/lib/server/admin/social-landing-repository.ts
+++ b/apps/web/src/lib/server/admin/social-landing-repository.ts
@@ -45,7 +45,6 @@ import {
   type CoveredShow,
 } from "@/lib/server/admin/covered-shows-repository";
 import { loadSharedAccountSourcesFromLocalDb } from "@/lib/server/admin/shared-account-sources";
-import { query, queryWithStatementTimeout } from "@/lib/server/postgres";
 import {
   ADMIN_READ_PROXY_SHORT_TIMEOUT_MS,
   fetchAdminBackendJson,
@@ -106,10 +105,6 @@ type SocialBladeRowsPayload = {
   rows?: SocialBladeSummaryRow[];
 };
 
-type SocialBladeProgressCountsPayload = {
-  rows?: SocialBladeProgressCountRow[];
-};
-
 type SocialProgressRollupPayload = {
   rows?: SocialProgressRow[];
   cache_status?: string | null;
@@ -133,14 +128,6 @@ const EMPTY_SCRAPE_JOB_HEALTH: ScrapeJobHealthSummary = {
   failure_signal_jobs: 0,
   in_failed_sql_transaction_hits: 0,
   latest_failure_at: null,
-};
-
-type SocialBladeProgressCountRow = {
-  platform: string | null;
-  account_handle: string | null;
-  socialblade_scraped_count: number | string | null;
-  socialblade_saved_count: number | string | null;
-  socialblade_supported?: boolean | null;
 };
 
 type SocialProgressRow = {
@@ -345,38 +332,10 @@ const CAST_SOCIALBLADE_PLATFORMS =
   );
 
 const SOCIAL_LANDING_PROGRESS_MAX_TARGETS = 96;
-const SOCIAL_LANDING_PROGRESS_STATEMENT_TIMEOUT_MS = 1_200;
 const SOCIAL_LANDING_OPTIONAL_ENRICHMENT_TIMEOUT_MS = parseCacheTtlMs(
   process.env.TRR_ADMIN_SOCIAL_LANDING_OPTIONAL_ENRICHMENT_TIMEOUT_MS,
   2_500,
 );
-
-const sqlJsonTextNonNegativeInt = (expr: string): string =>
-  `coalesce(nullif(regexp_replace(coalesce(${expr}, ''), '[^0-9]', '', 'g'), '')::bigint, 0)`;
-
-const instagramReportedCommentsSql = (alias: string): string => {
-  const safeAlias = alias.trim() || "p";
-  const raw = `coalesce(${safeAlias}.raw_data, '{}'::jsonb)`;
-  const rawCandidates = [
-    `${raw} ->> 'comments_count'`,
-    `${raw} ->> 'comments'`,
-    `${raw} ->> 'comment_count'`,
-    `${raw} ->> 'commentsCount'`,
-    `${raw} -> 'edge_media_to_comment' ->> 'count'`,
-    `${raw} -> 'edge_media_to_parent_comment' ->> 'count'`,
-    `${raw} -> 'edge_media_preview_comment' ->> 'count'`,
-    `${raw} -> 'media' ->> 'comments_count'`,
-    `${raw} -> 'media' ->> 'comments'`,
-    `${raw} -> 'media' ->> 'comment_count'`,
-    `${raw} -> 'media' ->> 'commentsCount'`,
-    `${raw} -> 'metrics' ->> 'comments_count'`,
-    `${raw} -> 'metrics' ->> 'comments'`,
-  ];
-
-  return `greatest(coalesce(${safeAlias}.comments_count, 0), ${rawCandidates
-    .map(sqlJsonTextNonNegativeInt)
-    .join(", ")}, 0)`;
-};
 
 const SHOW_EXTERNAL_ID_KEYS: Record<
   SupportedPersonSocialSource,
@@ -716,8 +675,8 @@ const buildProgressLanes = (
           : "No following-list snapshot",
     ),
     buildLane("posts", "Posts", row.saved_count, row.scraped_count),
-    buildLane("comments", "Comments", row.comments_saved_count, row.comments_saved_count, row.comments_total_count),
-    buildLane("media", "Media", row.media_saved_count, row.media_saved_count, row.media_total_count),
+    buildLane("comments", "Comments", row.comments_saved_count, row.comments_total_count, row.comments_total_count),
+    buildLane("media", "Media", row.media_saved_count, row.media_total_count, row.media_total_count),
   ];
 };
 
@@ -777,47 +736,6 @@ const collectSocialProgressTargets = ({
     .slice(0, SOCIAL_LANDING_PROGRESS_MAX_TARGETS);
 };
 
-const safeLoadSocialBladeProgressCounts = async (
-  targets: readonly SocialProgressTarget[],
-  adminContext?: VerifiedAdminContext,
-): Promise<CacheableValue<ReadonlyMap<string, Partial<SocialProgressRow>>>> => {
-  if (targets.length === 0) return cacheableValue(new Map());
-
-  try {
-    const payload = (await fetchSocialBackendJson("/landing-socialblade-progress-counts", {
-      adminContext,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        platforms: targets.map((target) => target.platform),
-        account_handles: targets.map((target) => target.handle),
-      }),
-      fallbackError: "Failed to fetch social landing SocialBlade progress counts",
-      retries: 0,
-      timeoutMs: ADMIN_READ_PROXY_SHORT_TIMEOUT_MS,
-    })) as SocialBladeProgressCountsPayload;
-    const rows = Array.isArray(payload.rows) ? payload.rows : [];
-    const countsByKey = new Map<string, Partial<SocialProgressRow>>();
-    for (const row of rows) {
-      const platform = normalizePlatform(row.platform ?? "");
-      const handle =
-        typeof row.account_handle === "string"
-          ? row.account_handle.trim().replace(/^@+/, "")
-          : "";
-      if (!platform || !handle) continue;
-      countsByKey.set(buildSocialProgressKey(platform, handle), {
-        socialblade_scraped_count: row.socialblade_scraped_count,
-        socialblade_saved_count: row.socialblade_saved_count,
-        socialblade_supported: row.socialblade_supported,
-      });
-    }
-    return cacheableValue(countsByKey);
-  } catch (error) {
-    console.warn("[social-landing] Failed to load SocialBlade progress counts", error);
-    return uncacheableValue(new Map());
-  }
-};
-
 const buildSocialProgressMap = (
   rows: readonly SocialProgressRow[],
   overridesByKey: ReadonlyMap<string, Partial<SocialProgressRow>> = new Map(),
@@ -843,7 +761,7 @@ const buildSocialProgressMap = (
 
 const safeLoadBackendSocialProgressRollup = async (
   targets: readonly SocialProgressTarget[],
-  adminContext: VerifiedAdminContext,
+  adminContext?: VerifiedAdminContext,
   timingCollector?: SocialLandingTimingCollector,
 ): Promise<SocialProgressSummaryResult> => {
   try {
@@ -919,267 +837,7 @@ const safeLoadSocialProgressSummaries = async (
     };
   }
 
-  if (adminContext) {
-    return safeLoadBackendSocialProgressRollup(targets, adminContext, timingCollector);
-  }
-
-  const platforms = targets.map((target) => target.platform);
-  const handles = targets.map((target) => target.handle);
-  const instagramMaterializedReportedCommentsSql =
-    instagramReportedCommentsSql("p");
-  const instagramCatalogReportedCommentsSql = instagramReportedCommentsSql("p");
-
-  try {
-    const [socialBladeCountsResult, result] = await Promise.all([
-      safeLoadSocialBladeProgressCounts(targets, adminContext),
-      queryWithStatementTimeout<SocialProgressRow>(
-        `
-        /* landing_social_progress */
-        WITH targets AS (
-          SELECT DISTINCT
-            lower(input.platform) AS platform,
-            lower(regexp_replace(input.account_handle, '^@+', '')) AS account_handle
-          FROM unnest($1::text[], $2::text[]) AS input(platform, account_handle)
-          WHERE input.platform IN ('instagram', 'tiktok', 'twitter', 'youtube', 'facebook', 'threads')
-            AND nullif(trim(input.account_handle), '') IS NOT NULL
-        ),
-        materialized_rows AS (
-          SELECT
-            'instagram'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            id,
-            nullif(shortcode, '') AS source_id,
-            (${instagramMaterializedReportedCommentsSql})::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files,
-            (
-              jsonb_array_length(coalesce(hosted_media_urls, '[]'::jsonb)) +
-              case when nullif(hosted_thumbnail_url, '') is not null then 1 else 0 end
-            )::bigint AS hosted_media_files
-          FROM social.instagram_posts p
-          UNION ALL
-          SELECT
-            'tiktok'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            id,
-            nullif(video_id, '') AS source_id,
-            greatest(coalesce(comments_count, 0), 0)::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files,
-            (
-              jsonb_array_length(coalesce(hosted_media_urls, '[]'::jsonb)) +
-              case when nullif(hosted_thumbnail_url, '') is not null then 1 else 0 end
-            )::bigint AS hosted_media_files
-          FROM social.tiktok_posts
-          UNION ALL
-          SELECT
-            'twitter'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            id,
-            nullif(tweet_id, '') AS source_id,
-            0::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files,
-            (
-              jsonb_array_length(coalesce(hosted_media_urls, '[]'::jsonb)) +
-              case when nullif(hosted_thumbnail_url, '') is not null then 1 else 0 end
-            )::bigint AS hosted_media_files
-          FROM social.twitter_tweets
-          UNION ALL
-          SELECT
-            'youtube'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            id,
-            nullif(video_id, '') AS source_id,
-            greatest(coalesce(comments_count, 0), 0)::bigint AS reported_comments,
-            0::bigint AS source_media_files,
-            case when nullif(hosted_thumbnail_url, '') is not null then 1 else 0 end::bigint AS hosted_media_files
-          FROM social.youtube_videos
-          UNION ALL
-          SELECT
-            'facebook'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            id,
-            nullif(post_id, '') AS source_id,
-            greatest(coalesce(comments_count, 0), 0)::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files,
-            (
-              jsonb_array_length(coalesce(hosted_media_urls, '[]'::jsonb)) +
-              case when nullif(hosted_thumbnail_url, '') is not null then 1 else 0 end
-            )::bigint AS hosted_media_files
-          FROM social.facebook_posts
-          UNION ALL
-          SELECT
-            'threads'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            id,
-            nullif(post_id, '') AS source_id,
-            0::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files,
-            (
-              jsonb_array_length(coalesce(hosted_media_urls, '[]'::jsonb)) +
-              case when nullif(hosted_thumbnail_url, '') is not null then 1 else 0 end
-            )::bigint AS hosted_media_files
-          FROM social.meta_threads_posts
-        ),
-        catalog_rows AS (
-          SELECT
-            'instagram'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            nullif(source_id, '') AS source_id,
-            (${instagramCatalogReportedCommentsSql})::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files
-          FROM social.instagram_account_catalog_posts p
-          UNION ALL
-          SELECT
-            'tiktok'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            nullif(source_id, '') AS source_id,
-            greatest(coalesce(comments_count, 0), 0)::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files
-          FROM social.tiktok_account_catalog_posts
-          UNION ALL
-          SELECT
-            'twitter'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            nullif(source_id, '') AS source_id,
-            greatest(coalesce(comments_count, 0), 0)::bigint + greatest(coalesce(quotes, 0), 0)::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files
-          FROM social.twitter_account_catalog_posts
-          UNION ALL
-          SELECT
-            'youtube'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            nullif(source_id, '') AS source_id,
-            greatest(coalesce(comments_count, 0), 0)::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files
-          FROM social.youtube_account_catalog_posts
-          UNION ALL
-          SELECT
-            'facebook'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            nullif(source_id, '') AS source_id,
-            greatest(coalesce(comments_count, 0), 0)::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files
-          FROM social.facebook_account_catalog_posts
-          UNION ALL
-          SELECT
-            'threads'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            nullif(source_id, '') AS source_id,
-            greatest(coalesce(comments_count, 0), 0)::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files
-          FROM social.threads_account_catalog_posts
-        ),
-        materialized_counts AS (
-          SELECT
-            rows.platform,
-            rows.account_handle,
-            count(*)::int AS saved_count,
-            sum(rows.reported_comments)::int AS comments_total_count,
-            sum(rows.hosted_media_files)::int AS media_saved_count
-          FROM materialized_rows rows
-          INNER JOIN targets
-            ON targets.platform = rows.platform
-           AND targets.account_handle = rows.account_handle
-          WHERE rows.account_handle <> ''
-          GROUP BY rows.platform, rows.account_handle
-        ),
-        catalog_counts AS (
-          SELECT
-            rows.platform,
-            rows.account_handle,
-            count(*)::int AS scraped_count,
-            sum(rows.reported_comments)::int AS comments_total_count,
-            sum(rows.source_media_files)::int AS media_total_count
-          FROM catalog_rows rows
-          INNER JOIN targets
-            ON targets.platform = rows.platform
-           AND targets.account_handle = rows.account_handle
-          WHERE rows.account_handle <> ''
-          GROUP BY rows.platform, rows.account_handle
-        ),
-        instagram_profile_targets AS (
-          SELECT DISTINCT ON (targets.account_handle)
-            targets.account_handle,
-            profiles.id AS profile_id,
-            greatest(coalesce(profiles.follows_count, 0), 0)::int AS following_total_count
-          FROM targets
-          INNER JOIN social.instagram_profiles profiles
-            ON targets.platform = 'instagram'
-           AND lower(regexp_replace(coalesce(profiles.normalized_username, profiles.username, profiles.source_account, ''), '^@+', '')) = targets.account_handle
-          ORDER BY
-            targets.account_handle,
-            profiles.last_scraped_at DESC NULLS LAST,
-            profiles.updated_at DESC NULLS LAST,
-            profiles.id
-        ),
-        following_counts AS (
-          SELECT
-            'instagram'::text AS platform,
-            profile_targets.account_handle,
-            count(relationships.id) FILTER (WHERE coalesce(relationships.is_missing, false) = false)::int AS following_saved_count,
-            max(profile_targets.following_total_count)::int AS following_total_count
-          FROM instagram_profile_targets profile_targets
-          LEFT JOIN social.instagram_profile_relationships relationships
-            ON relationships.owner_profile_id = profile_targets.profile_id
-           AND relationships.relationship_type = 'following'
-          GROUP BY profile_targets.account_handle
-        )
-        SELECT
-          targets.platform,
-          targets.account_handle,
-          coalesce(materialized_counts.saved_count, 0)::int AS saved_count,
-          coalesce(catalog_counts.scraped_count, 0)::int AS scraped_count,
-          (targets.platform IN ('instagram', 'youtube', 'tiktok'))::boolean AS socialblade_supported,
-          0::int AS socialblade_scraped_count,
-          0::int AS socialblade_saved_count,
-          coalesce(following_counts.following_saved_count, 0)::int AS following_saved_count,
-          coalesce(following_counts.following_total_count, 0)::int AS following_total_count,
-          0::int AS comments_saved_count,
-          greatest(
-            coalesce(materialized_counts.comments_total_count, 0),
-            coalesce(catalog_counts.comments_total_count, 0)
-          )::int AS comments_total_count,
-          coalesce(materialized_counts.media_saved_count, 0)::int AS media_saved_count,
-          greatest(coalesce(catalog_counts.media_total_count, 0), coalesce(materialized_counts.media_saved_count, 0))::int AS media_total_count
-        FROM targets
-        LEFT JOIN materialized_counts
-          ON materialized_counts.platform = targets.platform
-         AND materialized_counts.account_handle = targets.account_handle
-        LEFT JOIN catalog_counts
-          ON catalog_counts.platform = targets.platform
-         AND catalog_counts.account_handle = targets.account_handle
-        LEFT JOIN following_counts
-          ON following_counts.platform = targets.platform
-         AND following_counts.account_handle = targets.account_handle
-        `,
-        [platforms, handles],
-        SOCIAL_LANDING_PROGRESS_STATEMENT_TIMEOUT_MS,
-      ),
-    ]);
-
-    const socialBladeCountsByKey = socialBladeCountsResult.value;
-    return {
-      value: buildSocialProgressMap(result.rows, socialBladeCountsByKey),
-      cacheable: socialBladeCountsResult.cacheable,
-      status: {
-        source: "fallback",
-        cache_status: null,
-        generated_at: null,
-        stale: !socialBladeCountsResult.cacheable,
-      },
-    };
-  } catch (error) {
-    console.warn("[social-landing] Failed to load social progress summaries", error);
-    return {
-      ...uncacheableValue(new Map()),
-      status: {
-        source: "fallback",
-        cache_status: null,
-        generated_at: null,
-        stale: true,
-        warning: error instanceof Error ? error.message : "Failed to load social progress summaries",
-      },
-    };
-  }
+  return safeLoadBackendSocialProgressRollup(targets, adminContext, timingCollector);
 };
 
 const hydrateHandleProgress = (
@@ -1364,62 +1022,16 @@ const coerceCount = (value: number | string | null | undefined): number => {
   return Number.isFinite(parsed) ? Math.max(0, Math.trunc(parsed)) : 0;
 };
 
-const safeLoadScrapeJobHealth = async (): Promise<ScrapeJobHealthSummary> => {
+const safeLoadScrapeJobHealth = async (
+  adminContext?: VerifiedAdminContext,
+): Promise<ScrapeJobHealthSummary> => {
   try {
-    const result = await query<ScrapeJobHealthRow>(
-      `
-        /* landing_social_scrape_job_health */
-        WITH recent_jobs AS (
-          SELECT
-            status,
-            error_message,
-            last_error_code,
-            metadata,
-            created_at
-          FROM social.scrape_jobs
-          WHERE platform = ANY($2::text[])
-            AND created_at >= now() - ($1::int * interval '1 hour')
-        ),
-        job_signals AS (
-          SELECT
-            status,
-            created_at,
-            coalesce(error_message, '') || ' ' ||
-              coalesce(last_error_code, '') AS error_signal,
-            coalesce(error_message, '') || ' ' ||
-              coalesce(last_error_code, '') || ' ' ||
-              coalesce(metadata::text, '') AS diagnostic_text
-          FROM recent_jobs
-        )
-        SELECT
-          now() AS generated_at,
-          now() - ($1::int * interval '1 hour') AS window_started_at,
-          count(*)::bigint AS total_jobs,
-          count(*) FILTER (
-            WHERE status IN ('queued', 'pending', 'running', 'retrying', 'cancelling')
-          )::bigint AS active_jobs,
-          count(*) FILTER (
-            WHERE status IN ('failed', 'error')
-          )::bigint AS failed_jobs,
-          count(*) FILTER (
-            WHERE status IN ('failed', 'error')
-              OR nullif(trim(error_signal), '') IS NOT NULL
-          )::bigint AS failure_signal_jobs,
-          count(*) FILTER (
-            WHERE diagnostic_text ILIKE '%InFailedSqlTransaction%'
-          )::bigint AS in_failed_sql_transaction_hits,
-          max(created_at) FILTER (
-            WHERE status IN ('failed', 'error')
-              OR nullif(trim(error_signal), '') IS NOT NULL
-          ) AS latest_failure_at
-        FROM job_signals
-      `,
-      [
-        SCRAPE_JOB_HEALTH_WINDOW_HOURS,
-        ["instagram", "tiktok", "twitter", "youtube"],
-      ],
-    );
-    const row = result.rows[0] ?? {};
+    const row = (await fetchSocialBackendJson("/landing-scrape-job-health", {
+      adminContext,
+      fallbackError: "Failed to load social landing scrape-job health",
+      retries: 1,
+      timeoutMs: SOCIAL_PROXY_DEFAULT_TIMEOUT_MS,
+    })) as ScrapeJobHealthRow;
     return {
       window_hours: SCRAPE_JOB_HEALTH_WINDOW_HOURS,
       window_started_at: toIsoStringOrNull(row.window_started_at),
@@ -2660,7 +2272,7 @@ export async function getSocialLandingPayloadResult(
     );
   const scrapeJobHealthPromise = withSocialLandingTiming(
     "scrape job health",
-    safeLoadScrapeJobHealth(),
+    safeLoadScrapeJobHealth(adminContext),
   );
   const coveredShowIds = coveredShows.map((show) => show.trr_show_id);
   const [
@@ -2731,7 +2343,7 @@ export async function getSocialLandingPayloadResult(
     "people profiles",
     buildPeopleProfiles(coveredShows, castByShowId),
   );
-  const castSocialBladeShowsResult = await withOptionalLandingTimeout(
+  const castSocialBladeShowsPromise = withOptionalLandingTimeout(
     "cast SocialBlade",
     buildCastSocialBladeShows(
       coveredShows,
@@ -2749,7 +2361,7 @@ export async function getSocialLandingPayloadResult(
     networkSharedSources,
   );
   const sharedSourceSets = buildSharedSourceSets(sourcesByScope);
-  const progressResult = await withOptionalLandingTimeout(
+  const progressPromise = withOptionalLandingTimeout(
     "social progress",
     safeLoadSocialProgressSummaries(
       collectSocialProgressTargets({
@@ -2761,7 +2373,11 @@ export async function getSocialLandingPayloadResult(
       timingCollector,
     ),
     new Map(),
-  ) as SocialProgressSummaryResult;
+  ) as Promise<SocialProgressSummaryResult>;
+  const [castSocialBladeShowsResult, progressResult] = await Promise.all([
+    castSocialBladeShowsPromise,
+    progressPromise,
+  ]);
   const progressByKey = progressResult.value;
   const hydratedNetworkSets = networkSets.map((set) =>
     hydrateNetworkSetProgress(set, progressByKey),

--- a/apps/web/tests/cast-socialblade-comparison.test.tsx
+++ b/apps/web/tests/cast-socialblade-comparison.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import CastSocialBladeComparison from "@/components/admin/cast-socialblade-comparison";
+
+const mocks = vi.hoisted(() => ({
+  fetchAdminWithAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/admin/client-auth", () => ({
+  fetchAdminWithAuth: (...args: unknown[]) => (mocks.fetchAdminWithAuth as (...inner: unknown[]) => unknown)(...args),
+}));
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+describe("CastSocialBladeComparison", () => {
+  it("normalizes partial cookie health payloads without nested cookie metadata", async () => {
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/social-growth/cookies/health")) {
+        return jsonResponse({
+          healthy: true,
+          status: "ready",
+          reason: null,
+          retryable: false,
+          cookieNames: ["sessionid"],
+          checkedAt: "2026-06-19T12:00:00.000Z",
+        });
+      }
+      if (url.includes("/social-growth/history")) {
+        return jsonResponse({ items: [] });
+      }
+      if (url.includes("/social-growth")) {
+        return jsonResponse({ error: "No SocialBlade data found" }, 404);
+      }
+      return jsonResponse({});
+    });
+
+    render(
+      <CastSocialBladeComparison
+        seasonNumber={6}
+        comparisonWindow={null}
+        castMembers={[
+          {
+            person_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            person_name: "Lisa Barlow",
+            display_name: "Lisa Barlow",
+            instagram_handle: "lisabarlow",
+            roles: ["Housewife"],
+          },
+        ]}
+      />,
+    );
+
+    expect(await screen.findByText("Ready")).toBeInTheDocument();
+    expect(screen.getByText("Authenticated SocialBlade session is usable")).toBeInTheDocument();
+    expect(screen.getByText("Cookie file not written")).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/season-social-analytics-section.test.tsx
+++ b/apps/web/tests/season-social-analytics-section.test.tsx
@@ -624,7 +624,15 @@ const syncSessionStreamResponse = (body: unknown): Response =>
 const buildSnapshotEnvelope = (
   analytics: AnalyticsPayload | null,
   overrides?: {
-    targets?: Array<{ platform: string; accounts?: string[]; hashtags?: string[]; keywords?: string[]; is_active?: boolean }>;
+    targets?: Array<{
+      platform: string;
+      accounts?: string[];
+      hashtags?: string[];
+      keywords?: string[];
+      timezone?: string;
+      is_active?: boolean;
+      config?: Record<string, unknown>;
+    }>;
     runs?: Array<Record<string, unknown>>;
     run_summaries?: Array<Record<string, unknown>>;
     worker_health?: Record<string, unknown> | null;
@@ -962,6 +970,120 @@ describe("SeasonSocialAnalyticsSection weekly trend", () => {
     expect(screen.getByText("Matched posts")).toBeInTheDocument();
     expect(screen.getByText("Review queue")).toBeInTheDocument();
     expect(screen.getByText("Retained unassigned")).toBeInTheDocument();
+  });
+
+  it("renders official season windows from analytics data", async () => {
+    const payload: AnalyticsPayload = {
+      ...analyticsBase,
+      weekly: [
+        {
+          week_index: 0,
+          label: "Pre-Season",
+          start: "2026-01-02T01:00:00Z",
+          end: "2026-01-09T01:00:00Z",
+          week_type: "preseason",
+          episode_number: null,
+          post_volume: 1,
+          comment_volume: 1,
+          engagement: 10,
+          sentiment: { positive: 1, neutral: 0, negative: 0 },
+        },
+        ...analyticsBase.weekly,
+        {
+          week_index: 3,
+          label: "Post-Season",
+          start: "2026-01-21T01:00:00Z",
+          end: "2026-01-24T01:00:00Z",
+          week_type: "postseason",
+          episode_number: null,
+          post_volume: 0,
+          comment_volume: 0,
+          engagement: 0,
+          sentiment: { positive: 0, neutral: 0, negative: 0 },
+        },
+      ],
+    };
+    mockSeasonSocialFetch(payload);
+
+    render(
+      <SeasonSocialAnalyticsSection
+        showId="show-1"
+        seasonNumber={6}
+        seasonId="season-1"
+        showName="Test Show"
+      />,
+    );
+
+    const panel = await screen.findByTestId("season-window-settings");
+    expect(within(panel).getByText("Season Windows")).toBeInTheDocument();
+    expect(within(panel).getByText("Trailer to premiere")).toBeInTheDocument();
+    expect(within(panel).getByText("After finale")).toBeInTheDocument();
+    expect(within(panel).getAllByText("Pre-Season").length).toBeGreaterThan(0);
+    expect(within(panel).getAllByText("Post-Season").length).toBeGreaterThan(0);
+  });
+
+  it("saves trailer drop and postseason overrides through the targets endpoint", async () => {
+    const fetchMock = mockSeasonSocialFetch(analyticsBase, {
+      targets: [
+        {
+          platform: "instagram",
+          accounts: ["bravotv"],
+          hashtags: ["rhoslc"],
+          keywords: [],
+          timezone: "America/New_York",
+          is_active: true,
+          config: {
+            trailer_drop_at: "2026-01-02T01:00:00+00:00",
+            preseason_start: "2026-01-02T01:00:00+00:00",
+            preseason_start_at: "2026-01-02T01:00:00+00:00",
+            week_zero_start: "2026-01-02T01:00:00+00:00",
+          },
+        },
+      ],
+    });
+
+    render(
+      <SeasonSocialAnalyticsSection
+        showId="show-1"
+        seasonNumber={6}
+        seasonId="season-1"
+        showName="Test Show"
+      />,
+    );
+
+    const trailerInput = await screen.findByLabelText("Trailer Drop");
+    await waitFor(() => {
+      expect(trailerInput).toHaveValue("2026-01-01T20:00");
+    });
+
+    fireEvent.change(trailerInput, { target: { value: "2026-01-02T21:30" } });
+    const postseasonInput = screen.getByLabelText("Post-Season End Override");
+    fireEvent.change(postseasonInput, { target: { value: "2026-02-09T20:00" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save Windows" }));
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(
+          ([input, init]) => String(input).includes("/social/targets?") && init?.method === "PUT",
+        ),
+      ).toBe(true);
+    });
+
+    const putCall = fetchMock.mock.calls.find(
+      ([input, init]) => String(input).includes("/social/targets?") && init?.method === "PUT",
+    );
+    expect(putCall).toBeDefined();
+    const body = JSON.parse(String((putCall?.[1] as RequestInit | undefined)?.body ?? "{}")) as {
+      source_scope?: string;
+      targets?: Array<{ config?: Record<string, unknown>; timezone?: string }>;
+    };
+    expect(body.source_scope).toBe("network");
+    expect(body.targets?.[0]?.timezone).toBe("America/New_York");
+    expect(body.targets?.[0]?.config?.trailer_drop_at).toBe("2026-01-02T21:30");
+    expect(body.targets?.[0]?.config?.preseason_start).toBe("2026-01-02T21:30");
+    expect(body.targets?.[0]?.config?.preseason_start_at).toBe("2026-01-02T21:30");
+    expect(body.targets?.[0]?.config?.week_zero_start).toBe("2026-01-02T21:30");
+    expect(body.targets?.[0]?.config?.postseason_end_at).toBe("2026-02-09T20:00");
   });
 
   it("formats summary count cards with compact number notation", async () => {

--- a/apps/web/tests/social-account-catalog-capacity-route.test.ts
+++ b/apps/web/tests/social-account-catalog-capacity-route.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { requireAdminMock, fetchSocialBackendJsonMock, socialProxyErrorResponseMock } = vi.hoisted(() => ({
+  requireAdminMock: vi.fn(),
+  fetchSocialBackendJsonMock: vi.fn(),
+  socialProxyErrorResponseMock: vi.fn(),
+}));
+
+vi.mock("@/lib/server/auth", () => ({
+  requireAdmin: requireAdminMock,
+}));
+
+vi.mock("@/lib/server/trr-api/social-admin-proxy", () => ({
+  fetchSocialBackendJson: fetchSocialBackendJsonMock,
+  socialProxyErrorResponse: socialProxyErrorResponseMock,
+}));
+
+import { GET } from "@/app/api/admin/trr-api/social/profiles/[platform]/[handle]/catalog/capacity/route";
+
+describe("social account catalog capacity proxy route", () => {
+  beforeEach(() => {
+    requireAdminMock.mockReset();
+    fetchSocialBackendJsonMock.mockReset();
+    socialProxyErrorResponseMock.mockReset();
+    requireAdminMock.mockResolvedValue({ uid: "admin-1" });
+    fetchSocialBackendJsonMock.mockResolvedValue({ available: true, blocked: false });
+    socialProxyErrorResponseMock.mockImplementation((error: unknown) =>
+      Response.json({ error: String(error), code: "BACKEND_UNREACHABLE" }, { status: 502 }),
+    );
+  });
+
+  it("forwards the fresh selected-task and worker query without caching", async () => {
+    const response = await GET(
+      new NextRequest(
+        "http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/catalog/capacity?selected_tasks=post_details%2Ccomments%2Cmedia&detail_worker_count=8&comments_worker_count=8",
+      ),
+      { params: Promise.resolve({ platform: "instagram", handle: "bravotv" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(fetchSocialBackendJsonMock).toHaveBeenCalledWith(
+      "/profiles/instagram/bravotv/catalog/capacity",
+      expect.objectContaining({
+        method: "GET",
+        queryString: "selected_tasks=post_details%2Ccomments%2Cmedia&detail_worker_count=8&comments_worker_count=8",
+        retries: 0,
+        timeoutMs: 30_000,
+      }),
+    );
+  });
+
+  it("returns the standard proxy error when capacity is unavailable", async () => {
+    fetchSocialBackendJsonMock.mockRejectedValueOnce(new Error("offline"));
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/catalog/capacity"),
+      { params: Promise.resolve({ platform: "instagram", handle: "bravotv" }) },
+    );
+
+    expect(response.status).toBe(502);
+    expect(socialProxyErrorResponseMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/tests/social-account-catalog-recent-runs-route.test.ts
+++ b/apps/web/tests/social-account-catalog-recent-runs-route.test.ts
@@ -87,6 +87,18 @@ describe("social account catalog recent runs route", () => {
     ]);
   });
 
+  it("rejects malformed explicit limits before querying recent runs", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/trr-api/social/profiles/instagram/@bravotv/catalog/runs/recent?limit=abc"),
+      { params: Promise.resolve({ platform: "instagram", handle: "@bravotv" }) },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("limit must be an integer");
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
   it("mutes pending attached lanes when the parent run is cancelled", async () => {
     queryMock.mockResolvedValue({
       rows: [

--- a/apps/web/tests/social-account-catalog-run-progress-route.test.ts
+++ b/apps/web/tests/social-account-catalog-run-progress-route.test.ts
@@ -67,6 +67,7 @@ describe("social account catalog run progress proxy route", () => {
         timeoutMs: 30_000,
       }),
     );
+    expect((await response.clone().json()).progress_authoritative).toBe(true);
   });
 
   it("uses the progress timeout and degraded fallback for fast polling", async () => {

--- a/apps/web/tests/social-account-profile-capacity.test.ts
+++ b/apps/web/tests/social-account-profile-capacity.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildInstagramCatalogCapacityQuery,
+  describeInstagramCatalogCapacity,
+  type InstagramCatalogCapacitySnapshot,
+} from "@/components/admin/SocialAccountProfilePage";
+
+const capacity = (
+  overrides: Partial<InstagramCatalogCapacitySnapshot> = {},
+): InstagramCatalogCapacitySnapshot => ({
+  available: true,
+  blocked: false,
+  safe_combined_worker_limit: 10,
+  remaining_workers: 6,
+  raw_requested_workers: 4,
+  backend_effective_requested_workers: 4,
+  effective_details_worker_count: 2,
+  effective_comments_worker_count: 2,
+  active_db_jobs: 0,
+  dispatched_unclaimed_jobs: 0,
+  nonterminal_remote_call_ids: [],
+  ...overrides,
+});
+
+describe("Instagram catalog capacity presentation", () => {
+  it("shows a clean backend-effective snapshot without blocking Start", () => {
+    const result = describeInstagramCatalogCapacity(capacity());
+
+    expect(result.blocked).toBe(false);
+    expect(result.warning).toBeNull();
+    expect(result.summary).toContain("2 detail + 2 comments (4 combined)");
+    expect(result.summary).toContain("6 of 10 slots remain");
+  });
+
+  it("blocks Start only when the fresh backend snapshot is blocked", () => {
+    const result = describeInstagramCatalogCapacity(
+      capacity({ blocked: true, remaining_workers: 1 }),
+    );
+
+    expect(result.blocked).toBe(true);
+    expect(result.warning).toContain("Start is blocked");
+  });
+
+  it("warns without blocking when current capacity is unavailable", () => {
+    const result = describeInstagramCatalogCapacity(null, true);
+
+    expect(result.blocked).toBe(false);
+    expect(result.warning).toContain("backend will make the final safety decision");
+  });
+
+  it("uses the backend-effective zero-session result for a media-only request", () => {
+    const query = buildInstagramCatalogCapacityQuery({
+      selectedTasks: ["media"],
+      detailWorkerCount: 8,
+      commentsWorkerCount: 8,
+    });
+    const result = describeInstagramCatalogCapacity(
+      capacity({
+        raw_requested_workers: 0,
+        backend_effective_requested_workers: 0,
+        effective_details_worker_count: 0,
+        effective_comments_worker_count: 0,
+      }),
+    );
+
+    expect(query.get("selected_tasks")).toBe("media");
+    expect(query.get("detail_worker_count")).toBe("8");
+    expect(query.get("comments_worker_count")).toBe("8");
+    expect(result.summary).toContain("0 detail + 0 comments (0 combined)");
+  });
+
+  it("shows raw 8+8 as backend-effective 2+2", () => {
+    const result = describeInstagramCatalogCapacity(
+      capacity({ raw_requested_workers: 16 }),
+    );
+
+    expect(result.summary).toContain("2 detail + 2 comments (4 combined)");
+    expect(result.summary).toContain("16 raw requested");
+  });
+});

--- a/apps/web/tests/social-account-profile-completion-summary-route.test.ts
+++ b/apps/web/tests/social-account-profile-completion-summary-route.test.ts
@@ -1,33 +1,78 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
-const { requireAdminMock, queryMock, socialProxyErrorResponseMock } = vi.hoisted(() => ({
+const {
+  fetchSocialBackendJsonMock,
+  requireAdminMock,
+  socialProxyErrorResponseMock,
+  toVerifiedAdminContextMock,
+} = vi.hoisted(() => ({
+  fetchSocialBackendJsonMock: vi.fn(),
   requireAdminMock: vi.fn(),
-  queryMock: vi.fn(),
   socialProxyErrorResponseMock: vi.fn(),
+  toVerifiedAdminContextMock: vi.fn(),
 }));
 
 vi.mock("@/lib/server/auth", () => ({
   requireAdmin: requireAdminMock,
-}));
-
-vi.mock("@/lib/server/postgres", () => ({
-  query: queryMock,
+  toVerifiedAdminContext: toVerifiedAdminContextMock,
 }));
 
 vi.mock("@/lib/server/trr-api/social-admin-proxy", () => ({
+  fetchSocialBackendJson: fetchSocialBackendJsonMock,
   socialProxyErrorResponse: socialProxyErrorResponseMock,
 }));
 
 import { GET } from "@/app/api/admin/trr-api/social/profiles/[platform]/[handle]/completion-summary/route";
+import { invalidateRouteResponseCache } from "@/lib/server/admin/route-response-cache";
+
+const CACHE_NAMESPACE = "social-account-profile-completion-summary";
+
+const completionPayload = {
+  platform: "instagram",
+  handle: "bravotv",
+  year: 2026,
+  total_posts: 3,
+  total_reported_comments: 1200,
+  saved_comments: 780,
+  missing_comments: 420,
+  accounted_comments: 1200,
+  lanes: {
+    comments: { finished: 1, in_progress: 2, not_started: 0 },
+    details: { finished: 2, in_progress: 0, not_started: 1 },
+    media: { finished: 1, in_progress: 1, not_started: 1 },
+  },
+};
+
+const requestCompletionSummary = (
+  url = "http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary",
+  params = { platform: "instagram", handle: "bravotv" },
+) => GET(new NextRequest(url), { params: Promise.resolve(params) });
+
+const expectTimingHeaders = (response: Response) => {
+  expect(response.headers.get("server-timing")).toContain("trr_admin_route;dur=");
+  expect(response.headers.get("x-trr-admin-route-ms")).toMatch(/^\d+$/);
+};
 
 describe("social account profile completion summary route", () => {
   beforeEach(() => {
+    invalidateRouteResponseCache(CACHE_NAMESPACE);
     requireAdminMock.mockReset();
-    queryMock.mockReset();
+    toVerifiedAdminContextMock.mockReset();
+    fetchSocialBackendJsonMock.mockReset();
     socialProxyErrorResponseMock.mockReset();
 
-    requireAdminMock.mockResolvedValue({ uid: "admin-1", provider: "firebase" });
+    requireAdminMock.mockResolvedValue({
+      uid: "admin-1",
+      email: "admin@example.com",
+      provider: "firebase",
+    });
+    toVerifiedAdminContextMock.mockReturnValue({
+      uid: "admin-1",
+      email: "admin@example.com",
+      verifiedAt: 1_750_000_000_000,
+    });
+    fetchSocialBackendJsonMock.mockResolvedValue(completionPayload);
     socialProxyErrorResponseMock.mockImplementation((error: unknown) =>
       Response.json({ error: String(error), code: "BACKEND_UNREACHABLE" }, { status: 502 }),
     );
@@ -37,116 +82,130 @@ describe("social account profile completion summary route", () => {
     vi.useRealTimers();
   });
 
-  it("defaults to the current year and counts collab comment gaps from health-aware matches", async () => {
+  it("normalizes the profile, defaults to the current year, and proxies the exact payload", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-29T12:00:00Z"));
 
-    queryMock.mockResolvedValue({
-      rows: [
-        {
-          total_posts: "3",
-          total_reported_comments: "1200",
-          saved_comments: "780",
-          missing_comments: "420",
-          accounted_comments: "1200",
-          comments_finished: "1",
-          comments_in_progress: "2",
-          comments_not_started: "0",
-          details_finished: "2",
-          details_not_started: "1",
-          media_finished: "1",
-          media_in_progress: "1",
-          media_not_started: "1",
-        },
-      ],
-    });
-
-    const response = await GET(
-      new NextRequest("http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary"),
-      { params: Promise.resolve({ platform: "instagram", handle: "bravotv" }) },
+    const response = await requestCompletionSummary(
+      "http://localhost/api/admin/trr-api/social/profiles/Instagram/%40BravoTV/completion-summary",
+      { platform: " Instagram ", handle: " @BravoTV " },
     );
-    const body = (await response.json()) as {
-      year: number;
-      total_posts: number;
-      total_reported_comments: number;
-      saved_comments: number;
-      missing_comments: number;
-      lanes: {
-        comments: { finished: number; in_progress: number; not_started: number };
-      };
-    };
 
     expect(response.status).toBe(200);
-    expect(body.year).toBe(2026);
-    expect(body.total_posts).toBe(3);
-    expect(body.total_reported_comments).toBe(1200);
-    expect(body.saved_comments).toBe(780);
-    expect(body.missing_comments).toBe(420);
-    expect(body.lanes.comments).toEqual({
-      finished: 1,
-      in_progress: 2,
-      not_started: 0,
-    });
-
-    expect(queryMock).toHaveBeenCalledWith(expect.any(String), ["bravotv", 2026]);
-    const sql = String(queryMock.mock.calls[0]?.[0] ?? "");
-    expect(sql).toContain("social.comment_capture_health");
-    expect(sql).toContain("cp.owner_username");
-    expect(sql).toContain("p.owner_username");
-    expect(sql).toContain("p.username");
-    expect(sql).toContain("cp.collaborators");
-    expect(sql).toContain("p.collaborators");
-    expect(sql).toContain("source_account");
-    expect(sql).toContain("p.raw_data");
-    expect(sql).not.toMatch(/\bp\.comments_count\b/);
+    expect(await response.json()).toEqual(completionPayload);
+    expect(response.headers.get("x-trr-cache")).toBe("miss");
+    expect(response.headers.get("x-trr-admin-backend-ms")).toMatch(/^\d+$/);
+    expectTimingHeaders(response);
+    expect(fetchSocialBackendJsonMock).toHaveBeenCalledWith(
+      "/profiles/instagram/bravotv/completion-summary",
+      expect.objectContaining({
+        adminContext: expect.objectContaining({ uid: "admin-1" }),
+        queryString: "year=2026",
+        fallbackError: "Failed to load social completion summary",
+        retries: 0,
+        timeoutMs: 30_000,
+      }),
+    );
   });
 
   it("falls back to the current year when the year query param is invalid", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-01T12:00:00Z"));
-    queryMock.mockResolvedValue({ rows: [] });
 
-    const response = await GET(
-      new NextRequest("http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary?year=nope"),
-      { params: Promise.resolve({ platform: "instagram", handle: "@bravotv" }) },
+    const response = await requestCompletionSummary(
+      "http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary?year=nope",
+      { platform: "instagram", handle: "@bravotv" },
     );
-    const body = (await response.json()) as { year: number; handle: string; total_posts: number };
 
     expect(response.status).toBe(200);
-    expect(body.year).toBe(2026);
-    expect(body.handle).toBe("bravotv");
-    expect(body.total_posts).toBe(0);
-    expect(queryMock).toHaveBeenCalledWith(expect.any(String), ["bravotv", 2026]);
+    expect(fetchSocialBackendJsonMock).toHaveBeenCalledWith(
+      "/profiles/instagram/bravotv/completion-summary",
+      expect.objectContaining({ queryString: "year=2026" }),
+    );
   });
 
-  it("rejects unsupported platforms before querying completion data", async () => {
-    const response = await GET(
-      new NextRequest("http://localhost/api/admin/trr-api/social/profiles/tiktok/bravotv/completion-summary"),
-      { params: Promise.resolve({ platform: "tiktok", handle: "bravotv" }) },
+  it("preserves user-scoped cache miss and hit behavior", async () => {
+    const miss = await requestCompletionSummary(
+      "http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary?year=2026",
     );
-    const body = (await response.json()) as { error: string };
+    const hit = await requestCompletionSummary(
+      "http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary?year=2026",
+    );
+
+    requireAdminMock.mockResolvedValueOnce({
+      uid: "admin-2",
+      email: "other@example.com",
+      provider: "firebase",
+    });
+    toVerifiedAdminContextMock.mockReturnValueOnce({
+      uid: "admin-2",
+      email: "other@example.com",
+      verifiedAt: 1_750_000_000_001,
+    });
+    const otherUserMiss = await requestCompletionSummary(
+      "http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary?year=2026",
+    );
+
+    expect(miss.headers.get("x-trr-cache")).toBe("miss");
+    expect(hit.headers.get("x-trr-cache")).toBe("hit");
+    expect(otherUserMiss.headers.get("x-trr-cache")).toBe("miss");
+    expect(fetchSocialBackendJsonMock).toHaveBeenCalledTimes(2);
+    expectTimingHeaders(hit);
+  });
+
+  it("serves stale cached data when the bounded backend request times out", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-13T12:00:00Z"));
+    await requestCompletionSummary(
+      "http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary?year=2026",
+    );
+    vi.advanceTimersByTime(5 * 60_000 + 1);
+    fetchSocialBackendJsonMock.mockRejectedValueOnce(new Error("upstream request timed out"));
+
+    const response = await requestCompletionSummary(
+      "http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary?year=2026",
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(completionPayload);
+    expect(response.headers.get("x-trr-cache")).toBe("stale");
+    expect(response.headers.get("x-trr-cacheable")).toBe("0");
+    expect(fetchSocialBackendJsonMock).toHaveBeenLastCalledWith(
+      "/profiles/instagram/bravotv/completion-summary",
+      expect.objectContaining({ timeoutMs: 30_000 }),
+    );
+    expectTimingHeaders(response);
+  });
+
+  it("rejects unsupported platforms before requesting completion data", async () => {
+    const response = await requestCompletionSummary(
+      "http://localhost/api/admin/trr-api/social/profiles/tiktok/bravotv/completion-summary",
+      { platform: "tiktok", handle: "bravotv" },
+    );
 
     expect(response.status).toBe(400);
-    expect(body.error).toBe("unsupported_profile");
-    expect(queryMock).not.toHaveBeenCalled();
+    expect(await response.json()).toEqual({ error: "unsupported_profile" });
+    expect(fetchSocialBackendJsonMock).not.toHaveBeenCalled();
+    expectTimingHeaders(response);
   });
 
-  it("returns the shared proxy error response when the completion query fails", async () => {
-    const error = new Error("column p.comments_count does not exist");
-    queryMock.mockRejectedValue(error);
+  it("preserves the shared upstream error envelope when no stale value exists", async () => {
+    const error = new Error("backend unavailable");
+    fetchSocialBackendJsonMock.mockRejectedValue(error);
 
-    const response = await GET(
-      new NextRequest("http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary?year=2026"),
-      { params: Promise.resolve({ platform: "instagram", handle: "bravotv" }) },
+    const response = await requestCompletionSummary(
+      "http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary?year=2026",
     );
-    const body = (await response.json()) as { error: string; code: string };
 
     expect(response.status).toBe(502);
-    expect(body.code).toBe("BACKEND_UNREACHABLE");
-    expect(body.error).toContain("column p.comments_count does not exist");
+    expect(await response.json()).toEqual({
+      error: "Error: backend unavailable",
+      code: "BACKEND_UNREACHABLE",
+    });
     expect(socialProxyErrorResponseMock).toHaveBeenCalledWith(
       error,
       "[api] Failed to load social completion summary",
     );
+    expectTimingHeaders(response);
   });
 });

--- a/apps/web/tests/social-account-profile-completion-summary-route.test.ts
+++ b/apps/web/tests/social-account-profile-completion-summary-route.test.ts
@@ -88,7 +88,7 @@ describe("social account profile completion summary route", () => {
 
     const response = await requestCompletionSummary(
       "http://localhost/api/admin/trr-api/social/profiles/Instagram/%40BravoTV/completion-summary",
-      { platform: " Instagram ", handle: " @BravoTV " },
+      { platform: " Instagram ", handle: " @@BravoTV " },
     );
 
     expect(response.status).toBe(200);

--- a/apps/web/tests/social-account-profile-page.runtime.test.tsx
+++ b/apps/web/tests/social-account-profile-page.runtime.test.tsx
@@ -74,6 +74,7 @@ vi.mock("@/lib/admin/show-admin-routes", async () => {
 
 import SocialAccountProfilePage, {
   __resetSocialProfileRequestInflightForTests,
+  buildCatalogProgressDiagnosticRows,
   getCatalogRepairAuthEndpointSegment,
 } from "@/components/admin/SocialAccountProfilePage";
 import { __resetSharedLiveResourceRegistryForTests } from "@/lib/admin/shared-live-resource";
@@ -346,6 +347,80 @@ describe("SocialAccountProfilePage", () => {
     vi.useRealTimers();
   });
 
+  it("shows the combined Instagram DB worker budget in catalog diagnostics", () => {
+    const progress = {
+      db_session_capacity: {
+        safe_combined_worker_limit: 10,
+        active_workers: 4,
+        remaining_workers: 6,
+      },
+    } as Parameters<typeof buildCatalogProgressDiagnosticRows>[0];
+    const rows = buildCatalogProgressDiagnosticRows(progress);
+
+    expect(rows).toContainEqual({
+      key: "db-session-worker-capacity",
+      label: "DB-safe Combined Workers",
+      value: "10 max · 4 active · 6 remaining",
+      detail: "This combined limit covers Instagram detail, shared-post, comments, and recovery workers.",
+    });
+  });
+
+  it("refreshes Instagram capacity when the dialog opens and immediately before Start", async () => {
+    let capacityCalls = 0;
+    let backfillCalls = 0;
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/catalog/capacity")) {
+        capacityCalls += 1;
+        return jsonResponse({
+          available: true,
+          blocked: false,
+          safe_combined_worker_limit: 10,
+          remaining_workers: 6,
+          raw_requested_workers: 16,
+          backend_effective_requested_workers: 4,
+          effective_details_worker_count: 2,
+          effective_comments_worker_count: 2,
+          active_db_jobs: 0,
+          dispatched_unclaimed_jobs: 0,
+          nonterminal_remote_call_ids: [],
+        });
+      }
+      if (url.includes("/catalog/backfill")) {
+        backfillCalls += 1;
+        return jsonResponse({ run_id: "catalog-capacity-run", status: "queued" });
+      }
+      if (url.includes("/cookies/health")) return jsonResponse(healthyCookieHealth("instagram"));
+      if (url.includes("/snapshot")) {
+        return jsonResponse({
+          summary: baseSummary,
+          catalog_run_progress: null,
+          generated_at: "2026-07-10T12:00:00.000Z",
+        });
+      }
+      if (url.includes("/summary")) return jsonResponse(baseSummary);
+      if (url.includes("/catalog/posts")) {
+        return jsonResponse({ items: [], pagination: { page: 1, page_size: 25, total: 0, total_pages: 1 } });
+      }
+      if (url.includes("/catalog/review-queue")) return jsonResponse({ items: [] });
+      return jsonResponse({});
+    });
+
+    render(<SocialAccountProfilePage platform="instagram" handle="bravotv" activeTab="catalog" />);
+    fireEvent.click(await screen.findByRole("button", { name: "Backfill Posts" }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/2 backend-effective · 8 requested/).length).toBeGreaterThan(0);
+      expect(capacityCalls).toBeGreaterThanOrEqual(1);
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start Backfill" }));
+
+    await waitFor(() => {
+      expect(capacityCalls).toBeGreaterThanOrEqual(2);
+      expect(backfillCalls).toBe(1);
+    });
+  });
+
   it("renders the catalog page without a backgroundCatalogRunId initialization error", async () => {
     mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input);
@@ -485,6 +560,10 @@ describe("SocialAccountProfilePage", () => {
         retrieved_comment_posts: 437,
         saved_comment_media_files: 7,
       },
+      comments_coverage: {
+        ...baseSummary.comments_coverage,
+        active_run_id: "comments-run-active-full-1234567890",
+      },
       catalog_recent_runs: [
         {
           job_id: "job-progress-only",
@@ -548,6 +627,12 @@ describe("SocialAccountProfilePage", () => {
     await waitFor(() => {
       expect(requestUrls.some((url) => url.includes(`/catalog/runs/${runId}/progress`))).toBe(true);
     });
+
+    const browserRunIds = await screen.findByLabelText("Active catalog run ids");
+    expect(within(browserRunIds).getByText("Active catalog run")).toBeInTheDocument();
+    expect(within(browserRunIds).getByText(runId)).toBeInTheDocument();
+    expect(within(browserRunIds).getByText("Active comments run")).toBeInTheDocument();
+    expect(within(browserRunIds).getByText("comments-run-active-full-1234567890")).toBeInTheDocument();
 
     expect(screen.getByText("Saved Posts", { selector: "p" }).parentElement?.textContent?.replace(/\s+/g, " ").trim()).toContain(
       "437 / 438",
@@ -4460,6 +4545,70 @@ describe("SocialAccountProfilePage", () => {
     });
   });
 
+  it("uses browser input events for the bounded month picker and warns on reused comments runs", async () => {
+    let backfillBody: Record<string, unknown> | null = null;
+
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse(baseSummary);
+      }
+      if (url.includes("/cookies/health")) {
+        return jsonResponse(healthyCookieHealth("instagram"));
+      }
+      if (url.includes("/snapshot")) {
+        return jsonResponse({
+          summary: baseSummary,
+          catalog_run_progress: null,
+          generated_at: "2026-07-08T12:00:00.000Z",
+        });
+      }
+      if (url.includes("/catalog/backfill")) {
+        expect(init?.method).toBe("POST");
+        backfillBody = typeof init?.body === "string" ? JSON.parse(init.body) : {};
+        return jsonResponse({
+          run_id: "catalog-run-reused-comments",
+          status: "queued",
+          catalog_run_id: "catalog-run-reused-comments",
+          comments_run_id: "comments-run-existing",
+          comments_reused_existing_run: true,
+          attached_followups: {
+            comments: {
+              run_id: "comments-run-existing",
+              status: "running",
+              state: "running",
+              source: "reused_run",
+            },
+          },
+        });
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="instagram" handle="bravotv" activeTab="catalog" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Backfill Posts" })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Backfill Posts" }));
+    expect(await screen.findByText("Choose what this backfill should run")).toBeInTheDocument();
+
+    fireEvent.input(screen.getByLabelText("Instagram backfill start month"), { target: { value: "2026-05" } });
+    fireEvent.input(screen.getByLabelText("Instagram backfill end month"), { target: { value: "2026-07" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Start Backfill" }));
+
+    await waitFor(() => {
+      expect(backfillBody).toMatchObject({
+        backfill_scope: "bounded_window",
+        date_start: "2026-05-01T00:00:00.000Z",
+        date_end: "2026-07-31T23:59:59.999Z",
+      });
+    });
+    expect(await screen.findByText(/Warning: reused existing comments run/i)).toBeInTheDocument();
+  });
+
   it("requires explicit Live APPLY before a 2025 Instagram backfill is finalized", async () => {
     const runId = "11111111-1111-4111-8111-111111111111";
     const requiredConfirmation = `APPLY INSTAGRAM 2025 BACKFILL ${runId}`;
@@ -5716,6 +5865,106 @@ describe("SocialAccountProfilePage", () => {
     expect(await screen.findByText("Posts waiting in the streaming comments lane")).toBeInTheDocument();
     expect(screen.getByText("DVstream1")).toBeInTheDocument();
     expect(screen.getByText("Public-first")).toBeInTheDocument();
+  });
+
+  it("shows the attached comments run when catalog streaming is superseded", async () => {
+    const expectedYear = new Date().getUTCFullYear();
+    const progressPayload = {
+      run_id: "catalog-direct-run-1",
+      run_status: "running",
+      source_scope: "network",
+      selected_tasks: ["post_details", "comments"],
+      effective_selected_tasks: ["post_details", "comments"],
+      comments_run_id: "comments-direct-run-1",
+      comments_streaming: {
+        enabled: false,
+        state: "superseded_by_direct_comments_run",
+        source: "catalog_batch_persist",
+        comments_run_id: "comments-direct-run-1",
+        next_action: {
+          label: "Watch direct comments run",
+          detail: "The comments run is processing the saved post set.",
+        },
+      },
+      stages: {},
+      per_handle: [],
+      recent_log: [],
+      alerts: [],
+      summary: {
+        total_jobs: 1,
+        completed_jobs: 0,
+        failed_jobs: 0,
+        active_jobs: 1,
+      },
+    };
+
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse({
+          ...baseSummary,
+          catalog_recent_runs: [
+            {
+              run_id: "catalog-direct-run-1",
+              status: "running",
+              created_at: "2026-06-12T12:00:00Z",
+              selected_tasks: ["post_details", "comments"],
+              effective_selected_tasks: ["post_details", "comments"],
+              comments_run_id: "comments-direct-run-1",
+            },
+          ],
+        });
+      }
+      if (url.includes("/snapshot")) {
+        return jsonResponse({
+          summary: {
+            ...baseSummary,
+            catalog_recent_runs: [
+              {
+                run_id: "catalog-direct-run-1",
+                status: "running",
+                created_at: "2026-06-12T12:00:00Z",
+                selected_tasks: ["post_details", "comments"],
+                effective_selected_tasks: ["post_details", "comments"],
+                comments_run_id: "comments-direct-run-1",
+              },
+            ],
+          },
+          catalog_run_progress: progressPayload,
+        });
+      }
+      if (url.includes("/catalog/runs/catalog-direct-run-1/progress")) {
+        return jsonResponse(progressPayload);
+      }
+      if (url.includes(`/completion-summary?year=${expectedYear}`)) {
+        return jsonResponse({
+          year: expectedYear,
+          total_posts: 437,
+          total_reported_comments: 1820,
+          saved_comments: 1764,
+          missing_comments: 56,
+          accounted_comments: 1820,
+          lanes: {
+            comments: { finished: 320, in_progress: 18, not_started: 99 },
+            details: { finished: 401, in_progress: 11, not_started: 25 },
+            media: { finished: 288, in_progress: 44, not_started: 105 },
+          },
+        });
+      }
+      if (url.includes("/cookies/health")) {
+        return jsonResponse(healthyCookieHealth("instagram"));
+      }
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="instagram" handle="bravotv" activeTab="catalog" />);
+
+    const banner = await screen.findByTestId("instagram-comments-streaming-banner");
+    const streaming = within(banner);
+    expect(streaming.getByText("Comments Moved To A Direct Run")).toBeInTheDocument();
+    expect(streaming.getByText("Superseded By Direct Comments Run")).toBeInTheDocument();
+    expect(streaming.getByText("run comments")).toBeInTheDocument();
+    expect(streaming.getByText("Next: Watch the attached comments run")).toBeInTheDocument();
   });
 
   it("uses resolved attached follow-up status over stale stage graph lanes", async () => {
@@ -7622,6 +7871,7 @@ describe("SocialAccountProfilePage", () => {
   });
 
   it("renders Twitter catalog actions with the shared profile UI", async () => {
+    let receivedBackfillBody: Record<string, unknown> | null = null;
     mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes("/summary")) {
@@ -7644,17 +7894,7 @@ describe("SocialAccountProfilePage", () => {
         return jsonResponse({ items: [] });
       }
       if (url.includes("/catalog/backfill")) {
-        expect(init?.method).toBe("POST");
-        const requestBody = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
-        expect(requestBody).toMatchObject({
-          source_scope: "network",
-          backfill_scope: "bounded_window",
-        });
-        const dateStart = Date.parse(String(requestBody.date_start));
-        const dateEnd = Date.parse(String(requestBody.date_end));
-        expect(Number.isNaN(dateStart)).toBe(false);
-        expect(Number.isNaN(dateEnd)).toBe(false);
-        expect(dateEnd - dateStart).toBe(365 * 24 * 60 * 60 * 1000);
+        receivedBackfillBody = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
         return jsonResponse({
           run_id: "catalog-run-twitter-12345678",
           status: "queued",
@@ -7686,6 +7926,15 @@ describe("SocialAccountProfilePage", () => {
     await waitFor(() => {
       expect(screen.getByText("Twitter / X backfill queued for Post Details, Comments, Media. Catalog catalog-.")).toBeInTheDocument();
     });
+    expect(receivedBackfillBody).toMatchObject({
+      source_scope: "network",
+      backfill_scope: "bounded_window",
+    });
+    const dateStart = Date.parse(String(receivedBackfillBody?.date_start));
+    const dateEnd = Date.parse(String(receivedBackfillBody?.date_end));
+    expect(Number.isNaN(dateStart)).toBe(false);
+    expect(Number.isNaN(dateEnd)).toBe(false);
+    expect(dateEnd - dateStart).toBe(365 * 24 * 60 * 60 * 1000);
   });
 
   it("expands caption search without switching tabs and shows backend search results", async () => {

--- a/apps/web/tests/social-account-profile-page.runtime.test.tsx
+++ b/apps/web/tests/social-account-profile-page.runtime.test.tsx
@@ -76,6 +76,7 @@ import SocialAccountProfilePage, {
   __resetSocialProfileRequestInflightForTests,
   buildCatalogProgressDiagnosticRows,
   getCatalogRepairAuthEndpointSegment,
+  waitForCatalogRetry,
 } from "@/components/admin/SocialAccountProfilePage";
 import { __resetSharedLiveResourceRegistryForTests } from "@/lib/admin/shared-live-resource";
 import * as devAdminBypass from "@/lib/admin/dev-admin-bypass";
@@ -363,6 +364,64 @@ describe("SocialAccountProfilePage", () => {
       value: "10 max · 4 active · 6 remaining",
       detail: "This combined limit covers Instagram detail, shared-post, comments, and recovery workers.",
     });
+  });
+
+  it("settles and clears a cancelled catalog retry wait", async () => {
+    vi.useFakeTimers();
+    const abortController = new AbortController();
+    const retryWait = waitForCatalogRetry(60_000, abortController.signal);
+
+    abortController.abort();
+
+    await expect(retryWait).resolves.toBe("cancelled");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("does not leave catalog loading stuck when a retry is cancelled by a filter change", async () => {
+    const catalogRequests: string[] = [];
+    mocks.fetchAdminWithAuth.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/summary")) {
+        return jsonResponse({
+          ...baseSummary,
+          catalog_recent_runs: [],
+        });
+      }
+      if (url.includes("/catalog/posts")) {
+        catalogRequests.push(url);
+        if (url.includes("assignment_status=assigned")) {
+          return jsonResponse({
+            items: [],
+            pagination: { page: 1, page_size: 25, total: 0, total_pages: 1 },
+          });
+        }
+        return jsonResponse(
+          {
+            error: "TRR-Backend request timed out.",
+            code: "UPSTREAM_TIMEOUT",
+            retryable: true,
+            retry_after_seconds: 60,
+            upstream_status: 504,
+          },
+          504,
+        );
+      }
+      if (url.includes("/catalog/review-queue")) return jsonResponse({ items: [] });
+      throw new Error(`Unhandled request: ${url}`);
+    });
+
+    render(<SocialAccountProfilePage platform="instagram" handle="bravotv" activeTab="catalog" />);
+
+    await waitFor(() => expect(catalogRequests).toHaveLength(1));
+    expect(screen.getByText("Loading catalog posts…")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^assigned$/i }));
+
+    await waitFor(() => {
+      expect(catalogRequests.some((url) => url.includes("assignment_status=assigned"))).toBe(true);
+      expect(screen.getByText("No catalog posts found for this filter.")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Loading catalog posts…")).not.toBeInTheDocument();
   });
 
   it("refreshes Instagram capacity when the dialog opens and immediately before Start", async () => {

--- a/apps/web/tests/social-landing-repository.test.ts
+++ b/apps/web/tests/social-landing-repository.test.ts
@@ -173,6 +173,20 @@ describe("social landing repository", () => {
     ]);
 
     fetchSocialBackendJsonMock.mockImplementation(async (path: string) => {
+      if (path === "/landing-scrape-job-health") {
+        return {
+          window_hours: 8,
+          window_started_at: null,
+          generated_at: null,
+          total_jobs: 0,
+          active_jobs: 0,
+          failed_jobs: 0,
+          failure_signal_jobs: 0,
+          in_failed_sql_transaction_hits: 0,
+          latest_failure_at: null,
+        };
+      }
+
       if (path === "/landing-progress-rollup") {
         return { rows: [] };
       }
@@ -669,82 +683,65 @@ describe("social landing repository", () => {
       show_count: expect.any(Number),
     });
   });
-
-  it("sums Instagram landing comments from post-detail reported counts", async () => {
-    await getSocialLandingPayload();
-
-    const landingCall = queryMock.mock.calls.find(([sql]) =>
-      String(sql).includes("landing_social_progress"),
-    );
-    const sql = String(landingCall?.[0] ?? "");
-
-    expect(sql).toContain("FROM social.instagram_posts p");
-    expect(sql).toContain("FROM social.instagram_account_catalog_posts p");
-    expect(sql).toContain("greatest(coalesce(p.comments_count, 0),");
-    expect(sql).toContain("p.raw_data");
-    expect(sql).toContain("-> 'metrics' ->> 'comments_count'");
-    expect(sql).toContain(
-      "sum(rows.reported_comments)::int AS comments_total_count",
-    );
-    expect(sql).toContain("coalesce(materialized_counts.comments_total_count, 0)");
-  });
-
-  it("loads SocialBlade progress counts through the backend instead of direct app SQL", async () => {
+  it("loads unauthenticated social progress through the backend rollup without direct SQL", async () => {
     const defaultSocialBackend = fetchSocialBackendJsonMock.getMockImplementation();
     if (!defaultSocialBackend) throw new Error("Missing default social backend mock");
     fetchSocialBackendJsonMock.mockImplementation(async (path: string, options?: unknown) => {
-      if (path === "/landing-socialblade-progress-counts") {
+      if (path === "/landing-progress-rollup") {
         return {
           rows: [
             {
               platform: "instagram",
               account_handle: "bravotv",
+              saved_count: 7,
+              scraped_count: 9,
               socialblade_supported: true,
               socialblade_scraped_count: 1,
               socialblade_saved_count: 1,
+              following_saved_count: 25,
+              following_total_count: 30,
+              comments_saved_count: 100,
+              comments_total_count: 120,
+              media_saved_count: 4,
+              media_total_count: 6,
             },
           ],
+          cache_status: "miss",
+          generated_at: "2026-07-13T12:00:00.000Z",
+          stale: false,
         };
       }
       return defaultSocialBackend(path, options);
     });
-    queryMock.mockImplementation(async (sql: string) => {
-      if (String(sql).includes("landing_social_progress")) {
-        return {
-          rows: [
-            {
-              platform: "instagram",
-              account_handle: "bravotv",
-              saved_count: 0,
-              scraped_count: 0,
-              socialblade_supported: true,
-            },
-          ],
-        };
-      }
-      return { rows: [] };
-    });
 
-    const payload = await getSocialLandingPayload();
+    const result = await getSocialLandingPayloadResult();
 
-    const landingCall = queryMock.mock.calls.find(([sql]) =>
-      String(sql).includes("landing_social_progress"),
-    );
-    const sql = String(landingCall?.[0] ?? "");
     const progressCall = fetchSocialBackendJsonMock.mock.calls.find(
-      ([path]) => path === "/landing-socialblade-progress-counts",
+      ([path]) => path === "/landing-progress-rollup",
     );
-    const progressOptions = progressCall?.[1] as { body?: string; method?: string } | undefined;
+    const progressOptions = progressCall?.[1] as
+      | { body?: string; method?: string; adminContext?: unknown }
+      | undefined;
     const progressBody = JSON.parse(progressOptions?.body ?? "{}") as {
       platforms?: string[];
       account_handles?: string[];
     };
 
-    expect(sql).not.toContain("pipeline.socialblade_growth_data");
     expect(progressOptions?.method).toBe("POST");
+    expect(progressOptions?.adminContext).toBeUndefined();
     expect(progressBody.platforms?.length).toBe(progressBody.account_handles?.length);
     expect(progressBody.account_handles).toEqual(expect.arrayContaining(["bravotv"]));
-    expect(payload.network_sets[0]?.handles).toEqual(
+    expect(
+      queryMock.mock.calls.some(([sql]) => String(sql).includes("landing_social_progress")),
+    ).toBe(false);
+    expect(result.cacheable).toBe(true);
+    expect(result.payload.social_progress_status).toEqual({
+      source: "backend",
+      cache_status: "miss",
+      generated_at: "2026-07-13T12:00:00.000Z",
+      stale: false,
+    });
+    expect(result.payload.network_sets[0]?.handles).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           platform: "instagram",
@@ -752,10 +749,17 @@ describe("social landing repository", () => {
           progress: expect.objectContaining({
             lanes: expect.arrayContaining([
               expect.objectContaining({
+                key: "comments",
+                saved_count: 100,
+                scraped_count: 120,
+                total_count: 120,
+              }),
+              expect.objectContaining({
                 key: "socialblade",
                 status: "ready",
-                saved_count: 1,
-                scraped_count: 1,
+                saved_count: 26,
+                scraped_count: 26,
+                total_count: 31,
               }),
             ]),
           }),
@@ -825,6 +829,45 @@ describe("social landing repository", () => {
     expect(rollupOptions?.method).toBe("POST");
     expect(rollupBody.platforms?.length).toBe(rollupBody.account_handles?.length);
     expect(rollupBody.account_handles).toEqual(expect.arrayContaining(["bravotv"]));
+    const bravotvHandle = result.payload.network_sets[0]?.handles.find(
+      (handle) => handle.platform === "instagram" && handle.handle === "bravotv",
+    );
+    if (!bravotvHandle?.progress) {
+      throw new Error("Expected bravotv progress from the backend rollup");
+    }
+    const postsLane = bravotvHandle.progress.lanes.find((lane) => lane.key === "posts");
+    const commentsLane = bravotvHandle.progress.lanes.find((lane) => lane.key === "comments");
+    const mediaLane = bravotvHandle.progress.lanes.find((lane) => lane.key === "media");
+    if (!postsLane || !commentsLane || !mediaLane) {
+      throw new Error("Expected posts, comments, and media progress lanes");
+    }
+
+    expect(postsLane).toEqual(
+      expect.objectContaining({
+        key: "posts",
+        saved_count: 7,
+        scraped_count: 9,
+        total_count: 9,
+      }),
+    );
+    expect(commentsLane).toEqual(
+      expect.objectContaining({
+        key: "comments",
+        saved_count: 100,
+        scraped_count: 120,
+        total_count: 120,
+      }),
+    );
+    expect(commentsLane.scraped_percent).toBeGreaterThan(0);
+    expect(mediaLane).toEqual(
+      expect.objectContaining({
+        key: "media",
+        saved_count: 4,
+        scraped_count: 6,
+        total_count: 6,
+      }),
+    );
+    expect(mediaLane.saved_percent).toBeLessThan(mediaLane.scraped_percent);
     expect(result.payload.network_sets[0]?.handles).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -847,24 +890,22 @@ describe("social landing repository", () => {
   });
 
   it("includes recent scrape job health for the social landing badge", async () => {
-    queryMock.mockImplementation(async (sql: string) => {
-      if (String(sql).includes("landing_social_scrape_job_health")) {
+    const defaultSocialBackend = fetchSocialBackendJsonMock.getMockImplementation();
+    if (!defaultSocialBackend) throw new Error("Missing default social backend mock");
+    fetchSocialBackendJsonMock.mockImplementation(async (path: string, options?: unknown) => {
+      if (path === "/landing-scrape-job-health") {
         return {
-          rows: [
-            {
-              generated_at: "2026-05-18T12:00:00.000Z",
-              window_started_at: "2026-05-18T04:00:00.000Z",
-              total_jobs: "9",
-              active_jobs: "1",
-              failed_jobs: "2",
-              failure_signal_jobs: "3",
-              in_failed_sql_transaction_hits: "1",
-              latest_failure_at: "2026-05-18T11:45:00.000Z",
-            },
-          ],
+          generated_at: "2026-05-18T12:00:00.000Z",
+          window_started_at: "2026-05-18T04:00:00.000Z",
+          total_jobs: "9",
+          active_jobs: "1",
+          failed_jobs: "2",
+          failure_signal_jobs: "3",
+          in_failed_sql_transaction_hits: "1",
+          latest_failure_at: "2026-05-18T11:45:00.000Z",
         };
       }
-      return { rows: [] };
+      return defaultSocialBackend(path, options);
     });
 
     const payload = await getSocialLandingPayload();
@@ -880,6 +921,48 @@ describe("social landing repository", () => {
       in_failed_sql_transaction_hits: 1,
       latest_failure_at: "2026-05-18T11:45:00.000Z",
     });
+    expect(fetchSocialBackendJsonMock).toHaveBeenCalledWith(
+      "/landing-scrape-job-health",
+      expect.objectContaining({
+        fallbackError: "Failed to load social landing scrape-job health",
+        retries: 1,
+        timeoutMs: 25_000,
+      }),
+    );
+    expect(
+      queryMock.mock.calls.some(([sql]) =>
+        String(sql).includes("landing_social_scrape_job_health"),
+      ),
+    ).toBe(false);
+  });
+
+  it("degrades scrape job health to the empty summary when the backend read fails", async () => {
+    const expectedWarn = captureExpectedConsoleWarn(
+      /^\[social-landing\] Failed to load scrape job health /,
+    );
+    const defaultSocialBackend = fetchSocialBackendJsonMock.getMockImplementation();
+    if (!defaultSocialBackend) throw new Error("Missing default social backend mock");
+    fetchSocialBackendJsonMock.mockImplementation(async (path: string, options?: unknown) => {
+      if (path === "/landing-scrape-job-health") {
+        throw new Error("health backend unavailable");
+      }
+      return defaultSocialBackend(path, options);
+    });
+
+    const payload = await getSocialLandingPayload();
+
+    expect(payload.scrape_job_health).toEqual({
+      window_hours: 8,
+      window_started_at: null,
+      generated_at: null,
+      total_jobs: 0,
+      active_jobs: 0,
+      failed_jobs: 0,
+      failure_signal_jobs: 0,
+      in_failed_sql_transaction_hits: 0,
+      latest_failure_at: null,
+    });
+    expectedWarn.restore();
   });
 
   it("labels assigned YouTube playlist show handles with playlist metadata", async () => {
@@ -1004,6 +1087,44 @@ describe("social landing repository", () => {
       }),
     ]);
     expect(result.cacheable).toBe(true);
+  });
+
+  it("starts social progress before cast SocialBlade rows resolve", async () => {
+    const events: string[] = [];
+    let resolveCastSocialBladeRows!: () => void;
+    const castSocialBladeRowsPromise = new Promise<{ rows: [] }>((resolve) => {
+      resolveCastSocialBladeRows = () => resolve({ rows: [] });
+    });
+    const defaultSocialBackend = fetchSocialBackendJsonMock.getMockImplementation();
+    if (!defaultSocialBackend) throw new Error("Missing default social backend mock");
+
+    fetchSocialBackendJsonMock.mockImplementation(async (path: string, options?: unknown) => {
+      if (path === "/landing-socialblade-rows") {
+        events.push("cast-socialblade-started");
+        return castSocialBladeRowsPromise;
+      }
+      if (path === "/landing-progress-rollup") {
+        events.push("social-progress-started");
+        return { rows: [] };
+      }
+      return defaultSocialBackend(path, options);
+    });
+
+    const resultPromise = getSocialLandingPayloadResult();
+    while (!events.includes("cast-socialblade-started")) {
+      await delay(0);
+    }
+    await delay(0);
+
+    expect(events).toContain("social-progress-started");
+    expect(events.indexOf("social-progress-started")).toBeGreaterThan(
+      events.indexOf("cast-socialblade-started"),
+    );
+
+    resolveCastSocialBladeRows();
+    const result = await resultPromise;
+
+    expect(result.payload.cast_socialblade_shows).toEqual([]);
   });
 
   it("falls back to local shared-source rows when backend shared-source reads fail", async () => {
@@ -1135,7 +1256,49 @@ describe("social landing repository", () => {
       }
       if (path.startsWith("/shared/ingest/runs")) return [];
       if (path.startsWith("/shared/review-queue")) return { items: [] };
-      if (path === "/landing-socialblade-progress-counts") return { rows: [] };
+      if (path === "/landing-scrape-job-health") {
+        return {
+          window_hours: 8,
+          window_started_at: null,
+          generated_at: null,
+          total_jobs: 0,
+          active_jobs: 0,
+          failed_jobs: 0,
+          failure_signal_jobs: 0,
+          in_failed_sql_transaction_hits: 0,
+          latest_failure_at: null,
+        };
+      }
+      if (path === "/landing-progress-rollup") {
+        return {
+          rows: [
+            {
+              platform: "instagram",
+              account_handle: "bravotv",
+              saved_count: 90,
+              scraped_count: 75,
+            },
+            {
+              platform: "instagram",
+              account_handle: "thetraitorsus",
+              saved_count: 442,
+              scraped_count: 442,
+            },
+            {
+              platform: "tiktok",
+              account_handle: "thetraitorsus",
+              saved_count: 275,
+              scraped_count: 275,
+            },
+            {
+              platform: "twitter",
+              account_handle: "thetraitorsus",
+              saved_count: 5227,
+              scraped_count: 285,
+            },
+          ],
+        };
+      }
       if (path.startsWith("/profiles/") && path.endsWith("/summary")) {
         const [platform, rawHandle] = path
           .replace(/^\/profiles\//, "")
@@ -1176,40 +1339,6 @@ describe("social landing repository", () => {
         ],
       ]),
     );
-    queryMock.mockImplementation(async (sql: string) => {
-      if (String(sql).includes("landing_social_progress")) {
-        return {
-          rows: [
-            {
-              platform: "instagram",
-              account_handle: "bravotv",
-              saved_count: 90,
-              scraped_count: 75,
-            },
-            {
-              platform: "instagram",
-              account_handle: "thetraitorsus",
-              saved_count: 442,
-              scraped_count: 442,
-            },
-            {
-              platform: "tiktok",
-              account_handle: "thetraitorsus",
-              saved_count: 275,
-              scraped_count: 275,
-            },
-            {
-              platform: "twitter",
-              account_handle: "thetraitorsus",
-              saved_count: 5227,
-              scraped_count: 285,
-            },
-          ],
-        };
-      }
-      return { rows: [] };
-    });
-
     const result = await getSocialLandingPayloadResult();
     const networkSet = result.payload.network_sets[0];
     const traitors = result.payload.show_sets.find(

--- a/apps/web/tests/social-season-hint-routes.test.ts
+++ b/apps/web/tests/social-season-hint-routes.test.ts
@@ -34,7 +34,10 @@ vi.mock("@/lib/server/trr-api/social-admin-proxy", () => ({
 import { GET as getJobs } from "@/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/social/jobs/route";
 import { GET as getRuns } from "@/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/social/runs/route";
 import { GET as getRunsSummary } from "@/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/social/runs/summary/route";
-import { GET as getTargets } from "@/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/social/targets/route";
+import {
+  GET as getTargets,
+  PUT as putTargets,
+} from "@/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/social/targets/route";
 import { GET as getAnalytics } from "@/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/social/analytics/route";
 import { GET as getWeek } from "@/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/social/analytics/week/[weekIndex]/route";
 import { GET as getWeekSummary } from "@/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/social/analytics/week/[weekIndex]/summary/route";
@@ -108,6 +111,76 @@ describe("social routes season_id hint forwarding", () => {
     );
     const options = fetchSeasonBackendJsonMock.mock.calls[0]?.[3] as { queryString?: string };
     expect(String(options.queryString ?? "")).not.toContain("season_id=");
+  });
+
+  it("accepts season-window config objects on targets PUT", async () => {
+    const request = new NextRequest(
+      `http://localhost/api/admin/trr-api/shows/${showId}/seasons/6/social/targets?season_id=${seasonId}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({
+          source_scope: "network",
+          targets: [
+            {
+              platform: "instagram",
+              accounts: ["bravotv"],
+              hashtags: ["rhoslc"],
+              keywords: [],
+              timezone: "America/New_York",
+              is_active: true,
+              config: {
+                trailer_drop_at: "2026-01-02T21:30",
+                postseason_end_at: "2026-02-09T20:00",
+              },
+            },
+          ],
+        }),
+      },
+    );
+
+    const response = await putTargets(request, { params: Promise.resolve({ showId, seasonNumber: "6" }) });
+
+    expect(response.status).toBe(200);
+    expect(fetchSeasonBackendJsonMock).toHaveBeenCalledWith(
+      showId,
+      "6",
+      "/targets",
+      expect.objectContaining({
+        method: "PUT",
+        seasonIdHint: seasonId,
+        timeoutMs: 30_000,
+      }),
+    );
+    const options = fetchSeasonBackendJsonMock.mock.calls[0]?.[3] as { body?: string };
+    const forwardedBody = JSON.parse(String(options.body ?? "{}")) as {
+      targets?: Array<{ config?: Record<string, unknown> }>;
+    };
+    expect(forwardedBody.targets?.[0]?.config?.trailer_drop_at).toBe("2026-01-02T21:30");
+    expect(forwardedBody.targets?.[0]?.config?.postseason_end_at).toBe("2026-02-09T20:00");
+  });
+
+  it("rejects invalid target config shapes on targets PUT", async () => {
+    const request = new NextRequest(
+      `http://localhost/api/admin/trr-api/shows/${showId}/seasons/6/social/targets?season_id=${seasonId}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({
+          targets: [
+            {
+              platform: "instagram",
+              config: ["not", "an", "object"],
+            },
+          ],
+        }),
+      },
+    );
+
+    const response = await putTargets(request, { params: Promise.resolve({ showId, seasonNumber: "6" }) });
+    const payload = (await response.json()) as { error?: string; code?: string };
+
+    expect(response.status).toBe(400);
+    expect(payload.code).toBe("BAD_REQUEST");
+    expect(fetchSeasonBackendJsonMock).not.toHaveBeenCalled();
   });
 
   it("returns 400 for invalid season_id on jobs route", async () => {


### PR DESCRIPTION
## Summary
- add catalog capacity and degraded progress handling
- preserve stale cards and clarify auth/comment recovery state
- add season target-window editing and SocialBlade health normalization

## Validation
- seven focused suites passed
- the large profile runtime suite has nine failures that reproduce unchanged in the original dirty source and are not introduced by this partition

## Dependencies
Targets social-backend-ownership and consumes the backend social recovery stack.