### PR TITLE
Canonicalize the Screenalytics admin workspace

### DIFF
--- a/apps/web/src/app/admin/cast-screentime/CastScreentimePageClient.tsx
+++ b/apps/web/src/app/admin/cast-screentime/CastScreentimePageClient.tsx
@@ -429,6 +429,7 @@ const importModes: ImportMode[] = ["youtube_url", "external_url", "social_youtub
 const decisionScopes: OwnerScope[] = ["episode", "season", "show"];
 const subtitleCuePageSize = 50;
 const subtitlePollingDelays = [2_000, 5_000, 15_000] as const;
+const subtitleAutoPollingMaxAttempts = 6;
 const screenalyticsKnownContext = {
   show: {
     id: SCREENALYTICS_RHOBH_S5_E16_TEST_DEFAULTS.show_id,
@@ -777,9 +778,12 @@ export default function CastScreentimePageClient() {
   const [subtitleCueLoading, setSubtitleCueLoading] = useState(false);
   const [subtitleDownloadPending, setSubtitleDownloadPending] = useState(false);
   const [subtitlePollVersion, setSubtitlePollVersion] = useState(0);
+  const [subtitleAutoPollingStopped, setSubtitleAutoPollingStopped] = useState(false);
+  const subtitleAutoPollingStoppedRef = useRef(false);
   const mountedRef = useRef(true);
 
   useEffect(() => {
+    mountedRef.current = true;
     return () => {
       mountedRef.current = false;
     };
@@ -804,6 +808,11 @@ export default function CastScreentimePageClient() {
       ? [...mediaKindOptions, { value: promoSubtype.trim(), label: formatMediaKindLabel(promoSubtype) }]
       : mediaKindOptions;
   const activeVideoAssetId = String(videoAsset?.id || run?.video_asset_id || "").trim();
+
+  useEffect(() => {
+    subtitleAutoPollingStoppedRef.current = false;
+    setSubtitleAutoPollingStopped(false);
+  }, [activeVideoAssetId]);
 
   useEffect(() => {
     const timeoutId = window.setTimeout(() => {
@@ -852,8 +861,17 @@ export default function CastScreentimePageClient() {
           );
         });
         if (normalized.status === "queued" || normalized.status === "running") {
+          if (subtitleAutoPollingStoppedRef.current) return;
+          if (pollAttempt + 1 >= subtitleAutoPollingMaxAttempts) {
+            subtitleAutoPollingStoppedRef.current = true;
+            setSubtitleAutoPollingStopped(true);
+            return;
+          }
           const delay = subtitlePollingDelays[Math.min(pollAttempt, subtitlePollingDelays.length - 1)];
           timerId = window.setTimeout(() => void loadSummary(pollAttempt + 1), delay);
+        } else if (subtitleAutoPollingStoppedRef.current) {
+          subtitleAutoPollingStoppedRef.current = false;
+          setSubtitleAutoPollingStopped(false);
         }
       } catch (summaryError) {
         if (!cancelled) {
@@ -1040,6 +1058,9 @@ export default function CastScreentimePageClient() {
       const payload = await parseResponse<UploadSessionStatusPayload>(
         await fetchAdminWithAuth(`/api/admin/trr-api/cast-screentime/upload-sessions/${uploadSessionId}`),
       );
+      if (!mountedRef.current) {
+        throw new Error("Import polling stopped");
+      }
       setLatestUpload((current) => ({ ...(current || { upload_session_id: uploadSessionId }), ...payload }));
       if (payload.status === "failed") {
         throw new Error(payload.error_text || "Import failed");
@@ -1210,6 +1231,8 @@ export default function CastScreentimePageClient() {
       setSubtitleSummary((current) =>
         normalizeSubtitleSummary({ ...(current ?? {}), ...payload }, activeVideoAssetId),
       );
+      subtitleAutoPollingStoppedRef.current = false;
+      setSubtitleAutoPollingStopped(false);
       setSubtitlePollVersion((current) => current + 1);
     } catch (actionError) {
       setSubtitleError(actionError instanceof Error ? actionError.message : "Subtitle extraction could not be queued");
@@ -1561,8 +1584,10 @@ export default function CastScreentimePageClient() {
         throw new Error("Clipboard access is not available in this browser.");
       }
       await clipboard.writeText(buildScreenalyticsRunUrl(runId));
+      if (!mountedRef.current) return;
       setCopiedRunLinkId(runId);
       window.setTimeout(() => {
+        if (!mountedRef.current) return;
         setCopiedRunLinkId((current) => (current === runId ? null : current));
       }, 1800);
     } catch (copyError) {
@@ -2122,7 +2147,9 @@ export default function CastScreentimePageClient() {
 
           {subtitleSummary?.status === "queued" || subtitleSummary?.status === "running" ? (
             <p className="mt-4 text-sm text-neutral-600" role="status">
-              Subtitle extraction is running in the background. This video remains available for analysis.
+              {subtitleAutoPollingStopped
+                ? `Subtitle extraction is still running. Automatic refresh paused after ${subtitleAutoPollingMaxAttempts} checks; use Refresh to check again.`
+                : "Subtitle extraction is running in the background. This video remains available for analysis."}
             </p>
           ) : null}
           {subtitleSummary?.status === "unavailable" ? (

--- a/apps/web/src/app/admin/cast-screentime/CastScreentimePageClient.tsx
+++ b/apps/web/src/app/admin/cast-screentime/CastScreentimePageClient.tsx
@@ -2,12 +2,29 @@
 
 import Image from "next/image";
 import type { ReactNode } from "react";
-import { useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import AdminBreadcrumbs from "@/components/admin/AdminBreadcrumbs";
 import AdminGlobalHeader from "@/components/admin/AdminGlobalHeader";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { buildAdminSectionBreadcrumb } from "@/lib/admin/admin-breadcrumbs";
-import { fetchAdminWithAuth } from "@/lib/admin/client-auth";
+import { fetchAdminWithAuth as fetchAdminWithAuthBase } from "@/lib/admin/client-auth";
+import {
+  buildScreenalyticsRunPath,
+  buildScreenalyticsRunUrl,
+  isScreenalyticsRhobhS5E16TestPath,
+  SCREENALYTICS_CANONICAL_PATH,
+  SCREENALYTICS_RHOBH_S5_E16_TEST_DEFAULTS,
+  SCREENALYTICS_RHOBH_S5_E16_TEST_SEASON_ID,
+} from "@/lib/admin/screenalytics-routes";
 import { useAdminGuard } from "@/lib/admin/useAdminGuard";
 import { getAllowedReviewTransitions, getExecutionStatusLabel, getRunOverviewMessage } from "./run-state";
 
@@ -17,8 +34,14 @@ type MediaKind = string;
 type ImportMode = "youtube_url" | "external_url" | "social_youtube_row";
 type VideoClassFilter = "all" | VideoClass;
 
+const fetchAdminWithAuth: typeof fetchAdminWithAuthBase = (input, init, options) =>
+  fetchAdminWithAuthBase(input, init, { allowDevAdminBypass: true, ...options });
+
 type UploadSessionPayload = {
   upload_session_id: string;
+  status?: string;
+  error_text?: string | null;
+  promoted_video_asset_id?: string | null;
   put_url?: string;
   temp_object_key?: string;
   expires_at?: string;
@@ -28,6 +51,17 @@ type UploadSessionPayload = {
   media_kind?: string | null;
   video_class?: VideoClass;
   promo_subtype?: string | null;
+};
+
+type UploadSessionStatusPayload = UploadSessionPayload & {
+  video_asset?: VideoAssetPayload | null;
+};
+
+type ImportVideoAssetResponsePayload = {
+  upload_session_id: string;
+  queued?: boolean;
+  status?: string;
+  video_asset?: VideoAssetPayload | null;
 };
 
 type VideoAssetPayload = {
@@ -49,6 +83,76 @@ type VideoAssetPayload = {
   publication_mode?: string | null;
   is_canonical_publication?: boolean;
   supports_reference_publication?: boolean;
+  subtitle_summary?: SubtitleSummaryPayload | null;
+};
+
+type SubtitleExtractionStatus =
+  | "not_requested"
+  | "queued"
+  | "running"
+  | "complete"
+  | "partial"
+  | "unavailable"
+  | "failed";
+
+type SubtitleTrackPayload = {
+  id: string;
+  stream_index: number;
+  codec_name: string;
+  language?: string | null;
+  language_normalized?: string | null;
+  language_raw?: string | null;
+  title?: string | null;
+  is_default: boolean;
+  is_forced: boolean;
+  is_primary: boolean;
+  selection_status: string;
+  extraction_status: string;
+  cue_count?: number | null;
+  first_cue_start_ms?: number | null;
+  last_cue_end_ms?: number | null;
+  srt_size_bytes?: number | null;
+  srt_sha256?: string | null;
+  error?: string | null;
+};
+
+type SubtitleSummaryPayload = {
+  video_asset_id?: string;
+  status: SubtitleExtractionStatus;
+  error?: string | null;
+  attempts?: number;
+  requested_at?: string | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+  discovered_track_count?: number;
+  eligible_track_count?: number;
+  completed_track_count?: number;
+  failed_track_count?: number;
+  primary_track_id?: string | null;
+  tracks?: SubtitleTrackPayload[];
+};
+
+type SubtitleCuePayload = {
+  ordinal: number;
+  start_ms: number;
+  end_ms: number;
+  text: string;
+  plain_text: string;
+};
+
+type SubtitleCuePagePayload = {
+  video_asset_id: string;
+  track_id: string;
+  offset: number;
+  limit: number;
+  total_cues: number;
+  matched_cues?: number;
+  items: SubtitleCuePayload[];
+};
+
+type SubtitleDownloadPayload = {
+  filename: string;
+  download_url: string;
 };
 
 type RunPayload = {
@@ -89,6 +193,7 @@ type CandidateScopePolicyPayload = {
   scope_order?: string[];
   fallback_scopes_used?: string[];
   preferred_facebank_coverage?: boolean;
+  strict_credit_scope?: boolean;
 };
 
 type CastCoverageSummaryPayload = {
@@ -197,7 +302,7 @@ type ShotEntry = {
   end_ms: number;
   duration_ms: number;
   observation_count: number;
-  assigned_person_ids: string[];
+  assigned_person_ids?: string[];
 };
 
 type SceneEntry = {
@@ -207,7 +312,7 @@ type SceneEntry = {
   duration_ms: number;
   shot_count: number;
   composition_type: string;
-  dominant_person_ids: string[];
+  dominant_person_ids?: string[];
   dominant_display_names?: Record<string, string>;
   unknown_segment_count: number;
   title_card_shot_count: number;
@@ -318,11 +423,46 @@ type ReviewSummaryPayload = {
   current_publish_version?: PublishVersionEntry | null;
 };
 
-const breadcrumbs = buildAdminSectionBreadcrumb("Cast Screen Time", "/admin/cast-screentime");
-const ownerScopeOptions: OwnerScope[] = ["season", "show", "episode"];
+const breadcrumbs = buildAdminSectionBreadcrumb("Screenalytics", SCREENALYTICS_CANONICAL_PATH);
 const videoClassFilters: VideoClassFilter[] = ["all", "episode", "trailer", "extras"];
 const importModes: ImportMode[] = ["youtube_url", "external_url", "social_youtube_row"];
 const decisionScopes: OwnerScope[] = ["episode", "season", "show"];
+const subtitleCuePageSize = 50;
+const subtitlePollingDelays = [2_000, 5_000, 15_000] as const;
+const screenalyticsKnownContext = {
+  show: {
+    id: SCREENALYTICS_RHOBH_S5_E16_TEST_DEFAULTS.show_id,
+    label: "Real Housewives of Beverly Hills",
+    shortLabel: "RHOBH",
+  },
+  season: {
+    id: SCREENALYTICS_RHOBH_S5_E16_TEST_SEASON_ID,
+    label: "Season 5",
+  },
+  episode: {
+    id: SCREENALYTICS_RHOBH_S5_E16_TEST_DEFAULTS.owner_id,
+    label: "Episode 16",
+  },
+} as const;
+
+const mediaKindOptions = [
+  { value: "screenalytics_test", label: "Screenalytics test" },
+  { value: "bonus_scene", label: "Bonus scene" },
+  { value: "after_show", label: "After show" },
+  { value: "clip", label: "Clip" },
+  { value: "extended_scene", label: "Extended scene" },
+] as const;
+
+function getScreenalyticsRunId(pathname: string | null, searchParams: URLSearchParams): string {
+  const segments = (pathname || "")
+    .split("/")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+  if (segments.length === 3 && segments[0] === "screenalytics" && segments[1] === "runs") {
+    return segments[2] || "";
+  }
+  return String(searchParams.get("run_id") || searchParams.get("run") || "").trim();
+}
 
 function parseOwnerScope(value: string | null): OwnerScope | null {
   return value === "show" || value === "season" || value === "episode" ? value : null;
@@ -394,10 +534,87 @@ function formatMediaFilterLabel(value: VideoClassFilter): string {
   return "Extras";
 }
 
+function formatMediaKindLabel(value?: string | null): string {
+  const normalized = String(value || "").trim();
+  if (!normalized) return "No extra type";
+  return mediaKindOptions.find((option) => option.value === normalized)?.label ?? normalized.replaceAll("_", " ");
+}
+
+function normalizeSubtitleSummary(
+  payload: Partial<SubtitleSummaryPayload> | null | undefined,
+  videoAssetId: string,
+): SubtitleSummaryPayload {
+  const supportedStatuses: SubtitleExtractionStatus[] = [
+    "not_requested",
+    "queued",
+    "running",
+    "complete",
+    "partial",
+    "unavailable",
+    "failed",
+  ];
+  const status = supportedStatuses.includes(payload?.status as SubtitleExtractionStatus)
+    ? (payload?.status as SubtitleExtractionStatus)
+    : "not_requested";
+  return {
+    ...payload,
+    video_asset_id: payload?.video_asset_id || videoAssetId,
+    status,
+    tracks: Array.isArray(payload?.tracks) ? payload.tracks : [],
+  };
+}
+
+function formatSubtitleStatus(status?: SubtitleExtractionStatus | null): string {
+  if (status === "queued") return "Queued";
+  if (status === "running") return "Extracting";
+  if (status === "complete") return "Ready";
+  if (status === "partial") return "Partially extracted";
+  if (status === "unavailable") return "No English embedded subtitles";
+  if (status === "failed") return "Extraction failed";
+  return "Not extracted";
+}
+
+function formatSubtitleTimestamp(milliseconds?: number | null): string {
+  if (milliseconds == null || !Number.isFinite(milliseconds)) return "n/a";
+  const safeMilliseconds = Math.max(0, Math.floor(milliseconds));
+  const hours = Math.floor(safeMilliseconds / 3_600_000);
+  const minutes = Math.floor((safeMilliseconds % 3_600_000) / 60_000);
+  const seconds = Math.floor((safeMilliseconds % 60_000) / 1_000);
+  const millis = safeMilliseconds % 1_000;
+  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}.${String(millis).padStart(3, "0")}`;
+}
+
+function formatSubtitleBytes(bytes?: number | null): string {
+  if (bytes == null || !Number.isFinite(bytes)) return "n/a";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+}
+
+function formatOwnerSelectionLabel(
+  ownerScope?: string | null,
+  ownerId?: string | null,
+  seasonId?: string | null,
+  episodeId?: string | null,
+): string {
+  const resolvedOwnerId = String(ownerId || episodeId || seasonId || "").trim();
+  if (!resolvedOwnerId) return "Not selected";
+  if (resolvedOwnerId === screenalyticsKnownContext.episode.id || episodeId === screenalyticsKnownContext.episode.id) {
+    return `${screenalyticsKnownContext.show.shortLabel} ${screenalyticsKnownContext.season.label} ${screenalyticsKnownContext.episode.label}`;
+  }
+  if (resolvedOwnerId === screenalyticsKnownContext.season.id || seasonId === screenalyticsKnownContext.season.id) {
+    return `${screenalyticsKnownContext.show.shortLabel} ${screenalyticsKnownContext.season.label}`;
+  }
+  if (resolvedOwnerId === screenalyticsKnownContext.show.id) {
+    return screenalyticsKnownContext.show.label;
+  }
+  return ownerScope ? `${ownerScope} selected` : "Selected";
+}
+
 function formatCoverageWarning(value: string): string {
   if (value === "no_candidate_cast_rows_found") return "No candidate cast rows were found for this asset scope.";
   if (value === "no_approved_facebank_coverage") return "None of the current candidates have approved facebank coverage yet.";
-  if (value === "episode_scope_required_fallback") return "Episode cast was too sparse, so season or show fallback candidates were added.";
+  if (value === "episode_scope_required_fallback") return "Legacy run widened episode scope; rerun to use strict credits.";
   if (value === "sparse_candidate_cast") return "Candidate cast is still sparse for this run.";
   return value.replaceAll("_", " ");
 }
@@ -422,6 +639,8 @@ async function parseResponse<T>(response: Response): Promise<T> {
   return data;
 }
 
+const wait = (ms: number): Promise<void> => new Promise((resolve) => window.setTimeout(resolve, ms));
+
 function Badge({
   children,
   tone = "neutral",
@@ -440,18 +659,59 @@ function Badge({
   return <span className={`inline-flex rounded-full border px-2 py-1 text-[11px] font-medium ${toneClass}`}>{children}</span>;
 }
 
+function DebugJsonBlock({ title, value }: { title: string; value: unknown }) {
+  if (value == null) return null;
+  return (
+    <section className="space-y-2">
+      <h3 className="text-sm font-semibold text-neutral-900">{title}</h3>
+      <pre className="max-h-80 overflow-auto rounded-lg bg-neutral-950 p-3 text-xs text-neutral-100">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    </section>
+  );
+}
+
 export default function CastScreentimePageClient() {
   const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+  const isTestExtraPath = isScreenalyticsRhobhS5E16TestPath(pathname);
+  const routeRunId = getScreenalyticsRunId(pathname, searchParams);
   const prefillContext = String(searchParams.get("prefill_context") || "").trim();
   const { checking, hasAccess } = useAdminGuard();
-  const [showId, setShowId] = useState(() => String(searchParams.get("show_id") || "").trim());
-  const [ownerScope, setOwnerScope] = useState<OwnerScope>(() => parseOwnerScope(searchParams.get("owner_scope")) ?? "season");
-  const [ownerId, setOwnerId] = useState(() => String(searchParams.get("owner_id") || "").trim());
+  const [showId, setShowId] = useState(() =>
+    String(
+      searchParams.get("show_id") ||
+        (isTestExtraPath ? SCREENALYTICS_RHOBH_S5_E16_TEST_DEFAULTS.show_id : ""),
+    ).trim(),
+  );
+  const [ownerScope, setOwnerScope] = useState<OwnerScope>(
+    () =>
+      parseOwnerScope(searchParams.get("owner_scope")) ??
+      (isTestExtraPath ? (SCREENALYTICS_RHOBH_S5_E16_TEST_DEFAULTS.owner_scope as OwnerScope) : "season"),
+  );
+  const [ownerId, setOwnerId] = useState(() =>
+    String(
+      searchParams.get("owner_id") ||
+        (isTestExtraPath ? SCREENALYTICS_RHOBH_S5_E16_TEST_DEFAULTS.owner_id : ""),
+    ).trim(),
+  );
+  const [selectedSeasonId, setSelectedSeasonId] = useState(() =>
+    String(
+      searchParams.get("season_id") ||
+        (parseOwnerScope(searchParams.get("owner_scope")) === "season" ? searchParams.get("owner_id") : "") ||
+        (isTestExtraPath ? screenalyticsKnownContext.season.id : ""),
+    ).trim(),
+  );
   const [videoClass, setVideoClass] = useState<VideoClass>(
-    () => parseVideoClass(searchParams.get("media_type") || searchParams.get("video_class")) ?? "trailer",
+    () =>
+      parseVideoClass(searchParams.get("media_type") || searchParams.get("video_class")) ??
+      (isTestExtraPath ? (SCREENALYTICS_RHOBH_S5_E16_TEST_DEFAULTS.media_type as VideoClass) : "trailer"),
   );
   const [promoSubtype, setPromoSubtype] = useState<MediaKind>(
-    () => parsePromoSubtype(searchParams.get("media_kind") || searchParams.get("promo_subtype")) ?? "",
+    () =>
+      parsePromoSubtype(searchParams.get("media_kind") || searchParams.get("promo_subtype")) ??
+      (isTestExtraPath ? SCREENALYTICS_RHOBH_S5_E16_TEST_DEFAULTS.media_kind : ""),
   );
   const [videoClassFilter, setVideoClassFilter] = useState<VideoClassFilter>(
     () => parseVideoClassFilter(searchParams.get("media_type_filter") || searchParams.get("video_class_filter")) ?? "all",
@@ -464,6 +724,7 @@ export default function CastScreentimePageClient() {
   );
   const [uploading, setUploading] = useState(false);
   const [importingAsset, setImportingAsset] = useState(false);
+  const [importStatus, setImportStatus] = useState<string | null>(null);
   const [launchingRun, setLaunchingRun] = useState(false);
   const [refreshingRun, setRefreshingRun] = useState(false);
   const [refreshingRuns, setRefreshingRuns] = useState(false);
@@ -502,8 +763,205 @@ export default function CastScreentimePageClient() {
   const [actingUnknownQueueKey, setActingUnknownQueueKey] = useState<string | null>(null);
   const [decisionRerunRequired, setDecisionRerunRequired] = useState(false);
   const [decisionEffectSummary, setDecisionEffectSummary] = useState<string | null>(null);
+  const [autoLoadedRunId, setAutoLoadedRunId] = useState<string | null>(null);
+  const [copiedRunLinkId, setCopiedRunLinkId] = useState<string | null>(null);
+  const [subtitleSummary, setSubtitleSummary] = useState<SubtitleSummaryPayload | null>(null);
+  const [subtitleLoading, setSubtitleLoading] = useState(false);
+  const [subtitleActionPending, setSubtitleActionPending] = useState(false);
+  const [subtitleError, setSubtitleError] = useState<string | null>(null);
+  const [selectedSubtitleTrackId, setSelectedSubtitleTrackId] = useState("");
+  const [subtitleCuePage, setSubtitleCuePage] = useState<SubtitleCuePagePayload | null>(null);
+  const [subtitleCueOffset, setSubtitleCueOffset] = useState(0);
+  const [subtitleSearchInput, setSubtitleSearchInput] = useState("");
+  const [subtitleSearchQuery, setSubtitleSearchQuery] = useState("");
+  const [subtitleCueLoading, setSubtitleCueLoading] = useState(false);
+  const [subtitleDownloadPending, setSubtitleDownloadPending] = useState(false);
+  const [subtitlePollVersion, setSubtitlePollVersion] = useState(0);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const effectivePromoSubtype = videoClass === "episode" ? null : promoSubtype.trim() || null;
+  const selectedEpisodeId = ownerScope === "episode" ? ownerId.trim() : "";
+  const submissionOwnerScope: OwnerScope =
+    videoClass === "episode" || selectedEpisodeId ? "episode" : "season";
+  const submissionOwnerId = submissionOwnerScope === "episode" ? selectedEpisodeId : selectedSeasonId.trim();
+  const selectedScopeLabel = formatOwnerSelectionLabel(
+    submissionOwnerScope,
+    submissionOwnerId,
+    selectedSeasonId,
+    selectedEpisodeId,
+  );
+  const selectedMediaLabel =
+    videoClass === "episode" ? "Canonical episode" : formatMediaKindLabel(effectivePromoSubtype);
+  const visibleMediaKindOptions = mediaKindOptions.some((option) => option.value === promoSubtype)
+    ? mediaKindOptions
+    : promoSubtype.trim()
+      ? [...mediaKindOptions, { value: promoSubtype.trim(), label: formatMediaKindLabel(promoSubtype) }]
+      : mediaKindOptions;
+  const activeVideoAssetId = String(videoAsset?.id || run?.video_asset_id || "").trim();
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setSubtitleSearchQuery(subtitleSearchInput.trim());
+      setSubtitleCueOffset(0);
+    }, 300);
+    return () => window.clearTimeout(timeoutId);
+  }, [subtitleSearchInput]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timerId: number | undefined;
+
+    setSubtitleSummary(null);
+    setSelectedSubtitleTrackId("");
+    setSubtitleCuePage(null);
+    setSubtitleCueOffset(0);
+    setSubtitleSearchInput("");
+    setSubtitleSearchQuery("");
+    setSubtitleError(null);
+
+    if (!activeVideoAssetId || checking || !hasAccess) return undefined;
+
+    const loadSummary = async (pollAttempt: number) => {
+      setSubtitleLoading(true);
+      try {
+        const payload = await parseResponse<SubtitleSummaryPayload>(
+          await fetchAdminWithAuth(
+            `/api/admin/trr-api/cast-screentime/video-assets/${activeVideoAssetId}/subtitles`,
+          ),
+        );
+        if (cancelled) return;
+        const normalized = normalizeSubtitleSummary(payload, activeVideoAssetId);
+        setSubtitleSummary(normalized);
+        setSubtitleError(null);
+        const completedTracks = (normalized.tracks ?? []).filter(
+          (track) => track.extraction_status === "complete",
+        );
+        setSelectedSubtitleTrackId((current) => {
+          if (completedTracks.some((track) => track.id === current)) return current;
+          return (
+            completedTracks.find((track) => track.id === normalized.primary_track_id)?.id ||
+            completedTracks.find((track) => track.is_primary)?.id ||
+            completedTracks[0]?.id ||
+            ""
+          );
+        });
+        if (normalized.status === "queued" || normalized.status === "running") {
+          const delay = subtitlePollingDelays[Math.min(pollAttempt, subtitlePollingDelays.length - 1)];
+          timerId = window.setTimeout(() => void loadSummary(pollAttempt + 1), delay);
+        }
+      } catch (summaryError) {
+        if (!cancelled) {
+          setSubtitleError(
+            summaryError instanceof Error ? summaryError.message : "Subtitle status could not be loaded",
+          );
+        }
+      } finally {
+        if (!cancelled) setSubtitleLoading(false);
+      }
+    };
+
+    void loadSummary(0);
+    return () => {
+      cancelled = true;
+      if (timerId != null) window.clearTimeout(timerId);
+    };
+  }, [activeVideoAssetId, checking, hasAccess, subtitlePollVersion]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!activeVideoAssetId || !selectedSubtitleTrackId) {
+      setSubtitleCuePage(null);
+      return undefined;
+    }
+
+    const loadCues = async () => {
+      setSubtitleCueLoading(true);
+      try {
+        const query = new URLSearchParams({
+          offset: String(subtitleCueOffset),
+          limit: String(subtitleCuePageSize),
+        });
+        if (subtitleSearchQuery) query.set("q", subtitleSearchQuery);
+        const payload = await parseResponse<SubtitleCuePagePayload>(
+          await fetchAdminWithAuth(
+            `/api/admin/trr-api/cast-screentime/video-assets/${activeVideoAssetId}/subtitles/${selectedSubtitleTrackId}/cues?${query.toString()}`,
+          ),
+        );
+        if (!cancelled) {
+          setSubtitleCuePage({ ...payload, items: Array.isArray(payload.items) ? payload.items : [] });
+          setSubtitleError(null);
+        }
+      } catch (cueError) {
+        if (!cancelled) {
+          setSubtitleCuePage(null);
+          setSubtitleError(cueError instanceof Error ? cueError.message : "Subtitle cues could not be loaded");
+        }
+      } finally {
+        if (!cancelled) setSubtitleCueLoading(false);
+      }
+    };
+
+    void loadCues();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeVideoAssetId, selectedSubtitleTrackId, subtitleCueOffset, subtitleSearchQuery]);
+
+  const handleShowChange = (nextShowId: string) => {
+    setShowId(nextShowId);
+    if (nextShowId === screenalyticsKnownContext.show.id && !selectedSeasonId.trim()) {
+      setSelectedSeasonId(screenalyticsKnownContext.season.id);
+    }
+    if (!nextShowId.trim()) {
+      setSelectedSeasonId("");
+      setOwnerScope("season");
+      setOwnerId("");
+    }
+  };
+
+  const handleSeasonChange = (nextSeasonId: string) => {
+    setSelectedSeasonId(nextSeasonId);
+    if (!selectedEpisodeId) {
+      setOwnerScope("season");
+      setOwnerId(nextSeasonId);
+    }
+  };
+
+  const handleEpisodeChange = (nextEpisodeId: string) => {
+    if (nextEpisodeId) {
+      setOwnerScope("episode");
+      setOwnerId(nextEpisodeId);
+      return;
+    }
+    setOwnerScope("season");
+    setOwnerId(selectedSeasonId.trim());
+  };
+
+  const handleVideoClassChange = (nextVideoClass: VideoClass) => {
+    setVideoClass(nextVideoClass);
+    if (nextVideoClass === "episode") {
+      setPromoSubtype("");
+      setOwnerScope("episode");
+      setOwnerId(selectedEpisodeId || screenalyticsKnownContext.episode.id);
+      if (!selectedSeasonId.trim()) {
+        setSelectedSeasonId(screenalyticsKnownContext.season.id);
+      }
+      return;
+    }
+    if (!submissionOwnerId && selectedSeasonId.trim()) {
+      setOwnerScope("season");
+      setOwnerId(selectedSeasonId.trim());
+    }
+    if (!promoSubtype.trim() && nextVideoClass === "extras") {
+      setPromoSubtype(isTestExtraPath ? SCREENALYTICS_RHOBH_S5_E16_TEST_DEFAULTS.media_kind : "bonus_scene");
+    }
+  };
 
   const resetRunOutputs = () => {
     setRun(null);
@@ -537,6 +995,16 @@ export default function CastScreentimePageClient() {
     if (resolvedShowId) {
       setShowId(resolvedShowId);
     }
+    const resolvedSeasonId = String(asset?.season_id || nextRun?.season_id || "").trim();
+    if (resolvedSeasonId) {
+      setSelectedSeasonId(resolvedSeasonId);
+    }
+    const resolvedOwnerScope = parseOwnerScope(String(asset?.owner_scope || nextRun?.owner_scope || "").trim());
+    const resolvedOwnerId = String(asset?.owner_id || nextRun?.owner_id || "").trim();
+    if (resolvedOwnerScope && resolvedOwnerId) {
+      setOwnerScope(resolvedOwnerScope);
+      setOwnerId(resolvedOwnerId);
+    }
   };
 
   const refreshRecentRuns = async (forcedShowId?: string) => {
@@ -557,9 +1025,48 @@ export default function CastScreentimePageClient() {
     }
   };
 
+  const applyImportedVideoAsset = async (asset: VideoAssetPayload) => {
+    setVideoAsset(asset);
+    syncShowContext(asset, null);
+    resetRunOutputs();
+    await refreshRecentRuns(asset.show_id || undefined);
+  };
+
+  const pollImportedUploadSession = async (uploadSessionId: string): Promise<VideoAssetPayload> => {
+    for (let attempt = 0; attempt < 60; attempt += 1) {
+      if (!mountedRef.current) {
+        throw new Error("Import polling stopped");
+      }
+      const payload = await parseResponse<UploadSessionStatusPayload>(
+        await fetchAdminWithAuth(`/api/admin/trr-api/cast-screentime/upload-sessions/${uploadSessionId}`),
+      );
+      setLatestUpload((current) => ({ ...(current || { upload_session_id: uploadSessionId }), ...payload }));
+      if (payload.status === "failed") {
+        throw new Error(payload.error_text || "Import failed");
+      }
+      if (payload.status === "promoted") {
+        if (payload.video_asset) {
+          return payload.video_asset;
+        }
+        throw new Error("Import finished without a video asset");
+      }
+      setImportStatus("Importing remote video...");
+      await wait(2000);
+    }
+    throw new Error("Import timed out");
+  };
+
   const uploadVideo = async () => {
-    if (!ownerId.trim()) {
-      setError("Owner ID is required");
+    if (!showId.trim()) {
+      setError("Choose a show first");
+      return;
+    }
+    if (!selectedSeasonId.trim()) {
+      setError("Choose a season first");
+      return;
+    }
+    if (!submissionOwnerId) {
+      setError(videoClass === "episode" ? "Choose an episode first" : "Choose a season or episode first");
       return;
     }
     if (!selectedFile) {
@@ -575,8 +1082,8 @@ export default function CastScreentimePageClient() {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            owner_scope: videoClass === "episode" ? "episode" : ownerScope,
-            owner_id: ownerId.trim(),
+            owner_scope: submissionOwnerScope,
+            owner_id: submissionOwnerId,
             filename: selectedFile.name,
             content_type: selectedFile.type || "video/mp4",
             expected_size_bytes: selectedFile.size,
@@ -618,8 +1125,16 @@ export default function CastScreentimePageClient() {
   };
 
   const importVideoAsset = async () => {
-    if (!ownerId.trim()) {
-      setError("Owner ID is required");
+    if (!showId.trim()) {
+      setError("Choose a show first");
+      return;
+    }
+    if (!selectedSeasonId.trim()) {
+      setError("Choose a season first");
+      return;
+    }
+    if (!submissionOwnerId) {
+      setError(videoClass === "episode" ? "Choose an episode first" : "Choose a season or episode first");
       return;
     }
     if (importMode === "social_youtube_row" && !socialYoutubeVideoId.trim()) {
@@ -633,8 +1148,9 @@ export default function CastScreentimePageClient() {
 
     setError(null);
     setImportingAsset(true);
+    setImportStatus(null);
     try {
-      const payload = await parseResponse<{ upload_session_id: string; video_asset: VideoAssetPayload }>(
+      const payload = await parseResponse<ImportVideoAssetResponsePayload>(
         await fetchAdminWithAuth("/api/admin/trr-api/cast-screentime/video-assets/import", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -642,8 +1158,8 @@ export default function CastScreentimePageClient() {
             source_mode: importMode,
             source_url: importMode === "social_youtube_row" ? undefined : remoteSource.trim(),
             social_youtube_video_id: importMode === "social_youtube_row" ? socialYoutubeVideoId.trim() : undefined,
-            owner_scope: videoClass === "episode" ? "episode" : ownerScope,
-            owner_id: ownerId.trim(),
+            owner_scope: submissionOwnerScope,
+            owner_id: submissionOwnerId,
             media_type: videoClass,
             media_kind: effectivePromoSubtype,
           }),
@@ -651,19 +1167,78 @@ export default function CastScreentimePageClient() {
       );
       setLatestUpload({
         upload_session_id: payload.upload_session_id,
-        owner_scope: videoClass === "episode" ? "episode" : ownerScope,
-        owner_id: ownerId.trim(),
+        status: payload.status,
+        owner_scope: submissionOwnerScope,
+        owner_id: submissionOwnerId,
         media_type: videoClass,
         media_kind: effectivePromoSubtype,
       });
-      setVideoAsset(payload.video_asset);
-      syncShowContext(payload.video_asset, null);
-      resetRunOutputs();
-      await refreshRecentRuns(payload.video_asset.show_id || undefined);
+      if (payload.video_asset) {
+        await applyImportedVideoAsset(payload.video_asset);
+        setImportStatus(null);
+        return;
+      }
+      setImportStatus(payload.queued ? "Import queued..." : "Importing remote video...");
+      const promotedAsset = await pollImportedUploadSession(payload.upload_session_id);
+      await applyImportedVideoAsset(promotedAsset);
+      setImportStatus(null);
     } catch (importError) {
       setError(importError instanceof Error ? importError.message : "Import failed");
     } finally {
       setImportingAsset(false);
+    }
+  };
+
+  const requestSubtitleExtraction = async (force: boolean) => {
+    if (!activeVideoAssetId) return;
+    if (force && !window.confirm("Re-extract source subtitles and replace the active revision when it succeeds?")) {
+      return;
+    }
+    setSubtitleActionPending(true);
+    setSubtitleError(null);
+    try {
+      const payload = await parseResponse<Partial<SubtitleSummaryPayload>>(
+        await fetchAdminWithAuth(
+          `/api/admin/trr-api/cast-screentime/video-assets/${activeVideoAssetId}/subtitles/extract`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ force }),
+          },
+        ),
+      );
+      setSubtitleSummary((current) =>
+        normalizeSubtitleSummary({ ...(current ?? {}), ...payload }, activeVideoAssetId),
+      );
+      setSubtitlePollVersion((current) => current + 1);
+    } catch (actionError) {
+      setSubtitleError(actionError instanceof Error ? actionError.message : "Subtitle extraction could not be queued");
+    } finally {
+      setSubtitleActionPending(false);
+    }
+  };
+
+  const downloadSubtitleTrack = async () => {
+    if (!activeVideoAssetId || !selectedSubtitleTrackId) return;
+    setSubtitleDownloadPending(true);
+    setSubtitleError(null);
+    try {
+      const payload = await parseResponse<SubtitleDownloadPayload>(
+        await fetchAdminWithAuth(
+          `/api/admin/trr-api/cast-screentime/video-assets/${activeVideoAssetId}/subtitles/${selectedSubtitleTrackId}/download-url`,
+        ),
+      );
+      const anchor = document.createElement("a");
+      anchor.href = payload.download_url;
+      anchor.download = payload.filename;
+      anchor.rel = "noopener noreferrer";
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+    } catch (downloadError) {
+      setSubtitleError(downloadError instanceof Error ? downloadError.message : "Subtitle download could not start");
+    } finally {
+      setSubtitleDownloadPending(false);
     }
   };
 
@@ -688,6 +1263,7 @@ export default function CastScreentimePageClient() {
       setRun(response.run);
       syncShowContext(videoAsset, response.run);
       await refreshRun(response.run.id, response.run.show_id || videoAsset.show_id || undefined);
+      router.push(buildScreenalyticsRunPath(response.run.id));
       if (response.dispatch_state === "dispatch_failed") {
         setError(response.run.error_message || "Run dispatch failed");
       }
@@ -732,6 +1308,7 @@ export default function CastScreentimePageClient() {
       const excludedPayload = await parseResponse<{ excluded_sections: ExcludedSectionEntry[] }>(excludedResponse);
       const reviewSummaryPayload = await parseResponse<ReviewSummaryPayload>(reviewSummaryResponse);
       setRun(runPayload);
+      syncShowContext(null, runPayload);
       if (runPayload.owner_scope) {
         setDecisionScope(runPayload.owner_scope);
       }
@@ -943,7 +1520,7 @@ export default function CastScreentimePageClient() {
 
   const reconcileStaleRuns = async () => {
     if (!showId.trim()) {
-      setError("Show ID is required to reconcile stale runs");
+      setError("Choose a show to reconcile stale runs");
       return;
     }
     setError(null);
@@ -970,8 +1547,34 @@ export default function CastScreentimePageClient() {
   };
 
   const loadRecentRun = async (runId: string) => {
+    const canonicalPath = buildScreenalyticsRunPath(runId);
+    if (pathname !== canonicalPath) {
+      router.push(canonicalPath);
+    }
     await refreshRun(runId);
   };
+
+  const copyRunLink = async (runId: string) => {
+    try {
+      const clipboard = navigator.clipboard;
+      if (!clipboard || typeof clipboard.writeText !== "function") {
+        throw new Error("Clipboard access is not available in this browser.");
+      }
+      await clipboard.writeText(buildScreenalyticsRunUrl(runId));
+      setCopiedRunLinkId(runId);
+      window.setTimeout(() => {
+        setCopiedRunLinkId((current) => (current === runId ? null : current));
+      }, 1800);
+    } catch (copyError) {
+      setError(copyError instanceof Error ? copyError.message : "Failed to copy run link.");
+    }
+  };
+
+  useEffect(() => {
+    if (!routeRunId || checking || !hasAccess || autoLoadedRunId === routeRunId) return;
+    setAutoLoadedRunId(routeRunId);
+    void refreshRun(routeRunId);
+  }, [autoLoadedRunId, checking, hasAccess, routeRunId]);
 
   if (checking) {
     return (
@@ -1016,90 +1619,207 @@ export default function CastScreentimePageClient() {
       latestUnknownDecisionByGroup.set(key, entry);
     }
   });
+  const debugDetailsAvailable = Boolean(latestUpload || videoAsset || run);
+  const hasRunReviewArtifacts = Boolean(
+    progress ||
+      cacheMetrics ||
+      flashbackMatches.length > 0 ||
+      titleCardMatches.length > 0 ||
+      shots.length > 0 ||
+      scenes.length > 0 ||
+      titleCardCandidates.length > 0 ||
+      titleCardReferences.length > 0 ||
+      confessionalCandidates.length > 0,
+  );
+  const hasFrameOrFaceArtifacts = Boolean(
+    shots.length > 0 ||
+      scenes.length > 0 ||
+      titleCardCandidates.length > 0 ||
+      titleCardReferences.length > 0 ||
+      confessionalCandidates.length > 0,
+  );
+  const candidateScopePolicy = run?.candidate_scope_policy_json ?? null;
+  const candidateScopeLabel =
+    candidateScopePolicy?.primary_scope || candidateScopePolicy?.owner_scope || run?.owner_scope || "selected";
+  const strictCandidateScope = candidateScopePolicy?.strict_credit_scope === true;
+  const fallbackScopesUsed = run?.cast_coverage_summary_json?.fallback_scopes_used ?? [];
+  const completedSubtitleTracks = (subtitleSummary?.tracks ?? []).filter(
+    (track) => track.extraction_status === "complete",
+  );
+  const selectedSubtitleTrack =
+    completedSubtitleTracks.find((track) => track.id === selectedSubtitleTrackId) ?? null;
+  const subtitleResultCount = subtitleCuePage
+    ? subtitleSearchQuery
+      ? (subtitleCuePage.matched_cues ?? subtitleCuePage.items.length)
+      : subtitleCuePage.total_cues
+    : 0;
+  const subtitleHasPreviousPage = subtitleCueOffset > 0;
+  const subtitleHasNextPage = subtitleCueOffset + subtitleCuePageSize < subtitleResultCount;
 
   return (
     <AdminGlobalHeader bodyClassName="px-6 py-6">
       <div className="mx-auto flex max-w-6xl flex-col gap-6">
         <div>
           <AdminBreadcrumbs items={breadcrumbs} className="mb-2" />
-          <h1 className="text-2xl font-semibold text-neutral-900">Cast Screen-Time</h1>
+          <h1 className="text-2xl font-semibold text-neutral-900">Screenalytics Workspace</h1>
           <p className="mt-1 text-sm text-neutral-600">
-            Admin workflow for episode, trailer, and extras screen-time analysis, including official YouTube trailers, external mirrors, and existing social YouTube rows.
+            Prepare a video asset, run cast screen-time analysis, then review frames, faces, exclusions, and publishable totals from one admin surface.
           </p>
           {prefillContext === "social_week_youtube" ? (
             <p className="mt-2 inline-flex rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-medium text-amber-900">
               Prefilled from a social-week YouTube post. Review owner and source URL, then import the trailer into cast screentime.
             </p>
           ) : null}
+          {isTestExtraPath || prefillContext === "screenalytics_test_extra" ? (
+            <p className="mt-2 inline-flex rounded-full border border-sky-200 bg-sky-50 px-3 py-1 text-xs font-medium text-sky-900">
+              Prefilled for RHOBH S5 E16 extras screenalytics test.
+            </p>
+          ) : null}
         </div>
 
         <section className="rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm">
-          <div className="grid gap-4 lg:grid-cols-[1.4fr,1fr]">
-            <div className="grid gap-4 md:grid-cols-3">
-              <label className="flex flex-col gap-2 text-sm font-medium text-neutral-700">
-                Owner Scope
-                <select
-                  value={ownerScope}
-                  onChange={(event) => setOwnerScope(event.target.value as OwnerScope)}
-                  className="rounded-xl border border-neutral-300 px-3 py-2 text-sm text-neutral-900"
-                >
-                  {ownerScopeOptions.map((option) => (
-                    <option key={option} value={option}>
-                      {option}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label className="flex flex-col gap-2 text-sm font-medium text-neutral-700 md:col-span-2">
-                Owner ID
-                <input
-                  value={ownerId}
-                  onChange={(event) => setOwnerId(event.target.value)}
-                  placeholder={`UUID for core.${ownerScope}s.id`}
-                  className="rounded-xl border border-neutral-300 px-3 py-2 text-sm text-neutral-900"
-                />
-              </label>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h2 className="text-base font-semibold text-neutral-900">Analysis Setup</h2>
+              <p className="mt-1 text-sm text-neutral-600">
+                Choose the show and season first. Add an episode when the video belongs to one episode; leave it season-level for trailers or extras that span multiple episodes.
+              </p>
             </div>
-            <div className="grid gap-4 md:grid-cols-2">
-              <label className="flex flex-col gap-2 text-sm font-medium text-neutral-700">
-                Asset Type
-                <select
-                  value={videoClass}
-                  onChange={(event) => setVideoClass(event.target.value as VideoClass)}
-                  className="rounded-xl border border-neutral-300 px-3 py-2 text-sm text-neutral-900"
-                >
-                  <option value="episode">Episode</option>
-                  <option value="trailer">Trailer</option>
-                  <option value="extras">Extras</option>
-                </select>
-              </label>
-              <label className="flex flex-col gap-2 text-sm font-medium text-neutral-700">
-                Media Kind
-                <input
-                  value={promoSubtype}
-                  onChange={(event) => setPromoSubtype(event.target.value)}
-                  disabled={videoClass === "episode"}
-                  placeholder={videoClass === "extras" ? "after_show, clip, bonus_scene..." : "optional"}
-                  className="rounded-xl border border-neutral-300 px-3 py-2 text-sm text-neutral-900 disabled:bg-neutral-100"
-                />
-              </label>
+            <div className="flex flex-wrap gap-2">
+              <Badge tone={videoClass === "episode" ? "sky" : "amber"}>
+                {formatVideoClass(videoClass, effectivePromoSubtype)}
+              </Badge>
+              {videoClass === "episode" ? <Badge tone="emerald">Canonical episode</Badge> : <Badge tone="amber">Internal reference</Badge>}
             </div>
           </div>
-          <div className="mt-4 flex flex-wrap gap-2">
-            <Badge tone={videoClass === "episode" ? "sky" : "amber"}>
-              {formatVideoClass(videoClass, effectivePromoSubtype)}
-            </Badge>
-            <Badge tone="neutral">
-              Default owner linkage: {videoClass === "episode" ? "episode required" : ownerScope}
-            </Badge>
-            {videoClass === "episode" ? <Badge tone="emerald">Publishable lane</Badge> : <Badge tone="amber">Internal-reference lane</Badge>}
+
+          <div className="mt-5 grid gap-4 lg:grid-cols-[1fr,1fr,0.95fr]">
+            <label className="flex flex-col gap-2 text-sm font-medium text-neutral-700">
+              Show
+              <select
+                aria-label="Show"
+                value={showId}
+                onChange={(event) => handleShowChange(event.target.value)}
+                className="rounded-xl border border-neutral-300 px-3 py-2 text-sm text-neutral-900"
+              >
+                <option value="">Choose show</option>
+                <option value={screenalyticsKnownContext.show.id}>{screenalyticsKnownContext.show.label}</option>
+                {showId && showId !== screenalyticsKnownContext.show.id ? <option value={showId}>Current show</option> : null}
+              </select>
+            </label>
+
+            <label className="flex flex-col gap-2 text-sm font-medium text-neutral-700">
+              Season
+              <select
+                aria-label="Season"
+                value={selectedSeasonId}
+                onChange={(event) => handleSeasonChange(event.target.value)}
+                className="rounded-xl border border-neutral-300 px-3 py-2 text-sm text-neutral-900"
+              >
+                <option value="">Choose season</option>
+                <option value={screenalyticsKnownContext.season.id}>{screenalyticsKnownContext.season.label}</option>
+                {selectedSeasonId && selectedSeasonId !== screenalyticsKnownContext.season.id ? (
+                  <option value={selectedSeasonId}>Current season</option>
+                ) : null}
+              </select>
+            </label>
+
+            <label className="flex flex-col gap-2 text-sm font-medium text-neutral-700">
+              Episode
+              <select
+                aria-label="Episode"
+                value={selectedEpisodeId}
+                onChange={(event) => handleEpisodeChange(event.target.value)}
+                className="rounded-xl border border-neutral-300 px-3 py-2 text-sm text-neutral-900"
+              >
+                <option value="">Season-level or multiple episodes</option>
+                <option value={screenalyticsKnownContext.episode.id}>{screenalyticsKnownContext.episode.label}</option>
+                {selectedEpisodeId && selectedEpisodeId !== screenalyticsKnownContext.episode.id ? (
+                  <option value={selectedEpisodeId}>Current episode</option>
+                ) : null}
+              </select>
+              <span className="text-xs font-normal text-neutral-500">
+                Optional for trailers and extras. Required only for canonical episode assets.
+              </span>
+            </label>
           </div>
+
+          <div className="mt-5 grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col gap-2 text-sm font-medium text-neutral-700">
+              Asset Type
+              <select
+                aria-label="Asset Type"
+                value={videoClass}
+                onChange={(event) => handleVideoClassChange(event.target.value as VideoClass)}
+                className="rounded-xl border border-neutral-300 px-3 py-2 text-sm text-neutral-900"
+              >
+                <option value="episode">Episode</option>
+                <option value="trailer">Trailer</option>
+                <option value="extras">Extras</option>
+              </select>
+            </label>
+
+            <label className="flex flex-col gap-2 text-sm font-medium text-neutral-700">
+              {videoClass === "extras" ? "Extra Type" : videoClass === "trailer" ? "Trailer Type" : "Media Type"}
+              <select
+                aria-label="Content Type"
+                value={videoClass === "episode" ? "" : promoSubtype}
+                onChange={(event) => setPromoSubtype(event.target.value)}
+                disabled={videoClass === "episode"}
+                className="rounded-xl border border-neutral-300 px-3 py-2 text-sm text-neutral-900 disabled:bg-neutral-100"
+              >
+                <option value="">No subtype</option>
+                {visibleMediaKindOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <div className="mt-4 grid gap-3 rounded-xl bg-neutral-50 p-3 sm:grid-cols-3">
+            <div>
+              <p className="text-[11px] uppercase tracking-wide text-neutral-500">Context</p>
+              <p className="mt-1 text-sm font-medium text-neutral-900">{selectedScopeLabel}</p>
+            </div>
+            <div>
+              <p className="text-[11px] uppercase tracking-wide text-neutral-500">Video class</p>
+              <p className="mt-1 text-sm font-medium text-neutral-900">{formatVideoClass(videoClass, effectivePromoSubtype)}</p>
+            </div>
+            <div>
+              <p className="text-[11px] uppercase tracking-wide text-neutral-500">Label</p>
+              <p className="mt-1 text-sm font-medium text-neutral-900">{selectedMediaLabel}</p>
+            </div>
+          </div>
+
+          <details className="mt-3 rounded-xl border border-neutral-200 px-3 py-2 text-sm text-neutral-600">
+            <summary className="cursor-pointer font-medium text-neutral-800">Technical routing</summary>
+            <div className="mt-2 grid gap-2 text-xs sm:grid-cols-3">
+              <div>
+                <span className="text-neutral-500">Owner scope</span>
+                <div className="font-mono text-neutral-900">{submissionOwnerScope}</div>
+              </div>
+              <div>
+                <span className="text-neutral-500">Owner ID</span>
+                <div className="truncate font-mono text-neutral-900">{submissionOwnerId || "not selected"}</div>
+              </div>
+              <div>
+                <span className="text-neutral-500">Media key</span>
+                <div className="font-mono text-neutral-900">{effectivePromoSubtype || "none"}</div>
+              </div>
+            </div>
+          </details>
+
           {error ? <p className="mt-4 text-sm text-red-600">{error}</p> : null}
         </section>
 
         <section className="grid gap-6 xl:grid-cols-2">
           <div className="rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm">
-            <h2 className="text-base font-semibold text-neutral-900">Direct Upload</h2>
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="text-base font-semibold text-neutral-900">Direct Upload</h2>
+              <Badge tone="neutral">Source video</Badge>
+            </div>
             <p className="mt-1 text-sm text-neutral-600">
               Upload a local video directly to R2, verify it, and promote it into a cast-screentime video asset.
             </p>
@@ -1130,7 +1850,10 @@ export default function CastScreentimePageClient() {
           </div>
 
           <div className="rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm">
-            <h2 className="text-base font-semibold text-neutral-900">Remote Import</h2>
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="text-base font-semibold text-neutral-900">Remote Import</h2>
+              <Badge tone="neutral">Source video</Badge>
+            </div>
             <p className="mt-1 text-sm text-neutral-600">
               Mirror an official YouTube trailer, another explicit external video URL, or an existing social YouTube row into TRR storage first.
             </p>
@@ -1190,6 +1913,7 @@ export default function CastScreentimePageClient() {
               </button>
               <Badge tone="amber">YouTube imports must match an official configured channel</Badge>
             </div>
+            {importStatus ? <p className="mt-3 text-sm text-neutral-600">{importStatus}</p> : null}
           </div>
         </section>
 
@@ -1203,14 +1927,31 @@ export default function CastScreentimePageClient() {
                 </Badge>
               ) : null}
             </div>
-            <pre className="mt-3 overflow-x-auto rounded-xl bg-neutral-950 p-4 text-xs text-neutral-100">
-              {JSON.stringify(latestUpload, null, 2)}
-            </pre>
+            {latestUpload ? (
+              <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                <div className="rounded-xl bg-neutral-50 px-3 py-2">
+                  <p className="text-[11px] uppercase tracking-wide text-neutral-500">Session</p>
+                  <p className="mt-1 truncate font-mono text-xs font-medium text-neutral-900">{latestUpload.upload_session_id}</p>
+                </div>
+                <div className="rounded-xl bg-neutral-50 px-3 py-2">
+                  <p className="text-[11px] uppercase tracking-wide text-neutral-500">Context</p>
+                  <p className="mt-1 text-sm font-medium text-neutral-900">
+                    {formatOwnerSelectionLabel(latestUpload.owner_scope, latestUpload.owner_id)}
+                  </p>
+                </div>
+                <div className="rounded-xl bg-neutral-50 px-3 py-2">
+                  <p className="text-[11px] uppercase tracking-wide text-neutral-500">Expires</p>
+                  <p className="mt-1 text-sm font-medium text-neutral-900">{latestUpload.expires_at || "n/a"}</p>
+                </div>
+              </div>
+            ) : (
+              <p className="mt-3 text-sm text-neutral-500">No upload session has been created in this browser session.</p>
+            )}
           </div>
 
           <div className="rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm">
             <div className="flex flex-wrap items-center gap-2">
-              <h2 className="text-base font-semibold text-neutral-900">Current Video Asset</h2>
+              <h2 className="text-base font-semibold text-neutral-900">Run Control</h2>
               {videoAsset ? (
                 <>
                   <Badge tone={resolveMediaType(videoAsset) === "episode" ? "sky" : "amber"}>
@@ -1224,24 +1965,27 @@ export default function CastScreentimePageClient() {
             {videoAsset ? (
               <div className="mt-4 grid gap-3 sm:grid-cols-3">
                 <div className="rounded-xl bg-neutral-50 px-3 py-2">
-                  <p className="text-[11px] uppercase tracking-wide text-neutral-500">Owner</p>
+                  <p className="text-[11px] uppercase tracking-wide text-neutral-500">Context</p>
                   <p className="mt-1 text-sm font-medium text-neutral-900">
-                    {videoAsset.owner_scope || "n/a"} {videoAsset.owner_id || ""}
+                    {formatOwnerSelectionLabel(videoAsset.owner_scope, videoAsset.owner_id, videoAsset.season_id, videoAsset.episode_id)}
                   </p>
                 </div>
                 <div className="rounded-xl bg-neutral-50 px-3 py-2">
                   <p className="text-[11px] uppercase tracking-wide text-neutral-500">Show</p>
-                  <p className="mt-1 text-sm font-medium text-neutral-900">{videoAsset.show_id || "n/a"}</p>
+                  <p className="mt-1 text-sm font-medium text-neutral-900">
+                    {videoAsset.show_id === screenalyticsKnownContext.show.id ? screenalyticsKnownContext.show.label : videoAsset.show_id || "n/a"}
+                  </p>
                 </div>
                 <div className="rounded-xl bg-neutral-50 px-3 py-2">
                   <p className="text-[11px] uppercase tracking-wide text-neutral-500">Import Type</p>
                   <p className="mt-1 text-sm font-medium text-neutral-900">{formatImportType(videoAsset.source_import_type)}</p>
                 </div>
               </div>
-            ) : null}
-            <pre className="mt-3 overflow-x-auto rounded-xl bg-neutral-950 p-4 text-xs text-neutral-100">
-              {JSON.stringify(videoAsset, null, 2)}
-            </pre>
+            ) : importStatus ? (
+              <p className="mt-3 text-sm text-neutral-500">{importStatus}</p>
+            ) : (
+              <p className="mt-3 text-sm text-neutral-500">Create or import a video asset before launching a run.</p>
+            )}
             <div className="mt-4 flex flex-wrap gap-3">
               <button
                 type="button"
@@ -1263,6 +2007,286 @@ export default function CastScreentimePageClient() {
           </div>
         </section>
 
+        <section className="rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm" aria-labelledby="source-subtitles-heading">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 id="source-subtitles-heading" className="text-base font-semibold text-neutral-900">
+                  Source Subtitles
+                </h2>
+                {activeVideoAssetId ? (
+                  <Badge
+                    tone={
+                      subtitleSummary?.status === "complete"
+                        ? "sky"
+                        : subtitleSummary?.status === "failed" || subtitleSummary?.status === "partial"
+                          ? "amber"
+                          : "neutral"
+                    }
+                  >
+                    {subtitleLoading && !subtitleSummary
+                      ? "Loading"
+                      : formatSubtitleStatus(subtitleSummary?.status)}
+                  </Badge>
+                ) : null}
+              </div>
+              <p className="mt-1 text-sm text-neutral-600">
+                Preserve embedded English captions as the source reference for transcript review.
+              </p>
+            </div>
+            {activeVideoAssetId ? (
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => setSubtitlePollVersion((current) => current + 1)}
+                  disabled={subtitleLoading}
+                  className="rounded-xl border border-neutral-300 px-3 py-2 text-sm font-medium text-neutral-900 disabled:opacity-60"
+                >
+                  {subtitleLoading ? "Refreshing…" : "Refresh"}
+                </button>
+                {subtitleSummary?.status === "not_requested" || !subtitleSummary ? (
+                  <button
+                    type="button"
+                    onClick={() => void requestSubtitleExtraction(false)}
+                    disabled={subtitleActionPending}
+                    className="rounded-xl bg-neutral-900 px-3 py-2 text-sm font-medium text-white disabled:opacity-60"
+                  >
+                    {subtitleActionPending ? "Queuing…" : "Extract Subtitles"}
+                  </button>
+                ) : subtitleSummary.status === "failed" ||
+                  subtitleSummary.status === "partial" ||
+                  subtitleSummary.status === "unavailable" ? (
+                  <button
+                    type="button"
+                    onClick={() => void requestSubtitleExtraction(false)}
+                    disabled={subtitleActionPending}
+                    className="rounded-xl bg-neutral-900 px-3 py-2 text-sm font-medium text-white disabled:opacity-60"
+                  >
+                    {subtitleActionPending ? "Queuing…" : "Retry Extraction"}
+                  </button>
+                ) : subtitleSummary.status === "complete" ? (
+                  <button
+                    type="button"
+                    onClick={() => void requestSubtitleExtraction(true)}
+                    disabled={subtitleActionPending}
+                    className="rounded-xl border border-neutral-300 px-3 py-2 text-sm font-medium text-neutral-900 disabled:opacity-60"
+                  >
+                    {subtitleActionPending ? "Queuing…" : "Re-extract"}
+                  </button>
+                ) : subtitleSummary.status === "queued" || subtitleSummary.status === "running" ? (
+                  <button
+                    type="button"
+                    onClick={() => void requestSubtitleExtraction(true)}
+                    disabled={subtitleActionPending}
+                    className="rounded-xl border border-amber-300 px-3 py-2 text-sm font-medium text-amber-900 disabled:opacity-60"
+                  >
+                    {subtitleActionPending ? "Queuing…" : "Restart extraction"}
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+
+          {!activeVideoAssetId ? (
+            <p className="mt-4 text-sm text-neutral-500">
+              Create, import, or load a video asset to inspect its embedded subtitle tracks.
+            </p>
+          ) : null}
+
+          {activeVideoAssetId && subtitleSummary ? (
+            <div className="mt-4 grid gap-3 sm:grid-cols-4">
+              <div className="rounded-xl bg-neutral-50 px-3 py-2">
+                <p className="text-[11px] uppercase tracking-wide text-neutral-500">Discovered</p>
+                <p className="mt-1 text-sm font-medium text-neutral-900">
+                  {subtitleSummary.discovered_track_count ?? subtitleSummary.tracks?.length ?? 0} tracks
+                </p>
+              </div>
+              <div className="rounded-xl bg-neutral-50 px-3 py-2">
+                <p className="text-[11px] uppercase tracking-wide text-neutral-500">English</p>
+                <p className="mt-1 text-sm font-medium text-neutral-900">
+                  {subtitleSummary.eligible_track_count ?? 0} eligible
+                </p>
+              </div>
+              <div className="rounded-xl bg-neutral-50 px-3 py-2">
+                <p className="text-[11px] uppercase tracking-wide text-neutral-500">Extracted</p>
+                <p className="mt-1 text-sm font-medium text-neutral-900">
+                  {subtitleSummary.completed_track_count ?? completedSubtitleTracks.length} complete
+                </p>
+              </div>
+              <div className="rounded-xl bg-neutral-50 px-3 py-2">
+                <p className="text-[11px] uppercase tracking-wide text-neutral-500">Attempts</p>
+                <p className="mt-1 text-sm font-medium text-neutral-900">{subtitleSummary.attempts ?? 0}</p>
+              </div>
+            </div>
+          ) : null}
+
+          {subtitleSummary?.status === "queued" || subtitleSummary?.status === "running" ? (
+            <p className="mt-4 text-sm text-neutral-600" role="status">
+              Subtitle extraction is running in the background. This video remains available for analysis.
+            </p>
+          ) : null}
+          {subtitleSummary?.status === "unavailable" ? (
+            <p className="mt-4 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+              This asset has no supported English embedded subtitle track.
+            </p>
+          ) : null}
+          {subtitleSummary?.status === "failed" || subtitleSummary?.status === "partial" ? (
+            <p className="mt-4 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+              {subtitleSummary.error ||
+                (subtitleSummary.status === "partial"
+                  ? "Some English subtitle tracks could not be extracted."
+                  : "Subtitle extraction failed. The video upload is still available.")}
+            </p>
+          ) : null}
+          {subtitleError ? (
+            <p className="mt-4 text-sm text-red-600" role="alert">
+              {subtitleError}
+            </p>
+          ) : null}
+
+          {completedSubtitleTracks.length > 0 ? (
+            <div className="mt-5 border-t border-neutral-200 pt-5">
+              <div className="flex flex-wrap items-end justify-between gap-3">
+                <label className="flex min-w-64 flex-col gap-2 text-sm font-medium text-neutral-700">
+                  English subtitle track
+                  <select
+                    aria-label="English subtitle track"
+                    value={selectedSubtitleTrackId}
+                    onChange={(event) => {
+                      setSelectedSubtitleTrackId(event.target.value);
+                      setSubtitleCueOffset(0);
+                    }}
+                    className="rounded-xl border border-neutral-300 px-3 py-2 text-sm text-neutral-900"
+                  >
+                    {completedSubtitleTracks.map((track) => (
+                      <option key={track.id} value={track.id}>
+                        Stream {track.stream_index} · {track.language || track.language_normalized || track.language_raw || "English"} · {track.codec_name}
+                        {track.is_primary ? " · primary" : ""}
+                        {track.is_forced ? " · forced" : ""}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <button
+                  type="button"
+                  onClick={() => void downloadSubtitleTrack()}
+                  disabled={!selectedSubtitleTrack || subtitleDownloadPending}
+                  className="rounded-xl bg-neutral-900 px-4 py-2 text-sm font-medium text-white disabled:opacity-60"
+                >
+                  {subtitleDownloadPending ? "Preparing SRT…" : "Download SRT"}
+                </button>
+              </div>
+
+              {selectedSubtitleTrack ? (
+                <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                  <div className="rounded-xl bg-neutral-50 px-3 py-2">
+                    <p className="text-[11px] uppercase tracking-wide text-neutral-500">Track</p>
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      <span className="text-sm font-medium text-neutral-900">Stream {selectedSubtitleTrack.stream_index}</span>
+                      {selectedSubtitleTrack.is_primary ? <Badge tone="sky">Primary</Badge> : null}
+                      {selectedSubtitleTrack.is_default ? <Badge tone="neutral">Default</Badge> : null}
+                      {selectedSubtitleTrack.is_forced ? <Badge tone="amber">Forced</Badge> : null}
+                    </div>
+                  </div>
+                  <div className="rounded-xl bg-neutral-50 px-3 py-2">
+                    <p className="text-[11px] uppercase tracking-wide text-neutral-500">Cues</p>
+                    <p className="mt-1 text-sm font-medium text-neutral-900">
+                      {(selectedSubtitleTrack.cue_count ?? 0).toLocaleString()}
+                    </p>
+                  </div>
+                  <div className="rounded-xl bg-neutral-50 px-3 py-2">
+                    <p className="text-[11px] uppercase tracking-wide text-neutral-500">Timing</p>
+                    <p className="mt-1 text-xs font-medium text-neutral-900">
+                      {formatSubtitleTimestamp(selectedSubtitleTrack.first_cue_start_ms)} –{" "}
+                      {formatSubtitleTimestamp(selectedSubtitleTrack.last_cue_end_ms)}
+                    </p>
+                  </div>
+                  <div className="rounded-xl bg-neutral-50 px-3 py-2">
+                    <p className="text-[11px] uppercase tracking-wide text-neutral-500">SRT</p>
+                    <p className="mt-1 text-xs font-medium text-neutral-900">
+                      {formatSubtitleBytes(selectedSubtitleTrack.srt_size_bytes)}
+                      {selectedSubtitleTrack.srt_sha256
+                        ? ` · ${selectedSubtitleTrack.srt_sha256.slice(0, 10)}…`
+                        : ""}
+                    </p>
+                  </div>
+                </div>
+              ) : null}
+
+              <div className="mt-5">
+                <div className="flex flex-wrap items-end justify-between gap-3">
+                  <label className="flex min-w-64 flex-1 flex-col gap-2 text-sm font-medium text-neutral-700">
+                    Search subtitle cues
+                    <input
+                      type="search"
+                      value={subtitleSearchInput}
+                      onChange={(event) => setSubtitleSearchInput(event.target.value)}
+                      placeholder="Search spoken dialogue, speaker labels, or SDH cues"
+                      className="rounded-xl border border-neutral-300 px-3 py-2 text-sm text-neutral-900"
+                    />
+                  </label>
+                  <p className="pb-2 text-xs text-neutral-500" aria-live="polite">
+                    {subtitleCueLoading
+                      ? "Loading cues…"
+                      : `${subtitleResultCount.toLocaleString()} ${subtitleSearchQuery ? "matches" : "cues"}`}
+                  </p>
+                </div>
+
+                {!subtitleCueLoading && subtitleCuePage?.items.length === 0 ? (
+                  <p className="mt-4 text-sm text-neutral-500">No subtitle cues match this search.</p>
+                ) : null}
+                {subtitleCuePage?.items.length ? (
+                  <ol className="mt-4 divide-y divide-neutral-200 rounded-xl border border-neutral-200">
+                    {subtitleCuePage.items.map((cue) => (
+                      <li key={`${cue.ordinal}-${cue.start_ms}`} className="grid gap-2 px-3 py-3 md:grid-cols-[10rem,1fr]">
+                        <div className="font-mono text-xs text-neutral-500">
+                          {formatSubtitleTimestamp(cue.start_ms)}
+                          <span className="mx-1">–</span>
+                          {formatSubtitleTimestamp(cue.end_ms)}
+                        </div>
+                        <div>
+                          <p className="whitespace-pre-wrap text-sm text-neutral-900">{cue.plain_text}</p>
+                          {cue.text !== cue.plain_text ? (
+                            <details className="mt-2 text-xs text-neutral-500">
+                              <summary className="cursor-pointer">Raw subtitle text</summary>
+                              <pre className="mt-1 whitespace-pre-wrap break-words font-mono">{cue.text}</pre>
+                            </details>
+                          ) : null}
+                        </div>
+                      </li>
+                    ))}
+                  </ol>
+                ) : null}
+
+                {subtitleCuePage && subtitleResultCount > subtitleCuePageSize ? (
+                  <div className="mt-3 flex items-center justify-between gap-3">
+                    <button
+                      type="button"
+                      onClick={() => setSubtitleCueOffset((current) => Math.max(0, current - subtitleCuePageSize))}
+                      disabled={!subtitleHasPreviousPage || subtitleCueLoading}
+                      className="rounded-xl border border-neutral-300 px-3 py-2 text-sm font-medium text-neutral-900 disabled:opacity-50"
+                    >
+                      Previous cues
+                    </button>
+                    <span className="text-xs text-neutral-500">
+                      {subtitleCueOffset + 1}–{Math.min(subtitleCueOffset + subtitleCuePage.items.length, subtitleResultCount)} of{" "}
+                      {subtitleResultCount.toLocaleString()}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => setSubtitleCueOffset((current) => current + subtitleCuePageSize)}
+                      disabled={!subtitleHasNextPage || subtitleCueLoading}
+                      className="rounded-xl border border-neutral-300 px-3 py-2 text-sm font-medium text-neutral-900 disabled:opacity-50"
+                    >
+                      Next cues
+                    </button>
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          ) : null}
+        </section>
+
         <section className="rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm">
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div>
@@ -1273,13 +2297,17 @@ export default function CastScreentimePageClient() {
             </div>
             <div className="flex flex-wrap items-center gap-3">
               <label className="flex flex-col gap-2 text-sm font-medium text-neutral-700">
-                Show ID
-                <input
+                Show filter
+                <select
+                  aria-label="Run History Show"
                   value={showId}
-                  onChange={(event) => setShowId(event.target.value)}
-                  placeholder="UUID for core.shows.id"
+                  onChange={(event) => handleShowChange(event.target.value)}
                   className="rounded-xl border border-neutral-300 px-3 py-2 text-sm text-neutral-900"
-                />
+                >
+                  <option value="">Choose show</option>
+                  <option value={screenalyticsKnownContext.show.id}>{screenalyticsKnownContext.show.label}</option>
+                  {showId && showId !== screenalyticsKnownContext.show.id ? <option value={showId}>Current show</option> : null}
+                </select>
               </label>
               <div className="flex flex-wrap gap-2 pt-6">
                 {videoClassFilters.map((option) => (
@@ -1318,28 +2346,63 @@ export default function CastScreentimePageClient() {
         </section>
 
         <section className="rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-base font-semibold text-neutral-900">Current Run</h2>
-            {run ? (
-              <>
-                <Badge tone={resolveMediaType(run) === "episode" ? "sky" : "amber"}>
-                  {formatVideoClass(run.media_type, run.media_kind, run.video_class, run.promo_subtype)}
-                </Badge>
-                <Badge tone="neutral">{formatImportType(run.source_import_type)}</Badge>
-                {run.is_publishable === false ? <Badge tone="amber">Non-publishable</Badge> : null}
-              </>
-            ) : null}
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="text-base font-semibold text-neutral-900">Current Run</h2>
+              {run ? (
+                <>
+                  <Badge tone={resolveMediaType(run) === "episode" ? "sky" : "amber"}>
+                    {formatVideoClass(run.media_type, run.media_kind, run.video_class, run.promo_subtype)}
+                  </Badge>
+                  <Badge tone="neutral">{formatImportType(run.source_import_type)}</Badge>
+                  {run.is_publishable === false ? <Badge tone="amber">Non-publishable</Badge> : null}
+                </>
+              ) : null}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {run?.id ? (
+                <Button variant="outline" size="sm" onClick={() => void copyRunLink(run.id)}>
+                  {copiedRunLinkId === run.id ? "Copied link" : "Copy run link"}
+                </Button>
+              ) : null}
+              {debugDetailsAvailable ? (
+                <Dialog>
+                  <DialogTrigger asChild>
+                    <Button variant="outline" size="sm">Debug details</Button>
+                  </DialogTrigger>
+                  <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-4xl">
+                    <DialogHeader>
+                      <DialogTitle>Screenalytics debug details</DialogTitle>
+                      <DialogDescription>
+                        Raw payloads for troubleshooting. These are hidden from the normal review view.
+                      </DialogDescription>
+                    </DialogHeader>
+                    <div className="grid gap-4">
+                      <DebugJsonBlock title="Current run" value={run} />
+                      <DebugJsonBlock title="Current video asset" value={videoAsset} />
+                      <DebugJsonBlock title="Latest upload session" value={latestUpload} />
+                    </div>
+                  </DialogContent>
+                </Dialog>
+              ) : null}
+            </div>
           </div>
-          <pre className="mt-3 overflow-x-auto rounded-xl bg-neutral-950 p-4 text-xs text-neutral-100">
-            {JSON.stringify(run, null, 2)}
-          </pre>
+          {!run ? (
+            <p className="mt-3 text-sm text-neutral-500">
+              Load a recent run or launch a new one to review screen-time output.
+            </p>
+          ) : null}
           {run ? (
             <div className="mt-4 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
               {getRunOverviewMessage(run, currentPublishVersion)}
             </div>
           ) : null}
           {run ? (
-            <div className="mt-4 grid gap-3 sm:grid-cols-4">
+            <div className="mt-4 grid gap-3 sm:grid-cols-3 xl:grid-cols-6">
+              <div className="rounded-xl bg-neutral-50 px-3 py-2">
+                <p className="text-[11px] uppercase tracking-wide text-neutral-500">Run</p>
+                <p className="mt-1 truncate font-mono text-xs font-medium text-neutral-900">{run.id}</p>
+              </div>
               <div className="rounded-xl bg-neutral-50 px-3 py-2">
                 <p className="text-[11px] uppercase tracking-wide text-neutral-500">Execution</p>
                 <p className="mt-1 text-sm font-medium text-neutral-900">{getExecutionStatusLabel(run)}</p>
@@ -1353,8 +2416,10 @@ export default function CastScreentimePageClient() {
                 <p className="mt-1 text-sm font-medium text-neutral-900">{run.review_status || "draft"}</p>
               </div>
               <div className="rounded-xl bg-neutral-50 px-3 py-2">
-                <p className="text-[11px] uppercase tracking-wide text-neutral-500">Owner</p>
-                <p className="mt-1 text-sm font-medium text-neutral-900">{run.owner_scope || "n/a"}</p>
+                <p className="text-[11px] uppercase tracking-wide text-neutral-500">Context</p>
+                <p className="mt-1 truncate text-sm font-medium text-neutral-900">
+                  {formatOwnerSelectionLabel(run.owner_scope, run.owner_id, run.season_id, run.episode_id)}
+                </p>
               </div>
               <div className="rounded-xl bg-neutral-50 px-3 py-2">
                 <p className="text-[11px] uppercase tracking-wide text-neutral-500">Effective Runtime</p>
@@ -1370,10 +2435,17 @@ export default function CastScreentimePageClient() {
                 Candidate cast preflight: {run.cast_coverage_summary_json.candidate_count ?? 0} candidates,{" "}
                 {run.cast_coverage_summary_json.approved_facebank_coverage_count ?? 0} with approved facebank coverage.
               </div>
-              {Array.isArray(run.cast_coverage_summary_json.fallback_scopes_used) &&
-              run.cast_coverage_summary_json.fallback_scopes_used.length > 0 ? (
+              {candidateScopePolicy ? (
                 <div className="mt-1 text-xs text-sky-800">
-                  Fallback scopes used: {run.cast_coverage_summary_json.fallback_scopes_used.join(", ")}
+                  {strictCandidateScope
+                    ? `Strict ${candidateScopeLabel} credits only. Broader fallback cast is not included.`
+                    : `Candidate scope: ${candidateScopePolicy.scope_order?.join(", ") || candidateScopeLabel}.`}
+                </div>
+              ) : null}
+              {Array.isArray(fallbackScopesUsed) && fallbackScopesUsed.length > 0 ? (
+                <div className="mt-1 text-xs text-sky-800">
+                  {strictCandidateScope ? "Legacy fallback scopes recorded" : "Fallback scopes used"}:{" "}
+                  {fallbackScopesUsed.join(", ")}
                 </div>
               ) : null}
               {Array.isArray(run.cast_coverage_summary_json.warnings) && run.cast_coverage_summary_json.warnings.length > 0 ? (
@@ -1434,6 +2506,40 @@ export default function CastScreentimePageClient() {
                   </button>
                 ))
               : null}
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h2 className="text-base font-semibold text-neutral-900">Review Workspace</h2>
+              <p className="mt-1 text-sm text-neutral-600">
+                Use this as the handoff point after a run starts: metrics, frame artifacts, identity suggestions, and exclusions populate as retained artifacts arrive.
+              </p>
+            </div>
+            {run ? <Badge tone="sky">{getExecutionStatusLabel(run)}</Badge> : <Badge tone="neutral">No active run</Badge>}
+          </div>
+          <div className="mt-4 grid gap-3 md:grid-cols-4">
+            <div className="rounded-xl bg-neutral-50 px-3 py-3">
+              <p className="text-[11px] uppercase tracking-wide text-neutral-500">Metrics</p>
+              <p className="mt-1 text-lg font-semibold text-neutral-900">{leaderboard.length}</p>
+              <p className="text-xs text-neutral-500">leaderboard rows</p>
+            </div>
+            <div className="rounded-xl bg-neutral-50 px-3 py-3">
+              <p className="text-[11px] uppercase tracking-wide text-neutral-500">Frames and faces</p>
+              <p className="mt-1 text-lg font-semibold text-neutral-900">{shots.length + scenes.length}</p>
+              <p className="text-xs text-neutral-500">shots and scenes</p>
+            </div>
+            <div className="rounded-xl bg-neutral-50 px-3 py-3">
+              <p className="text-[11px] uppercase tracking-wide text-neutral-500">Identity review</p>
+              <p className="mt-1 text-lg font-semibold text-neutral-900">{castSuggestions.length + unknownReviewQueues.length}</p>
+              <p className="text-xs text-neutral-500">suggestions and queues</p>
+            </div>
+            <div className="rounded-xl bg-neutral-50 px-3 py-3">
+              <p className="text-[11px] uppercase tracking-wide text-neutral-500">Exclusions</p>
+              <p className="mt-1 text-lg font-semibold text-neutral-900">{excludedSections.length}</p>
+              <p className="text-xs text-neutral-500">sections marked out</p>
+            </div>
           </div>
         </section>
 
@@ -1675,7 +2781,7 @@ export default function CastScreentimePageClient() {
                           <th className="pb-2 pr-4">Run</th>
                           <th className="pb-2 pr-4">Status</th>
                           <th className="pb-2 pr-4">Review</th>
-                          <th className="pb-2">Load</th>
+                          <th className="pb-2">Actions</th>
                         </tr>
                       </thead>
                       <tbody>
@@ -1693,13 +2799,22 @@ export default function CastScreentimePageClient() {
                             <td className="py-2 pr-4">{showRun.status}</td>
                             <td className="py-2 pr-4">{showRun.review_status || "draft"}</td>
                             <td className="py-2">
-                              <button
-                                type="button"
-                                onClick={() => void loadRecentRun(showRun.id)}
-                                className="rounded-lg border border-neutral-300 px-2 py-1 text-xs font-medium text-neutral-900"
-                              >
-                                Load
-                              </button>
+                              <div className="flex flex-wrap gap-2">
+                                <button
+                                  type="button"
+                                  onClick={() => void loadRecentRun(showRun.id)}
+                                  className="rounded-lg border border-neutral-300 px-2 py-1 text-xs font-medium text-neutral-900"
+                                >
+                                  Load
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => void copyRunLink(showRun.id)}
+                                  className="rounded-lg border border-neutral-300 px-2 py-1 text-xs font-medium text-neutral-900"
+                                >
+                                  {copiedRunLinkId === showRun.id ? "Copied" : "Copy link"}
+                                </button>
+                              </div>
                             </td>
                           </tr>
                         ))}
@@ -1723,7 +2838,7 @@ export default function CastScreentimePageClient() {
                           <th className="pb-2 pr-4">Run</th>
                           <th className="pb-2 pr-4">Status</th>
                           <th className="pb-2 pr-4">Review</th>
-                          <th className="pb-2">Load</th>
+                          <th className="pb-2">Actions</th>
                         </tr>
                       </thead>
                       <tbody>
@@ -1741,13 +2856,22 @@ export default function CastScreentimePageClient() {
                             <td className="py-2 pr-4">{showRun.status}</td>
                             <td className="py-2 pr-4">{showRun.review_status || "draft"}</td>
                             <td className="py-2">
-                              <button
-                                type="button"
-                                onClick={() => void loadRecentRun(showRun.id)}
-                                className="rounded-lg border border-neutral-300 px-2 py-1 text-xs font-medium text-neutral-900"
-                              >
-                                Load
-                              </button>
+                              <div className="flex flex-wrap gap-2">
+                                <button
+                                  type="button"
+                                  onClick={() => void loadRecentRun(showRun.id)}
+                                  className="rounded-lg border border-neutral-300 px-2 py-1 text-xs font-medium text-neutral-900"
+                                >
+                                  Load
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => void copyRunLink(showRun.id)}
+                                  className="rounded-lg border border-neutral-300 px-2 py-1 text-xs font-medium text-neutral-900"
+                                >
+                                  {copiedRunLinkId === showRun.id ? "Copied" : "Copy link"}
+                                </button>
+                              </div>
                             </td>
                           </tr>
                         ))}
@@ -1918,6 +3042,7 @@ export default function CastScreentimePageClient() {
           </div>
         </section>
 
+        {hasFrameOrFaceArtifacts ? (
         <section className="grid gap-6 lg:grid-cols-4">
           <div className="rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm">
             <h2 className="text-base font-semibold text-neutral-900">Shots</h2>
@@ -1932,7 +3057,7 @@ export default function CastScreentimePageClient() {
                       {formatDurationMs(shot.start_ms)} to {formatDurationMs(shot.end_ms)}
                     </div>
                     <div className="mt-1 text-xs text-neutral-500">
-                      {shot.observation_count} observations, {shot.assigned_person_ids.length} assigned people
+                      {shot.observation_count} observations, {shot.assigned_person_ids?.length ?? 0} assigned people
                     </div>
                   </div>
                 ))}
@@ -1956,9 +3081,9 @@ export default function CastScreentimePageClient() {
                       {scene.composition_type}, {scene.shot_count} shots, {scene.unknown_segment_count} unknown segments
                     </div>
                     <div className="mt-1 text-xs text-neutral-500">
-                      {scene.dominant_person_ids.length === 0
+                      {(scene.dominant_person_ids?.length ?? 0) === 0
                         ? "No named cast present"
-                        : scene.dominant_person_ids
+                        : (scene.dominant_person_ids ?? [])
                             .map((personId) => scene.dominant_display_names?.[personId] || personId)
                             .join(", ")}
                     </div>
@@ -2013,6 +3138,24 @@ export default function CastScreentimePageClient() {
             )}
           </div>
         </section>
+        ) : (
+          <section className="rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <h2 className="text-base font-semibold text-neutral-900">Frame and face artifacts</h2>
+                <p className="mt-1 text-sm text-neutral-600">
+                  Detailed frame, scene, title-card, and confessional sections appear here when artifacts are present.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Badge tone={hasRunReviewArtifacts ? "sky" : "neutral"}>shots {shots.length}</Badge>
+                <Badge tone={hasRunReviewArtifacts ? "sky" : "neutral"}>scenes {scenes.length}</Badge>
+                <Badge tone={hasRunReviewArtifacts ? "sky" : "neutral"}>title cards {titleCardCandidates.length}</Badge>
+                <Badge tone={hasRunReviewArtifacts ? "sky" : "neutral"}>confessionals {confessionalCandidates.length}</Badge>
+              </div>
+            </div>
+          </section>
+        )}
 
         <section className="grid gap-6 lg:grid-cols-2">
           <div className="rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm">

--- a/apps/web/src/app/api/admin/trr-api/people/[personId]/credits/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/people/[personId]/credits/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/server/auth";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 import {
   getEpisodeCreditsByPersonId,
   type PersonShowEpisodeCredit,
@@ -340,10 +341,25 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     const { searchParams } = new URL(request.url);
-    const parsedLimit = Number.parseInt(searchParams.get("limit") ?? "50", 10);
-    const parsedOffset = Number.parseInt(searchParams.get("offset") ?? "0", 10);
-    const limit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : 50;
-    const offset = Number.isFinite(parsedOffset) && parsedOffset >= 0 ? parsedOffset : 0;
+    const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: 50,
+      min: 1,
+      max: 500,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const offsetResult = parseBoundedIntegerParam(searchParams.get("offset"), {
+      name: "offset",
+      defaultValue: 0,
+      min: 0,
+    });
+    if (!offsetResult.ok) {
+      return NextResponse.json({ error: offsetResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
+    const offset = offsetResult.value;
     const showIdRaw = searchParams.get("showId");
     const showId =
       typeof showIdRaw === "string" && showIdRaw.trim().length > 0

--- a/apps/web/src/app/api/admin/trr-api/people/[personId]/photos/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/people/[personId]/photos/route.ts
@@ -82,13 +82,23 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const requestRole =
       requestRoleRaw === "primary" || requestRoleRaw === "polling" ? requestRoleRaw : "secondary";
 
-    const requestedLimit = limit;
-    const cacheSearchParams = new URLSearchParams(searchParams);
-    cacheSearchParams.delete("request_role");
+    const backendParams = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+    });
+    if (sources.length > 0) {
+      backendParams.set("sources", sources.join(","));
+    }
+    if (includeBroken) {
+      backendParams.set("include_broken", "true");
+    }
+    if (!includeTotalCount) {
+      backendParams.set("include_total_count", "false");
+    }
     const cacheKey = buildUserScopedRouteCacheKey(
       user.uid,
       `${personId}:photos`,
-      cacheSearchParams,
+      backendParams,
     );
     const cachedPayload = getRouteResponseCache<{
       photos: Array<Record<string, unknown>>;
@@ -110,19 +120,6 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       PERSON_PHOTOS_CACHE_NAMESPACE,
       cacheKey,
       async () => {
-        const backendParams = new URLSearchParams({
-          limit: String(requestedLimit),
-          offset: String(offset),
-        });
-        if (sources.length > 0) {
-          backendParams.set("sources", sources.join(","));
-        }
-        if (includeBroken) {
-          backendParams.set("include_broken", "true");
-        }
-        if (!includeTotalCount) {
-          backendParams.set("include_total_count", "false");
-        }
         const upstream = await fetchAdminBackendJson(
           `/admin/people/${personId}/gallery?${backendParams.toString()}`,
           {
@@ -170,7 +167,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
         const nextPayload = {
           photos: pagePhotos,
           pagination: {
-            limit: requestedLimit,
+            limit,
             offset,
             count: pagePhotos.length,
             total_count:

--- a/apps/web/src/app/api/admin/trr-api/people/[personId]/photos/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/people/[personId]/photos/route.ts
@@ -13,6 +13,7 @@ import {
   fetchAdminBackendJson,
   ADMIN_READ_PROXY_GALLERY_TIMEOUT_MS,
 } from "@/lib/server/trr-api/admin-read-proxy";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 
 export const dynamic = "force-dynamic";
 const PERSON_PHOTOS_CACHE_NAMESPACE = "admin-person-photos";
@@ -50,10 +51,25 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     const { searchParams } = new URL(request.url);
-    const parsedLimit = parseInt(searchParams.get("limit") ?? "100", 10);
-    const parsedOffset = parseInt(searchParams.get("offset") ?? "0", 10);
-    const limit = Number.isFinite(parsedLimit) ? parsedLimit : 100;
-    const offset = Number.isFinite(parsedOffset) ? parsedOffset : 0;
+    const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: 100,
+      min: 1,
+      max: 500,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const offsetResult = parseBoundedIntegerParam(searchParams.get("offset"), {
+      name: "offset",
+      defaultValue: 0,
+      min: 0,
+    });
+    if (!offsetResult.ok) {
+      return NextResponse.json({ error: offsetResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
+    const offset = offsetResult.value;
     const sources = (searchParams.get("sources") ?? "")
       .split(",")
       .map((value) => value.trim())
@@ -66,7 +82,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const requestRole =
       requestRoleRaw === "primary" || requestRoleRaw === "polling" ? requestRoleRaw : "secondary";
 
-    const requestedLimit = Math.max(1, Math.min(limit, 500));
+    const requestedLimit = limit;
     const cacheSearchParams = new URLSearchParams(searchParams);
     cacheSearchParams.delete("request_role");
     const cacheKey = buildUserScopedRouteCacheKey(

--- a/apps/web/src/app/api/admin/trr-api/people/home/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/people/home/route.ts
@@ -35,7 +35,8 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: limitResult.error }, { status: 400 });
     }
     const limit = limitResult.value;
-    const cacheKey = buildUserScopedRouteCacheKey(user.uid, "people-home", request.nextUrl.searchParams);
+    const upstreamParams = new URLSearchParams({ limit: String(limit) });
+    const cacheKey = buildUserScopedRouteCacheKey(user.uid, "people-home", upstreamParams);
     const cached = getRouteResponseCache<Record<string, unknown>>(TRR_PEOPLE_HOME_CACHE_NAMESPACE, cacheKey);
     if (cached) {
       return NextResponse.json(cached, { headers: { "x-trr-cache": "hit" } });
@@ -46,9 +47,7 @@ export async function GET(request: NextRequest) {
       cacheKey,
       async () => {
         const upstream = await fetchAdminBackendJson(
-          `/admin/trr-api/people/home?${new URLSearchParams({
-            limit: String(limit),
-          }).toString()}`,
+          `/admin/trr-api/people/home?${upstreamParams.toString()}`,
           {
             headers: {
               "X-TRR-Admin-User-Uid": user.uid,

--- a/apps/web/src/app/api/admin/trr-api/people/home/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/people/home/route.ts
@@ -15,21 +15,26 @@ import {
   TRR_PEOPLE_HOME_CACHE_NAMESPACE,
   TRR_PEOPLE_HOME_CACHE_TTL_MS,
 } from "@/lib/server/trr-api/trr-show-read-route-cache";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 
 export const dynamic = "force-dynamic";
 
 const DEFAULT_SECTION_LIMIT = 12;
 const MAX_SECTION_LIMIT = 24;
-const parseLimit = (raw: string | null): number => {
-  const parsed = Number.parseInt(raw ?? String(DEFAULT_SECTION_LIMIT), 10);
-  if (!Number.isFinite(parsed)) return DEFAULT_SECTION_LIMIT;
-  return Math.min(Math.max(parsed, 1), MAX_SECTION_LIMIT);
-};
 
 export async function GET(request: NextRequest) {
   try {
     const user = await requireAdmin(request);
-    const limit = parseLimit(request.nextUrl.searchParams.get("limit"));
+    const limitResult = parseBoundedIntegerParam(request.nextUrl.searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: DEFAULT_SECTION_LIMIT,
+      min: 1,
+      max: MAX_SECTION_LIMIT,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
     const cacheKey = buildUserScopedRouteCacheKey(user.uid, "people-home", request.nextUrl.searchParams);
     const cached = getRouteResponseCache<Record<string, unknown>>(TRR_PEOPLE_HOME_CACHE_NAMESPACE, cacheKey);
     if (cached) {

--- a/apps/web/src/app/api/admin/trr-api/people/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/people/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/server/auth";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 import { searchPeople } from "@/lib/server/trr-api/trr-shows-repository";
 
 export const dynamic = "force-dynamic";
@@ -23,8 +24,23 @@ export async function GET(request: NextRequest) {
 
     const { searchParams } = new URL(request.url);
     const query = searchParams.get("q")?.trim() ?? "";
-    const rawLimit = parseInt(searchParams.get("limit") ?? "10", 10);
-    const offset = parseInt(searchParams.get("offset") ?? "0", 10);
+    const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: 10,
+      min: 1,
+      max: MAX_LIMIT,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const offsetResult = parseBoundedIntegerParam(searchParams.get("offset"), {
+      name: "offset",
+      defaultValue: 0,
+      min: 0,
+    });
+    if (!offsetResult.ok) {
+      return NextResponse.json({ error: offsetResult.error }, { status: 400 });
+    }
 
     // Enforce min query length to avoid full table scans
     if (query.length < MIN_QUERY_LENGTH) {
@@ -34,8 +50,8 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Cap limit to prevent abuse
-    const limit = Math.min(Math.max(1, rawLimit), MAX_LIMIT);
+    const limit = limitResult.value;
+    const offset = offsetResult.value;
 
     const people = await searchPeople(query, { limit, offset });
 

--- a/apps/web/src/app/api/admin/trr-api/search/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/search/route.ts
@@ -45,7 +45,8 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: limitResult.error }, { status: 400 });
     }
     const limit = limitResult.value;
-    const cacheKey = buildUserScopedRouteCacheKey(user.uid, "search", request.nextUrl.searchParams);
+    const upstreamParams = new URLSearchParams({ q: query, limit: String(limit) });
+    const cacheKey = buildUserScopedRouteCacheKey(user.uid, "search", upstreamParams);
     const cached = getRouteResponseCache<Record<string, unknown>>(TRR_SEARCH_CACHE_NAMESPACE, cacheKey);
     if (cached) {
       return NextResponse.json(cached, { headers: { "x-trr-cache": "hit" } });
@@ -56,7 +57,7 @@ export async function GET(request: NextRequest) {
       cacheKey,
       async () => {
         const upstream = await fetchAdminBackendJson(
-          `/admin/trr-api/search?${new URLSearchParams({ q: query, limit: String(limit) }).toString()}`,
+          `/admin/trr-api/search?${upstreamParams.toString()}`,
           {
             timeoutMs: ADMIN_READ_PROXY_SHORT_TIMEOUT_MS,
             routeName: "admin-global-search",

--- a/apps/web/src/app/api/admin/trr-api/search/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/search/route.ts
@@ -15,17 +15,13 @@ import {
   TRR_SEARCH_CACHE_NAMESPACE,
   TRR_SEARCH_CACHE_TTL_MS,
 } from "@/lib/server/trr-api/trr-show-read-route-cache";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 
 export const dynamic = "force-dynamic";
 
 const MIN_QUERY_LENGTH = 3;
 const DEFAULT_LIMIT = 8;
 const MAX_LIMIT = 20;
-const parseLimit = (raw: string | null): number => {
-  const parsed = Number.parseInt(raw ?? String(DEFAULT_LIMIT), 10);
-  if (!Number.isFinite(parsed)) return DEFAULT_LIMIT;
-  return Math.min(Math.max(parsed, 1), MAX_LIMIT);
-};
 
 export async function GET(request: NextRequest) {
   try {
@@ -39,7 +35,16 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const limit = parseLimit(request.nextUrl.searchParams.get("limit"));
+    const limitResult = parseBoundedIntegerParam(request.nextUrl.searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: DEFAULT_LIMIT,
+      min: 1,
+      max: MAX_LIMIT,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
     const cacheKey = buildUserScopedRouteCacheKey(user.uid, "search", request.nextUrl.searchParams);
     const cached = getRouteResponseCache<Record<string, unknown>>(TRR_SEARCH_CACHE_NAMESPACE, cacheKey);
     if (cached) {

--- a/apps/web/src/app/api/admin/trr-api/seasons/[seasonId]/episodes/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/seasons/[seasonId]/episodes/route.ts
@@ -15,6 +15,7 @@ import {
   TRR_SEASON_EPISODES_CACHE_NAMESPACE,
   TRR_SEASON_EPISODES_CACHE_TTL_MS,
 } from "@/lib/server/trr-api/trr-show-read-route-cache";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 
 export const dynamic = "force-dynamic";
 
@@ -32,8 +33,25 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     const { searchParams } = new URL(request.url);
-    const limit = parseInt(searchParams.get("limit") ?? "20", 10);
-    const offset = parseInt(searchParams.get("offset") ?? "0", 10);
+    const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: 20,
+      min: 1,
+      max: 500,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const offsetResult = parseBoundedIntegerParam(searchParams.get("offset"), {
+      name: "offset",
+      defaultValue: 0,
+      min: 0,
+    });
+    if (!offsetResult.ok) {
+      return NextResponse.json({ error: offsetResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
+    const offset = offsetResult.value;
     const cacheKey = buildUserScopedRouteCacheKey(
       user.uid,
       `season-episodes:${seasonId}`,

--- a/apps/web/src/app/api/admin/trr-api/seasons/[seasonId]/episodes/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/seasons/[seasonId]/episodes/route.ts
@@ -52,10 +52,14 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
     const limit = limitResult.value;
     const offset = offsetResult.value;
+    const upstreamParams = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+    });
     const cacheKey = buildUserScopedRouteCacheKey(
       user.uid,
       `season-episodes:${seasonId}`,
-      request.nextUrl.searchParams,
+      upstreamParams,
     );
     const cached = getRouteResponseCache<Record<string, unknown>>(TRR_SEASON_EPISODES_CACHE_NAMESPACE, cacheKey);
     if (cached) {
@@ -67,10 +71,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       cacheKey,
       async () => {
         const upstream = await fetchAdminBackendJson(
-          `/admin/trr-api/seasons/${seasonId}/episodes?${new URLSearchParams({
-            limit: String(limit),
-            offset: String(offset),
-          }).toString()}`,
+          `/admin/trr-api/seasons/${seasonId}/episodes?${upstreamParams.toString()}`,
           {
             timeoutMs: ADMIN_READ_PROXY_SHORT_TIMEOUT_MS,
             routeName: "season-episodes",

--- a/apps/web/src/app/api/admin/trr-api/shows/[showId]/assets/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/[showId]/assets/route.ts
@@ -17,6 +17,7 @@ import {
   TRR_SHOW_ASSETS_CACHE_NAMESPACE,
   TRR_SHOW_ASSETS_CACHE_TTL_MS,
 } from "@/lib/server/trr-api/trr-show-read-route-cache";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 
 export const dynamic = "force-dynamic";
 const DEFAULT_VISIBLE_ASSET_LIMIT = 48;
@@ -42,10 +43,25 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
     }
 
     const { searchParams } = new URL(_request.url);
-    const parsedLimit = parseInt(searchParams.get("limit") ?? String(DEFAULT_VISIBLE_ASSET_LIMIT), 10);
-    const parsedOffset = parseInt(searchParams.get("offset") ?? "0", 10);
-    const limit = Number.isFinite(parsedLimit) ? parsedLimit : DEFAULT_VISIBLE_ASSET_LIMIT;
-    const offset = Number.isFinite(parsedOffset) ? parsedOffset : 0;
+    const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: DEFAULT_VISIBLE_ASSET_LIMIT,
+      min: 1,
+      max: FULL_FETCH_LIMIT,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const offsetResult = parseBoundedIntegerParam(searchParams.get("offset"), {
+      name: "offset",
+      defaultValue: 0,
+      min: 0,
+    });
+    if (!offsetResult.ok) {
+      return NextResponse.json({ error: offsetResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
+    const offset = offsetResult.value;
     const cursor = searchParams.get("cursor")?.trim() || null;
     const full =
       searchParams.get("full") === "1" ||

--- a/apps/web/src/app/api/admin/trr-api/shows/[showId]/cast/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/[showId]/cast/route.ts
@@ -16,6 +16,7 @@ import {
   TRR_SHOW_CAST_CACHE_NAMESPACE,
   TRR_SHOW_CAST_CACHE_TTL_MS,
 } from "@/lib/server/trr-api/trr-show-read-route-cache";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 
 export const dynamic = "force-dynamic";
 
@@ -47,8 +48,25 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json(cached, { headers: { "x-trr-cache": "hit" } });
     }
 
-    const limit = parseInt(searchParams.get("limit") ?? "20", 10);
-    const offset = parseInt(searchParams.get("offset") ?? "0", 10);
+    const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: 20,
+      min: 1,
+      max: 500,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const offsetResult = parseBoundedIntegerParam(searchParams.get("offset"), {
+      name: "offset",
+      defaultValue: 0,
+      min: 0,
+    });
+    if (!offsetResult.ok) {
+      return NextResponse.json({ error: offsetResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
+    const offset = offsetResult.value;
     const minEpisodes = searchParams.get("minEpisodes");
     const excludeZeroEpisodeMembers =
       String(searchParams.get("exclude_zero_episode_members") ?? "").trim().toLowerCase() === "1" ||

--- a/apps/web/src/app/api/admin/trr-api/shows/[showId]/cast/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/[showId]/cast/route.ts
@@ -42,12 +42,6 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     const { searchParams } = new URL(request.url);
-    const cacheKey = buildUserScopedRouteCacheKey(user.uid, `${showId}:cast`, request.nextUrl.searchParams);
-    const cached = getRouteResponseCache<Record<string, unknown>>(TRR_SHOW_CAST_CACHE_NAMESPACE, cacheKey);
-    if (cached) {
-      return NextResponse.json(cached, { headers: { "x-trr-cache": "hit" } });
-    }
-
     const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
       name: "limit",
       defaultValue: 20,
@@ -83,25 +77,30 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const photoFallbackMode = parsePhotoFallbackMode(searchParams.get("photo_fallback"));
     const eligibilityModeRaw = String(searchParams.get("eligibility_mode") ?? "").trim().toLowerCase();
     const eligibilityMode: CastEligibilityMode = eligibilityModeRaw === "links" ? "links" : "default";
+    const upstreamParams = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+      roster_mode: rosterMode,
+      photo_fallback: photoFallbackMode,
+    });
+    if (typeof minEpisodes === "string" && minEpisodes.trim().length > 0) {
+      upstreamParams.set("minEpisodes", minEpisodes.trim());
+    }
+    if (excludeZeroEpisodeMembers) upstreamParams.set("exclude_zero_episode_members", "true");
+    if (requireImage === "true" || requireImage === "1") upstreamParams.set("requireImage", "true");
+    if (!includePhotos) upstreamParams.set("include_photos", "false");
+    if (eligibilityMode === "links") upstreamParams.set("eligibility_mode", "links");
+
+    const cacheKey = buildUserScopedRouteCacheKey(user.uid, `${showId}:cast`, upstreamParams);
+    const cached = getRouteResponseCache<Record<string, unknown>>(TRR_SHOW_CAST_CACHE_NAMESPACE, cacheKey);
+    if (cached) {
+      return NextResponse.json(cached, { headers: { "x-trr-cache": "hit" } });
+    }
 
     const payload = await getOrCreateRouteResponsePromise(
       TRR_SHOW_CAST_CACHE_NAMESPACE,
       cacheKey,
       async () => {
-        const upstreamParams = new URLSearchParams({
-          limit: String(limit),
-          offset: String(offset),
-          roster_mode: rosterMode,
-          photo_fallback: photoFallbackMode,
-        });
-        if (typeof minEpisodes === "string" && minEpisodes.trim().length > 0) {
-          upstreamParams.set("minEpisodes", minEpisodes.trim());
-        }
-        if (excludeZeroEpisodeMembers) upstreamParams.set("exclude_zero_episode_members", "true");
-        if (requireImage === "true" || requireImage === "1") upstreamParams.set("requireImage", "true");
-        if (!includePhotos) upstreamParams.set("include_photos", "false");
-        if (eligibilityMode === "links") upstreamParams.set("eligibility_mode", "links");
-
         const upstream = await fetchAdminBackendJson(
           `/admin/trr-api/shows/${showId}/cast?${upstreamParams.toString()}`,
           {

--- a/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/assets/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/assets/route.ts
@@ -17,6 +17,7 @@ import {
   TRR_SEASON_ASSETS_CACHE_NAMESPACE,
   TRR_SEASON_ASSETS_CACHE_TTL_MS,
 } from "@/lib/server/trr-api/trr-show-read-route-cache";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 
 export const dynamic = "force-dynamic";
 const DEFAULT_VISIBLE_ASSET_LIMIT = 48;
@@ -54,10 +55,25 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     const { searchParams } = new URL(request.url);
-    const parsedLimit = parseInt(searchParams.get("limit") ?? String(DEFAULT_VISIBLE_ASSET_LIMIT), 10);
-    const parsedOffset = parseInt(searchParams.get("offset") ?? "0", 10);
-    const limit = Number.isFinite(parsedLimit) ? parsedLimit : DEFAULT_VISIBLE_ASSET_LIMIT;
-    const offset = Number.isFinite(parsedOffset) ? parsedOffset : 0;
+    const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: DEFAULT_VISIBLE_ASSET_LIMIT,
+      min: 1,
+      max: FULL_FETCH_LIMIT,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const offsetResult = parseBoundedIntegerParam(searchParams.get("offset"), {
+      name: "offset",
+      defaultValue: 0,
+      min: 0,
+    });
+    if (!offsetResult.ok) {
+      return NextResponse.json({ error: offsetResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
+    const offset = offsetResult.value;
     const cursor = searchParams.get("cursor")?.trim() || null;
     const full =
       searchParams.get("full") === "1" ||

--- a/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/cast/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/cast/route.ts
@@ -15,6 +15,7 @@ import {
   TRR_SEASON_CAST_CACHE_NAMESPACE,
   TRR_SEASON_CAST_CACHE_TTL_MS,
 } from "@/lib/server/trr-api/trr-show-read-route-cache";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 
 export const dynamic = "force-dynamic";
 
@@ -40,10 +41,25 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     const { searchParams } = new URL(request.url);
-    const limitParam = parseInt(searchParams.get("limit") ?? "500", 10);
-    const offsetParam = parseInt(searchParams.get("offset") ?? "0", 10);
-    const limit = Number.isFinite(limitParam) ? Math.min(limitParam, 500) : 500;
-    const offset = Number.isFinite(offsetParam) ? Math.max(offsetParam, 0) : 0;
+    const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: 500,
+      min: 1,
+      max: 500,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const offsetResult = parseBoundedIntegerParam(searchParams.get("offset"), {
+      name: "offset",
+      defaultValue: 0,
+      min: 0,
+    });
+    if (!offsetResult.ok) {
+      return NextResponse.json({ error: offsetResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
+    const offset = offsetResult.value;
     const includeArchiveOnly = (searchParams.get("include_archive_only") ?? "").toLowerCase() === "true";
     const photoFallbackMode = parsePhotoFallbackMode(searchParams.get("photo_fallback"));
 

--- a/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/cast/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/cast/route.ts
@@ -62,11 +62,19 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const offset = offsetResult.value;
     const includeArchiveOnly = (searchParams.get("include_archive_only") ?? "").toLowerCase() === "true";
     const photoFallbackMode = parsePhotoFallbackMode(searchParams.get("photo_fallback"));
+    const upstreamParams = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+      photo_fallback: photoFallbackMode,
+    });
+    if (includeArchiveOnly) {
+      upstreamParams.set("include_archive_only", "true");
+    }
 
     const cacheKey = buildUserScopedRouteCacheKey(
       user.uid,
       `season-cast:${showId}:${seasonNum}`,
-      request.nextUrl.searchParams,
+      upstreamParams,
     );
     const cached = getRouteResponseCache<Record<string, unknown>>(TRR_SEASON_CAST_CACHE_NAMESPACE, cacheKey);
     if (cached) {
@@ -77,14 +85,6 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       TRR_SEASON_CAST_CACHE_NAMESPACE,
       cacheKey,
       async () => {
-        const upstreamParams = new URLSearchParams({
-          limit: String(limit),
-          offset: String(offset),
-          photo_fallback: photoFallbackMode,
-        });
-        if (includeArchiveOnly) {
-          upstreamParams.set("include_archive_only", "true");
-        }
         const upstream = await fetchAdminBackendJson(
           `/admin/trr-api/shows/${showId}/seasons/${seasonNum}/cast?${upstreamParams.toString()}`,
           {

--- a/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/route.ts
@@ -15,6 +15,7 @@ import {
   TRR_SHOW_SEASONS_CACHE_NAMESPACE,
   TRR_SHOW_SEASONS_CACHE_TTL_MS,
 } from "@/lib/server/trr-api/trr-show-read-route-cache";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 import { getSeasonsByShowId } from "@/lib/server/trr-api/trr-shows-repository";
 
 export const dynamic = "force-dynamic";
@@ -73,8 +74,25 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     const { searchParams } = new URL(request.url);
-    const limit = parseInt(searchParams.get("limit") ?? "20", 10);
-    const offset = parseInt(searchParams.get("offset") ?? "0", 10);
+    const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: 20,
+      min: 1,
+      max: 100,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const offsetResult = parseBoundedIntegerParam(searchParams.get("offset"), {
+      name: "offset",
+      defaultValue: 0,
+      min: 0,
+    });
+    if (!offsetResult.ok) {
+      return NextResponse.json({ error: offsetResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
+    const offset = offsetResult.value;
     const includeEpisodeSignal = parseBoolean(searchParams.get("include_episode_signal"));
 
     const cacheKey = buildUserScopedRouteCacheKey(

--- a/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/route.ts
@@ -57,7 +57,7 @@ const buildLocalSeasonsPayload = async (
  * Ordered by season_number DESC (newest first).
  *
  * Query params:
- * - limit: max results (default 20, max 100)
+ * - limit: max results (default 20, max 500)
  * - offset: pagination offset (default 0)
  */
 export async function GET(request: NextRequest, { params }: RouteParams) {
@@ -78,7 +78,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       name: "limit",
       defaultValue: 20,
       min: 1,
-      max: 100,
+      max: 500,
     });
     if (!limitResult.ok) {
       return NextResponse.json({ error: limitResult.error }, { status: 400 });
@@ -94,11 +94,18 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const limit = limitResult.value;
     const offset = offsetResult.value;
     const includeEpisodeSignal = parseBoolean(searchParams.get("include_episode_signal"));
+    const upstreamParams = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+    });
+    if (includeEpisodeSignal) {
+      upstreamParams.set("include_episode_signal", "true");
+    }
 
     const cacheKey = buildUserScopedRouteCacheKey(
       user.uid,
       `${showId}:list`,
-      request.nextUrl.searchParams,
+      upstreamParams,
     );
     const cached = getRouteResponseCache<Record<string, unknown>>(TRR_SHOW_SEASONS_CACHE_NAMESPACE, cacheKey);
     if (cached) {
@@ -109,13 +116,6 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       TRR_SHOW_SEASONS_CACHE_NAMESPACE,
       cacheKey,
       async () => {
-        const upstreamParams = new URLSearchParams({
-          limit: String(limit),
-          offset: String(offset),
-        });
-        if (includeEpisodeSignal) {
-          upstreamParams.set("include_episode_signal", "true");
-        }
         try {
           const upstream = await fetchAdminBackendJson(
             `/admin/trr-api/shows/${showId}/seasons?${upstreamParams.toString()}`,

--- a/apps/web/src/app/api/admin/trr-api/shows/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/route.ts
@@ -15,6 +15,7 @@ import {
   TRR_SHOWS_CACHE_NAMESPACE,
   TRR_SHOWS_CACHE_TTL_MS,
 } from "@/lib/server/trr-api/trr-show-read-route-cache";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 
 export const dynamic = "force-dynamic";
 
@@ -34,8 +35,25 @@ export async function GET(request: NextRequest) {
 
     const { searchParams } = new URL(request.url);
     const query = searchParams.get("q") ?? "";
-    const limit = parseInt(searchParams.get("limit") ?? "20", 10);
-    const offset = parseInt(searchParams.get("offset") ?? "0", 10);
+    const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: 20,
+      min: 1,
+      max: 100,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const offsetResult = parseBoundedIntegerParam(searchParams.get("offset"), {
+      name: "offset",
+      defaultValue: 0,
+      min: 0,
+    });
+    if (!offsetResult.ok) {
+      return NextResponse.json({ error: offsetResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
+    const offset = offsetResult.value;
 
     if (!query.trim()) {
       return NextResponse.json(

--- a/apps/web/src/app/api/admin/trr-api/shows/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/route.ts
@@ -62,7 +62,12 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const cacheKey = buildUserScopedRouteCacheKey(user.uid, "shows", searchParams);
+    const upstreamParams = new URLSearchParams({
+      q: query,
+      limit: String(limit),
+      offset: String(offset),
+    });
+    const cacheKey = buildUserScopedRouteCacheKey(user.uid, "shows", upstreamParams);
     const cached = getRouteResponseCache<Record<string, unknown>>(TRR_SHOWS_CACHE_NAMESPACE, cacheKey);
     if (cached) {
       return NextResponse.json(cached, { headers: { "x-trr-cache": "hit" } });
@@ -73,11 +78,7 @@ export async function GET(request: NextRequest) {
       cacheKey,
       async () => {
         const upstream = await fetchAdminBackendJson(
-          `/admin/trr-api/shows?${new URLSearchParams({
-            q: query,
-            limit: String(limit),
-            offset: String(offset),
-          }).toString()}`,
+          `/admin/trr-api/shows?${upstreamParams.toString()}`,
           {
             timeoutMs: ADMIN_READ_PROXY_SHORT_TIMEOUT_MS,
             routeName: "admin-shows",

--- a/apps/web/src/lib/admin/admin-navigation.ts
+++ b/apps/web/src/lib/admin/admin-navigation.ts
@@ -40,7 +40,14 @@ export const ADMIN_NAV_ITEMS: readonly AdminNavItem[] = [
     description:
       "Canonical TRR-APP admin entry for screen-time workflows. Pick a show here, then continue into its /<show> workspace.",
     badge: "Screen",
-    activeMatchPrefixes: ["/screenalytics", "/screenlaytics", "/admin/screenalytics", "/admin/screenlaytics", "/admin/trr-shows"],
+    activeMatchPrefixes: [
+      "/screenalytics",
+      "/screenlaytics",
+      "/admin/screenalytics",
+      "/admin/screenlaytics",
+      "/admin/cast-screentime",
+      "/admin/trr-shows",
+    ],
   },
   {
     key: "cast-reference-review",

--- a/apps/web/src/lib/admin/api-references/generated/inventory.ts
+++ b/apps/web/src/lib/admin/api-references/generated/inventory.ts
@@ -3,8 +3,8 @@ import type { AdminApiReferenceInventory } from "@/lib/admin/api-references/type
 export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
   "inventorySchemaVersion": "1.0.0",
   "generatorVersion": "1.0.0",
-  "generatedAt": "2026-07-13T21:51:22.814Z",
-  "sourceCommitSha": "8cb8ada50ff8b01db41d596ff10a22cbb90bf52b",
+  "generatedAt": "2026-07-13T21:52:10.426Z",
+  "sourceCommitSha": "33a9d40cd3eaa0d4f179ebe01d7cbd1b9ed816e3",
   "overrideDigest": "cd85a76fd2fc977cbc691ccab80ce844f9ea783e118af35eb3d9766e5d61fd36",
   "nodes": [
     {
@@ -10255,7 +10255,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/people/route.ts",
       "sourceLocator": {
-        "line": 20,
+        "line": 21,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -10358,7 +10358,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/people/[personId]/credits/route.ts",
       "sourceLocator": {
-        "line": 329,
+        "line": 330,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -10460,7 +10460,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/people/[personId]/photos/route.ts",
       "sourceLocator": {
-        "line": 39,
+        "line": 40,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -10529,7 +10529,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/people/home/route.ts",
       "sourceLocator": {
-        "line": 29,
+        "line": 25,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -10597,7 +10597,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/search/route.ts",
       "sourceLocator": {
-        "line": 30,
+        "line": 26,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -10631,7 +10631,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/seasons/[seasonId]/episodes/route.ts",
       "sourceLocator": {
-        "line": 25,
+        "line": 26,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -10698,7 +10698,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/shows/route.ts",
       "sourceLocator": {
-        "line": 31,
+        "line": 32,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -10766,7 +10766,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/shows/[showId]/assets/route.ts",
       "sourceLocator": {
-        "line": 34,
+        "line": 35,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -10870,7 +10870,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/shows/[showId]/cast/route.ts",
       "sourceLocator": {
-        "line": 32,
+        "line": 33,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -11109,7 +11109,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/shows/[showId]/seasons/route.ts",
       "sourceLocator": {
-        "line": 62,
+        "line": 63,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -11143,7 +11143,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/assets/route.ts",
       "sourceLocator": {
-        "line": 34,
+        "line": 35,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -11178,7 +11178,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/cast/route.ts",
       "sourceLocator": {
-        "line": 28,
+        "line": 29,
         "symbol": "GET"
       },
       "provenance": "static_scan",

--- a/apps/web/src/lib/admin/screenalytics-routes.ts
+++ b/apps/web/src/lib/admin/screenalytics-routes.ts
@@ -1,4 +1,5 @@
-export const SCREENALYTICS_ADMIN_ORIGIN = "https://admin.trr.localhost";
+import { PORTLESS_ADMIN_ORIGIN } from "@/lib/admin/admin-url-defaults";
+
 export const SCREENALYTICS_CANONICAL_PATH = "/screenalytics";
 export const SCREENALYTICS_INTERNAL_CAST_SCREENTIME_PATH = "/admin/cast-screentime";
 export const SCREENALYTICS_RHOBH_S5_E16_TEST_PATH =
@@ -33,7 +34,7 @@ export function buildScreenalyticsRunPath(runId: string): string {
 }
 
 export function buildScreenalyticsRunUrl(runId: string): string {
-  return new URL(buildScreenalyticsRunPath(runId), SCREENALYTICS_ADMIN_ORIGIN).toString();
+  return new URL(buildScreenalyticsRunPath(runId), PORTLESS_ADMIN_ORIGIN).toString();
 }
 
 export function isScreenalyticsRhobhS5E16TestPath(pathname: string | null): boolean {

--- a/apps/web/src/lib/admin/screenalytics-routes.ts
+++ b/apps/web/src/lib/admin/screenalytics-routes.ts
@@ -1,0 +1,74 @@
+export const SCREENALYTICS_ADMIN_ORIGIN = "https://admin.trr.localhost";
+export const SCREENALYTICS_CANONICAL_PATH = "/screenalytics";
+export const SCREENALYTICS_INTERNAL_CAST_SCREENTIME_PATH = "/admin/cast-screentime";
+export const SCREENALYTICS_RHOBH_S5_E16_TEST_PATH =
+  "/screenalytics/rhobh/s5/e16/extras/screenalytics-test";
+export const SCREENALYTICS_RHOBH_S5_E16_TEST_SEASON_ID =
+  "98ac397a-3928-4583-92bc-25ea84c42d89";
+
+export const SCREENALYTICS_RHOBH_S5_E16_TEST_DEFAULTS = {
+  owner_scope: "episode",
+  owner_id: "4eb4ceb4-c13d-4c29-bd0f-8bcde94b6591",
+  show_id: "909ddc36-ca4d-4b09-8aa5-dd5dd34f987e",
+  media_type: "extras",
+  media_kind: "screenalytics_test",
+  prefill_context: "screenalytics_test_extra",
+} as const;
+
+export const SCREENALYTICS_LEGACY_QUERY_KEYS = [
+  "run",
+  "run_id",
+  "owner_scope",
+  "owner_id",
+  "show_id",
+  "media_type",
+  "video_class",
+  "media_kind",
+  "promo_subtype",
+  "prefill_context",
+] as const;
+
+export function buildScreenalyticsRunPath(runId: string): string {
+  return `${SCREENALYTICS_CANONICAL_PATH}/runs/${encodeURIComponent(runId)}`;
+}
+
+export function buildScreenalyticsRunUrl(runId: string): string {
+  return new URL(buildScreenalyticsRunPath(runId), SCREENALYTICS_ADMIN_ORIGIN).toString();
+}
+
+export function isScreenalyticsRhobhS5E16TestPath(pathname: string | null): boolean {
+  return (pathname || "").toLowerCase() === SCREENALYTICS_RHOBH_S5_E16_TEST_PATH;
+}
+
+export function appendScreenalyticsRhobhS5E16TestDefaults(searchParams?: URLSearchParams): URLSearchParams {
+  const params = new URLSearchParams(searchParams?.toString() ?? "");
+  Object.entries(SCREENALYTICS_RHOBH_S5_E16_TEST_DEFAULTS).forEach(([key, value]) => {
+    params.set(key, value);
+  });
+  return params;
+}
+
+export function removeScreenalyticsLegacySearchParams(searchParams?: URLSearchParams): URLSearchParams {
+  const params = new URLSearchParams(searchParams?.toString() ?? "");
+  SCREENALYTICS_LEGACY_QUERY_KEYS.forEach((key) => params.delete(key));
+  return params;
+}
+
+export function hasScreenalyticsRhobhS5E16TestSearch(searchParams?: URLSearchParams): boolean {
+  if (!searchParams) return false;
+  const ownerScope = searchParams.get("owner_scope");
+  const ownerId = searchParams.get("owner_id");
+  const ownsTestExtra =
+    (ownerScope === SCREENALYTICS_RHOBH_S5_E16_TEST_DEFAULTS.owner_scope &&
+      ownerId === SCREENALYTICS_RHOBH_S5_E16_TEST_DEFAULTS.owner_id) ||
+    (ownerScope === "season" && ownerId === SCREENALYTICS_RHOBH_S5_E16_TEST_SEASON_ID);
+
+  return (
+    ownsTestExtra &&
+    searchParams.get("show_id") === SCREENALYTICS_RHOBH_S5_E16_TEST_DEFAULTS.show_id &&
+    (searchParams.get("media_type") === SCREENALYTICS_RHOBH_S5_E16_TEST_DEFAULTS.media_type ||
+      searchParams.get("video_class") === SCREENALYTICS_RHOBH_S5_E16_TEST_DEFAULTS.media_type) &&
+    (searchParams.get("media_kind") === SCREENALYTICS_RHOBH_S5_E16_TEST_DEFAULTS.media_kind ||
+      searchParams.get("promo_subtype") === SCREENALYTICS_RHOBH_S5_E16_TEST_DEFAULTS.media_kind)
+  );
+}

--- a/apps/web/src/lib/server/trr-api/query-integer-params.ts
+++ b/apps/web/src/lib/server/trr-api/query-integer-params.ts
@@ -1,0 +1,37 @@
+export type BoundedIntegerParamOptions = {
+  name: string;
+  defaultValue: number;
+  min?: number;
+  max?: number;
+};
+
+export type BoundedIntegerParamResult =
+  | { ok: true; value: number }
+  | { ok: false; error: string };
+
+const INTEGER_RE = /^[+-]?\d+$/;
+
+export function parseBoundedIntegerParam(
+  rawValue: string | null,
+  options: BoundedIntegerParamOptions,
+): BoundedIntegerParamResult {
+  const { name, defaultValue, min, max } = options;
+  if (rawValue === null) {
+    return { ok: true, value: defaultValue };
+  }
+
+  const trimmed = rawValue.trim();
+  if (!INTEGER_RE.test(trimmed)) {
+    return { ok: false, error: `${name} must be an integer` };
+  }
+
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed)) {
+    return { ok: false, error: `${name} must be a safe integer` };
+  }
+
+  let value = parsed;
+  if (typeof min === "number") value = Math.max(value, min);
+  if (typeof max === "number") value = Math.min(value, max);
+  return { ok: true, value };
+}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -19,6 +19,15 @@ import {
   resolveAdminOriginFromRequest,
 } from "@/lib/admin/admin-url-defaults";
 import { toFriendlyBrandSlug } from "@/lib/admin/brand-profile";
+import {
+  appendScreenalyticsRhobhS5E16TestDefaults,
+  buildScreenalyticsRunPath,
+  hasScreenalyticsRhobhS5E16TestSearch,
+  removeScreenalyticsLegacySearchParams,
+  SCREENALYTICS_CANONICAL_PATH,
+  SCREENALYTICS_INTERNAL_CAST_SCREENTIME_PATH,
+  SCREENALYTICS_RHOBH_S5_E16_TEST_PATH,
+} from "@/lib/admin/screenalytics-routes";
 
 const DEFAULT_DEV_ADMIN_API_HOSTS = ["admin.localhost", "localhost", "127.0.0.1", "[::1]", "::1"];
 const STATIC_PATH_PREFIXES = ["/_next", "/favicon.ico", "/robots.txt", "/sitemap.xml"];
@@ -26,7 +35,6 @@ const INTERNAL_ADMIN_REWRITE_HEADER = "x-trr-admin-rewrite";
 const CANONICAL_SOCIAL_PATH = "/social";
 const CANONICAL_API_REFERENCES_PATH = "/api-references";
 const CANONICAL_DEV_DASHBOARD_PATH = "/dev-dashboard";
-const CAST_SCREENTIME_ADMIN_PATH = "/admin/cast-screentime";
 const ROOT_SHOW_ROUTE_RESERVED_FIRST_SEGMENTS = new Set([
   "admin",
   "api",
@@ -45,6 +53,8 @@ const ROOT_SHOW_ROUTE_RESERVED_FIRST_SEGMENTS = new Set([
   "profile",
   "realations",
   "realitease",
+  "screenalytics",
+  "screenlaytics",
   "settings",
   "social",
   "social-media",
@@ -145,7 +155,7 @@ const ROOT_ONLY_ADMIN_SECTION_CANONICAL_PATHS = new Map<string, string>([
   ["people", "/people"],
   ["games", "/games"],
   ["screenalytics", "/screenalytics"],
-  ["screenlaytics", "/screenlaytics"],
+  ["screenlaytics", "/screenalytics"],
   ["surveys", "/surveys"],
   ["settings", "/settings"],
   ["users", "/users"],
@@ -166,10 +176,10 @@ const CANONICAL_ADMIN_REWRITE_PREFIXES = [
   [CANONICAL_DEV_DASHBOARD_PATH, ADMIN_DEV_DASHBOARD_PATH],
 ] as const;
 const LEGACY_SCREENALYTICS_ROUTE_PREFIXES = [
-  "/screenalytics",
   "/screenlaytics",
   "/admin/screenalytics",
   "/admin/screenlaytics",
+  "/admin/cast-screentime",
 ] as const;
 
 function parseOptionalBoolean(value: string | undefined): boolean | null {
@@ -298,12 +308,78 @@ function remapPathPrefix(pathname: string, fromPrefix: string, toPrefix: string)
   return `${toPrefix}${pathname.slice(fromPrefix.length)}`;
 }
 
-function mapLegacyScreenalyticsRoute(pathname: string, searchParams?: URLSearchParams): string | null {
-  for (const legacyPrefix of LEGACY_SCREENALYTICS_ROUTE_PREFIXES) {
-    if (remapPathPrefix(pathname, legacyPrefix, CAST_SCREENTIME_ADMIN_PATH)) {
-      return appendSearch(CAST_SCREENTIME_ADMIN_PATH, searchParams);
+function getScreenalyticsRunIdFromPath(pathname: string): string | null {
+  const segments = toPathSegments(pathname);
+  if (segments.length !== 3) return null;
+  if ((segments[0] ?? "").toLowerCase() !== "screenalytics") return null;
+  if ((segments[1] ?? "").toLowerCase() !== "runs") return null;
+  const runId = segments[2]?.trim();
+  return runId || null;
+}
+
+function getScreenalyticsRunIdFromSearch(searchParams?: URLSearchParams): string | null {
+  const runId = searchParams?.get("run_id") || searchParams?.get("run");
+  return runId?.trim() || null;
+}
+
+function mapScreenalyticsCanonicalRedirect(pathname: string, searchParams?: URLSearchParams): string | null {
+  if (pathname === SCREENALYTICS_CANONICAL_PATH) {
+    const runId = getScreenalyticsRunIdFromSearch(searchParams);
+    if (runId) {
+      return appendSearch(
+        buildScreenalyticsRunPath(runId),
+        removeScreenalyticsLegacySearchParams(searchParams),
+      );
+    }
+    if (hasScreenalyticsRhobhS5E16TestSearch(searchParams)) {
+      return appendSearch(SCREENALYTICS_RHOBH_S5_E16_TEST_PATH, removeScreenalyticsLegacySearchParams(searchParams));
     }
   }
+
+  for (const legacyPrefix of LEGACY_SCREENALYTICS_ROUTE_PREFIXES) {
+    const remapped = remapPathPrefix(pathname, legacyPrefix, SCREENALYTICS_CANONICAL_PATH);
+    if (!remapped) continue;
+
+    const runId = getScreenalyticsRunIdFromSearch(searchParams);
+    if (remapped === SCREENALYTICS_CANONICAL_PATH && runId) {
+      return appendSearch(
+        buildScreenalyticsRunPath(runId),
+        removeScreenalyticsLegacySearchParams(searchParams),
+      );
+    }
+    if (remapped === SCREENALYTICS_CANONICAL_PATH && hasScreenalyticsRhobhS5E16TestSearch(searchParams)) {
+      return appendSearch(SCREENALYTICS_RHOBH_S5_E16_TEST_PATH, removeScreenalyticsLegacySearchParams(searchParams));
+    }
+
+    return appendSearch(remapped, searchParams);
+  }
+  return null;
+}
+
+function mapScreenalyticsInternalRewrite(pathname: string, searchParams?: URLSearchParams): string | null {
+  if (pathname === SCREENALYTICS_RHOBH_S5_E16_TEST_PATH) {
+    return appendSearch(
+      SCREENALYTICS_INTERNAL_CAST_SCREENTIME_PATH,
+      appendScreenalyticsRhobhS5E16TestDefaults(searchParams),
+    );
+  }
+
+  const runId = getScreenalyticsRunIdFromPath(pathname);
+  if (runId) {
+    const params = new URLSearchParams(searchParams?.toString() ?? "");
+    params.set("run_id", runId);
+    params.delete("run");
+    return appendSearch(SCREENALYTICS_INTERNAL_CAST_SCREENTIME_PATH, params);
+  }
+
+  if (pathname === SCREENALYTICS_CANONICAL_PATH) {
+    return appendSearch(SCREENALYTICS_INTERNAL_CAST_SCREENTIME_PATH, searchParams);
+  }
+
+  if (pathname.startsWith(`${SCREENALYTICS_CANONICAL_PATH}/`)) {
+    return appendSearch(SCREENALYTICS_INTERNAL_CAST_SCREENTIME_PATH, searchParams);
+  }
+
   return null;
 }
 
@@ -536,6 +612,8 @@ function isCanonicalShortAdminPath(pathname: string): boolean {
   return (
     pathname === "/" ||
     pathname === "/shows" ||
+    pathname === "/screenalytics" ||
+    pathname.startsWith("/screenalytics/") ||
     pathname === "/social" ||
     pathname.startsWith("/social/") ||
     pathname === "/design-docs" ||
@@ -742,10 +820,15 @@ function mapCanonicalAdminUiRedirect(pathname: string, searchParams?: URLSearchP
   );
 }
 
-function mapCanonicalAdminUiRewrite(pathname: string): string | null {
+function mapCanonicalAdminUiRewrite(pathname: string, searchParams?: URLSearchParams): string | null {
   const legacyAdminSocialPath = mapLegacyAdminSocialPath(pathname);
   if (legacyAdminSocialPath) {
     return stripSearch(legacyAdminSocialPath);
+  }
+
+  const screenalyticsInternalRewrite = mapScreenalyticsInternalRewrite(pathname, searchParams);
+  if (screenalyticsInternalRewrite) {
+    return screenalyticsInternalRewrite;
   }
 
   if (pathname === "/") {
@@ -1036,15 +1119,18 @@ export function proxy(request: NextRequest): NextResponse {
   const requestHost = normalizeAdminHost(getForwardedRequestHost(request)) ?? normalizeAdminHost(request.nextUrl.hostname);
   const onCanonicalAdminHost = hostsMatch(canonicalAdminHost, requestHost);
   const isInternalAdminRewrite = request.headers.get(INTERNAL_ADMIN_REWRITE_HEADER) === "1";
-  const legacyScreenalyticsPath = mapLegacyScreenalyticsRoute(pathname, request.nextUrl.searchParams);
+  const screenalyticsCanonicalPath = isInternalAdminRewrite
+    ? null
+    : mapScreenalyticsCanonicalRedirect(pathname, request.nextUrl.searchParams);
   const legacyBrandsPath = mapLegacyBrandsPath(pathname, request.nextUrl.searchParams);
 
-  if (legacyScreenalyticsPath) {
-    const redirectOrigin = onCanonicalAdminHost ? request.nextUrl.origin : adminOrigin;
+  if (screenalyticsCanonicalPath) {
+    const requestUrlHost = normalizeAdminHost(request.nextUrl.hostname);
+    const redirectOrigin = onCanonicalAdminHost && requestHost === requestUrlHost ? request.nextUrl.origin : adminOrigin;
     if (!redirectOrigin) {
       return NextResponse.json({ error: "Admin origin is not configured." }, { status: 403 });
     }
-    return NextResponse.redirect(new URL(legacyScreenalyticsPath, redirectOrigin), 307);
+    return NextResponse.redirect(new URL(screenalyticsCanonicalPath, redirectOrigin), 307);
   }
 
   if (legacyBrandsPath) {
@@ -1102,7 +1188,7 @@ export function proxy(request: NextRequest): NextResponse {
       }
     }
 
-    const rewritePath = mapCanonicalAdminUiRewrite(pathname);
+    const rewritePath = mapCanonicalAdminUiRewrite(pathname, request.nextUrl.searchParams);
     if (rewritePath) {
       const targetUrl = buildInternalRewriteUrl(request, rewritePath);
       request.nextUrl.searchParams.forEach((value, key) => {

--- a/apps/web/tests/admin-global-header.test.tsx
+++ b/apps/web/tests/admin-global-header.test.tsx
@@ -75,6 +75,17 @@ describe("AdminGlobalHeader", () => {
     expect(screen.getByRole("link", { name: "View All Shows" })).toHaveAttribute("href", "/admin/shows");
   });
 
+  it("marks Screenalytics active for the hidden cast screen-time implementation route", async () => {
+    usePathnameMock.mockReturnValue("/admin/cast-screentime");
+
+    render(<AdminGlobalHeader />);
+    fireEvent.click(screen.getByRole("button", { name: "Open admin navigation menu" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: "Screenalytics" })).toHaveAttribute("aria-current", "page");
+    });
+  });
+
   it("renders recent shows from storage and limits to five", async () => {
     window.localStorage.setItem(
       ADMIN_RECENT_SHOWS_STORAGE_KEY,

--- a/apps/web/tests/admin-global-search-route.test.ts
+++ b/apps/web/tests/admin-global-search-route.test.ts
@@ -90,4 +90,15 @@ describe("/api/admin/trr-api/search", () => {
       show_slug: "the-traitors-us",
     });
   });
+
+  it("rejects malformed explicit limits before proxying", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/trr-api/search?q=ala&limit=abc"),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("limit must be an integer");
+    expect(fetchAdminBackendJsonMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/tests/admin-host-middleware.test.ts
+++ b/apps/web/tests/admin-host-middleware.test.ts
@@ -331,34 +331,122 @@ describe("admin host proxy", () => {
   });
 
   it.each([
-    ["/screenalytics", "http://admin.localhost:3000/admin/cast-screentime"],
-    ["/screenlaytics", "http://admin.localhost:3000/admin/cast-screentime"],
-    ["/admin/screenalytics", "http://admin.localhost:3000/admin/cast-screentime"],
-    ["/admin/screenlaytics", "http://admin.localhost:3000/admin/cast-screentime"],
-  ])("redirects retired Screenalytics alias %s to Cast Screen-Time", (pathname, expectedLocation) => {
-    process.env.ADMIN_APP_ORIGIN = "http://admin.localhost:3000";
+    ["/screenlaytics", "https://admin.trr.localhost/screenalytics"],
+    ["/admin/screenalytics", "https://admin.trr.localhost/screenalytics"],
+    ["/admin/screenlaytics", "https://admin.trr.localhost/screenalytics"],
+    ["/admin/cast-screentime", "https://admin.trr.localhost/screenalytics"],
+  ])("redirects legacy Screenalytics path %s to the canonical Screenalytics path", (pathname, expectedLocation) => {
+    process.env.ADMIN_APP_ORIGIN = "https://admin.trr.localhost";
+    process.env.ADMIN_APP_HOSTS = "admin.trr.localhost,trr.localhost,admin.localhost,localhost,127.0.0.1,[::1]";
     process.env.ADMIN_ENFORCE_HOST = "true";
     process.env.ADMIN_STRICT_HOST_ROUTING = "false";
 
-    const request = new NextRequest(`http://admin.localhost:3000${pathname}`);
+    const request = new NextRequest(`https://admin.trr.localhost${pathname}`);
     const response = proxy(request);
 
     expect(response.status).toBe(307);
     expect(response.headers.get("location")).toBe(expectedLocation);
   });
 
-  it("redirects retired Screenalytics aliases from the public host directly to the admin Cast Screen-Time route", () => {
-    process.env.ADMIN_APP_ORIGIN = "http://admin.localhost:3000";
+  it.each([
+    "http://localhost:3000/screenalytics?run=demo",
+    "http://localhost:3000/admin/cast-screentime?run=demo",
+  ])("canonicalizes %s to the Portless Screenalytics run URL", (url) => {
+    process.env.ADMIN_APP_ORIGIN = "https://admin.trr.localhost";
+    process.env.ADMIN_APP_HOSTS = "admin.trr.localhost,trr.localhost,admin.localhost,localhost,127.0.0.1,[::1]";
     process.env.ADMIN_ENFORCE_HOST = "true";
     process.env.ADMIN_STRICT_HOST_ROUTING = "false";
 
-    const request = new NextRequest("http://localhost:3000/screenalytics?run=demo");
+    const request = new NextRequest(url);
+    const response = proxy(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("https://admin.trr.localhost/screenalytics/runs/demo");
+  });
+
+  it("canonicalizes the RHOBH S5 E16 test extra setup query to the clean episode URL", () => {
+    process.env.ADMIN_APP_ORIGIN = "https://admin.trr.localhost";
+    process.env.ADMIN_APP_HOSTS = "admin.trr.localhost,trr.localhost,admin.localhost,localhost,127.0.0.1,[::1]";
+    process.env.ADMIN_ENFORCE_HOST = "true";
+    process.env.ADMIN_STRICT_HOST_ROUTING = "false";
+
+    const query = new URLSearchParams({
+      owner_scope: "season",
+      owner_id: "98ac397a-3928-4583-92bc-25ea84c42d89",
+      media_type: "extras",
+      media_kind: "screenalytics_test",
+      media_type_filter: "extras",
+      show_id: "909ddc36-ca4d-4b09-8aa5-dd5dd34f987e",
+    });
+    const request = new NextRequest(`http://localhost:3000/admin/cast-screentime?${query.toString()}`);
     const response = proxy(request);
 
     expect(response.status).toBe(307);
     expect(response.headers.get("location")).toBe(
-      "http://admin.localhost:3000/admin/cast-screentime?run=demo",
+      "https://admin.trr.localhost/screenalytics/rhobh/s5/e16/extras/screenalytics-test?media_type_filter=extras",
     );
+  });
+
+  it("rewrites canonical Screenalytics run URLs to the internal implementation while keeping the clean URL visible", () => {
+    process.env.NODE_ENV = "development";
+    process.env.ADMIN_APP_ORIGIN = "https://admin.trr.localhost";
+    process.env.ADMIN_APP_HOSTS = "admin.trr.localhost,trr.localhost,admin.localhost,localhost,127.0.0.1,[::1]";
+    process.env.ADMIN_ENFORCE_HOST = "true";
+    process.env.ADMIN_STRICT_HOST_ROUTING = "false";
+
+    const request = new NextRequest("https://localhost:3002/screenalytics/runs/demo?tab=review", {
+      headers: {
+        "x-forwarded-host": "admin.trr.localhost",
+      },
+    });
+    const response = proxy(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-middleware-rewrite")).toBe(
+      "http://localhost:3002/admin/cast-screentime?tab=review&run_id=demo",
+    );
+  });
+
+  it("rewrites the canonical Screenalytics RHOBH test-extra setup URL with its default context", () => {
+    process.env.NODE_ENV = "development";
+    process.env.ADMIN_APP_ORIGIN = "https://admin.trr.localhost";
+    process.env.ADMIN_APP_HOSTS = "admin.trr.localhost,trr.localhost,admin.localhost,localhost,127.0.0.1,[::1]";
+    process.env.ADMIN_ENFORCE_HOST = "true";
+    process.env.ADMIN_STRICT_HOST_ROUTING = "false";
+
+    const request = new NextRequest("https://localhost:3002/screenalytics/rhobh/s5/e16/extras/screenalytics-test", {
+      headers: {
+        "x-forwarded-host": "admin.trr.localhost",
+      },
+    });
+    const response = proxy(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-middleware-rewrite")).toBe(
+      "http://localhost:3002/admin/cast-screentime?owner_scope=episode&owner_id=4eb4ceb4-c13d-4c29-bd0f-8bcde94b6591&show_id=909ddc36-ca4d-4b09-8aa5-dd5dd34f987e&media_type=extras&media_kind=screenalytics_test&prefill_context=screenalytics_test_extra",
+    );
+  });
+
+  it("does not re-canonicalize the hidden Screenalytics implementation URL during an internal rewrite", () => {
+    process.env.NODE_ENV = "development";
+    process.env.ADMIN_APP_ORIGIN = "https://admin.trr.localhost";
+    process.env.ADMIN_APP_HOSTS = "admin.trr.localhost,trr.localhost,admin.localhost,localhost,127.0.0.1,[::1]";
+    process.env.ADMIN_ENFORCE_HOST = "true";
+    process.env.ADMIN_STRICT_HOST_ROUTING = "false";
+
+    const request = new NextRequest(
+      "http://localhost:3002/admin/cast-screentime?owner_scope=episode&owner_id=4eb4ceb4-c13d-4c29-bd0f-8bcde94b6591&show_id=909ddc36-ca4d-4b09-8aa5-dd5dd34f987e&media_type=extras&media_kind=screenalytics_test&prefill_context=screenalytics_test_extra",
+      {
+        headers: {
+          "x-forwarded-host": "admin.trr.localhost",
+          "x-trr-admin-rewrite": "1",
+        },
+      },
+    );
+    const response = proxy(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
   });
 
   it.each([

--- a/apps/web/tests/admin-people-route.test.ts
+++ b/apps/web/tests/admin-people-route.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { requireAdminMock, searchPeopleMock } = vi.hoisted(() => ({
+  requireAdminMock: vi.fn(),
+  searchPeopleMock: vi.fn(),
+}));
+
+vi.mock("@/lib/server/auth", () => ({
+  requireAdmin: requireAdminMock,
+}));
+
+vi.mock("@/lib/server/trr-api/trr-shows-repository", () => ({
+  searchPeople: searchPeopleMock,
+}));
+
+import { GET } from "@/app/api/admin/trr-api/people/route";
+
+describe("/api/admin/trr-api/people", () => {
+  beforeEach(() => {
+    requireAdminMock.mockReset();
+    searchPeopleMock.mockReset();
+    requireAdminMock.mockResolvedValue({ uid: "admin-user" });
+    searchPeopleMock.mockResolvedValue([]);
+  });
+
+  it("rejects malformed explicit limit values before searching", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/trr-api/people?q=al&limit=abc"),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("limit must be an integer");
+    expect(searchPeopleMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed explicit offset values before searching", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/trr-api/people?q=al&offset=abc"),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("offset must be an integer");
+    expect(searchPeopleMock).not.toHaveBeenCalled();
+  });
+
+  it("clamps valid out-of-range pagination values", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/trr-api/people?q=al&limit=999&offset=-4"),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(searchPeopleMock).toHaveBeenCalledWith("al", { limit: 20, offset: 0 });
+    expect(payload.pagination).toMatchObject({ limit: 20, offset: 0 });
+  });
+});

--- a/apps/web/tests/admin-route-cache-key-normalization.test.ts
+++ b/apps/web/tests/admin-route-cache-key-normalization.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const { fetchAdminBackendJsonMock, requireAdminMock, resolveAdminShowIdMock } = vi.hoisted(() => {
+  process.env.TRR_ADMIN_ROUTE_CACHE_DISABLED = "0";
+  return {
+    fetchAdminBackendJsonMock: vi.fn(),
+    requireAdminMock: vi.fn(),
+    resolveAdminShowIdMock: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/server/auth", () => ({ requireAdmin: requireAdminMock }));
+vi.mock("@/lib/server/admin/resolve-show-id", () => ({
+  resolveAdminShowId: resolveAdminShowIdMock,
+}));
+vi.mock("@/lib/server/trr-api/admin-read-proxy", () => ({
+  AdminReadProxyError: class AdminReadProxyError extends Error {},
+  ADMIN_READ_PROXY_GALLERY_TIMEOUT_MS: 8_000,
+  ADMIN_READ_PROXY_PRIMARY_TIMEOUT_MS: 20_000,
+  ADMIN_READ_PROXY_SHORT_TIMEOUT_MS: 5_000,
+  buildAdminProxyErrorResponse: (error: unknown) =>
+    NextResponse.json({ error: error instanceof Error ? error.message : "failed" }, { status: 500 }),
+  fetchAdminBackendJson: fetchAdminBackendJsonMock,
+}));
+vi.mock("@/lib/server/trr-api/trr-shows-repository", () => ({
+  getSeasonsByShowId: vi.fn(),
+}));
+
+import { GET as getPeopleHome } from "@/app/api/admin/trr-api/people/home/route";
+import { GET as getPersonPhotos } from "@/app/api/admin/trr-api/people/[personId]/photos/route";
+import { GET as getSearch } from "@/app/api/admin/trr-api/search/route";
+import { GET as getSeasonEpisodes } from "@/app/api/admin/trr-api/seasons/[seasonId]/episodes/route";
+import { GET as getShowCast } from "@/app/api/admin/trr-api/shows/[showId]/cast/route";
+import { GET as getSeasonCast } from "@/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/cast/route";
+import { GET as getShowSeasons } from "@/app/api/admin/trr-api/shows/[showId]/seasons/route";
+import { GET as getShows } from "@/app/api/admin/trr-api/shows/route";
+import { invalidateRouteResponseCache } from "@/lib/server/admin/route-response-cache";
+import {
+  TRR_PEOPLE_HOME_CACHE_NAMESPACE,
+  TRR_SEARCH_CACHE_NAMESPACE,
+  TRR_SEASON_CAST_CACHE_NAMESPACE,
+  TRR_SEASON_EPISODES_CACHE_NAMESPACE,
+  TRR_SHOW_CAST_CACHE_NAMESPACE,
+  TRR_SHOW_SEASONS_CACHE_NAMESPACE,
+  TRR_SHOWS_CACHE_NAMESPACE,
+} from "@/lib/server/trr-api/trr-show-read-route-cache";
+
+const PERSON_PHOTOS_CACHE_NAMESPACE = "admin-person-photos";
+
+describe("admin route cache key normalization", () => {
+  beforeEach(() => {
+    requireAdminMock.mockReset();
+    resolveAdminShowIdMock.mockReset();
+    fetchAdminBackendJsonMock.mockReset();
+    requireAdminMock.mockResolvedValue({ uid: "admin-user" });
+    resolveAdminShowIdMock.mockResolvedValue("show-1");
+    fetchAdminBackendJsonMock.mockResolvedValue({
+      status: 200,
+      data: { photos: [], pagination: {}, result: "ok" },
+      durationMs: 1,
+    });
+    for (const namespace of [
+      TRR_PEOPLE_HOME_CACHE_NAMESPACE,
+      TRR_SEARCH_CACHE_NAMESPACE,
+      TRR_SEASON_CAST_CACHE_NAMESPACE,
+      TRR_SEASON_EPISODES_CACHE_NAMESPACE,
+      TRR_SHOW_CAST_CACHE_NAMESPACE,
+      TRR_SHOW_SEASONS_CACHE_NAMESPACE,
+      TRR_SHOWS_CACHE_NAMESPACE,
+      PERSON_PHOTOS_CACHE_NAMESPACE,
+    ]) {
+      invalidateRouteResponseCache(namespace);
+    }
+  });
+
+  it("deduplicates equivalent top-level list requests", async () => {
+    const secondShows = await getShows(
+      new NextRequest("http://localhost/api/admin/trr-api/shows?q=bravo&limit=999&offset=-4"),
+    ).then(async () =>
+      getShows(new NextRequest("http://localhost/api/admin/trr-api/shows?q=bravo&limit=100&offset=0")),
+    );
+    const secondSearch = await getSearch(
+      new NextRequest("http://localhost/api/admin/trr-api/search?q=%20bravo%20&limit=999"),
+    ).then(async () =>
+      getSearch(new NextRequest("http://localhost/api/admin/trr-api/search?q=bravo&limit=20")),
+    );
+    const secondPeople = await getPeopleHome(
+      new NextRequest("http://localhost/api/admin/trr-api/people/home?limit=999"),
+    ).then(async () =>
+      getPeopleHome(new NextRequest("http://localhost/api/admin/trr-api/people/home?limit=24")),
+    );
+
+    expect(secondShows.headers.get("x-trr-cache")).toBe("hit");
+    expect(secondSearch.headers.get("x-trr-cache")).toBe("hit");
+    expect(secondPeople.headers.get("x-trr-cache")).toBe("hit");
+    expect(fetchAdminBackendJsonMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("deduplicates equivalent show, season, and episode requests", async () => {
+    const showParams = { params: Promise.resolve({ showId: "show-1" }) };
+    const secondSeasons = await getShowSeasons(
+      new NextRequest(
+        "http://localhost/api/admin/trr-api/shows/show-1/seasons?limit=999&offset=-1&include_episode_signal=1",
+      ),
+      showParams,
+    ).then(async () =>
+      getShowSeasons(
+        new NextRequest(
+          "http://localhost/api/admin/trr-api/shows/show-1/seasons?limit=500&offset=0&include_episode_signal=true",
+        ),
+        showParams,
+      ),
+    );
+    const secondShowCast = await getShowCast(
+      new NextRequest("http://localhost/api/admin/trr-api/shows/show-1/cast?limit=999&offset=-1"),
+      showParams,
+    ).then(async () =>
+      getShowCast(
+        new NextRequest("http://localhost/api/admin/trr-api/shows/show-1/cast?limit=500&offset=0"),
+        showParams,
+      ),
+    );
+    const seasonCastParams = {
+      params: Promise.resolve({ showId: "show-1", seasonNumber: "1" }),
+    };
+    const secondSeasonCast = await getSeasonCast(
+      new NextRequest(
+        "http://localhost/api/admin/trr-api/shows/show-1/seasons/1/cast?limit=999&offset=-1&include_archive_only=TRUE",
+      ),
+      seasonCastParams,
+    ).then(async () =>
+      getSeasonCast(
+        new NextRequest(
+          "http://localhost/api/admin/trr-api/shows/show-1/seasons/1/cast?limit=500&offset=0&include_archive_only=true&photo_fallback=none",
+        ),
+        seasonCastParams,
+      ),
+    );
+    const episodeParams = { params: Promise.resolve({ seasonId: "season-1" }) };
+    const secondEpisodes = await getSeasonEpisodes(
+      new NextRequest("http://localhost/api/admin/trr-api/seasons/season-1/episodes?limit=999&offset=-1"),
+      episodeParams,
+    ).then(async () =>
+      getSeasonEpisodes(
+        new NextRequest("http://localhost/api/admin/trr-api/seasons/season-1/episodes?limit=500&offset=0"),
+        episodeParams,
+      ),
+    );
+
+    expect(secondSeasons.headers.get("x-trr-cache")).toBe("hit");
+    expect(secondShowCast.headers.get("x-trr-cache")).toBe("hit");
+    expect(secondSeasonCast.headers.get("x-trr-cache")).toBe("hit");
+    expect(secondEpisodes.headers.get("x-trr-cache")).toBe("hit");
+    expect(fetchAdminBackendJsonMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("deduplicates canonical person-photo requests while excluding request role", async () => {
+    const params = { params: Promise.resolve({ personId: "person-1" }) };
+    await getPersonPhotos(
+      new NextRequest(
+        "http://localhost/api/admin/trr-api/people/person-1/photos?limit=999&offset=-1&include_broken=1&include_total_count=0&sources=getty,%20bravo&request_role=primary",
+      ),
+      params,
+    );
+    const second = await getPersonPhotos(
+      new NextRequest(
+        "http://localhost/api/admin/trr-api/people/person-1/photos?limit=500&offset=0&include_broken=true&include_total_count=false&sources=getty,bravo&request_role=polling",
+      ),
+      params,
+    );
+
+    expect(second.headers.get("x-trr-cache")).toBe("hit");
+    expect(fetchAdminBackendJsonMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/tests/admin-shows-route.test.ts
+++ b/apps/web/tests/admin-shows-route.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+process.env.TRR_ADMIN_ROUTE_CACHE_DISABLED = "1";
+
+const { requireAdminMock, fetchAdminBackendJsonMock } = vi.hoisted(() => ({
+  requireAdminMock: vi.fn(),
+  fetchAdminBackendJsonMock: vi.fn(),
+}));
+
+vi.mock("@/lib/server/auth", () => ({
+  requireAdmin: requireAdminMock,
+}));
+
+vi.mock("@/lib/server/trr-api/admin-read-proxy", () => ({
+  fetchAdminBackendJson: fetchAdminBackendJsonMock,
+  ADMIN_READ_PROXY_SHORT_TIMEOUT_MS: 5_000,
+  buildAdminProxyErrorResponse: (error: unknown) =>
+    NextResponse.json({ error: error instanceof Error ? error.message : "failed" }, { status: 500 }),
+}));
+
+import { GET } from "@/app/api/admin/trr-api/shows/route";
+
+describe("/api/admin/trr-api/shows", () => {
+  beforeEach(() => {
+    requireAdminMock.mockReset();
+    fetchAdminBackendJsonMock.mockReset();
+    requireAdminMock.mockResolvedValue({ uid: "admin-user" });
+    fetchAdminBackendJsonMock.mockResolvedValue({
+      status: 200,
+      data: { shows: [], pagination: { limit: 100, offset: 0, count: 0 } },
+      durationMs: 4,
+    });
+  });
+
+  it("rejects malformed explicit pagination values before proxying", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/trr-api/shows?q=bravo&limit=abc"),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("limit must be an integer");
+    expect(fetchAdminBackendJsonMock).not.toHaveBeenCalled();
+  });
+
+  it("clamps valid out-of-range pagination values before proxying", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/trr-api/shows?q=bravo&limit=999&offset=-4"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchAdminBackendJsonMock).toHaveBeenCalledWith(
+      "/admin/trr-api/shows?q=bravo&limit=100&offset=0",
+      expect.objectContaining({ routeName: "admin-shows" }),
+    );
+  });
+});

--- a/apps/web/tests/admin-shows-route.test.ts
+++ b/apps/web/tests/admin-shows-route.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest, NextResponse } from "next/server";
 
-process.env.TRR_ADMIN_ROUTE_CACHE_DISABLED = "1";
-
-const { requireAdminMock, fetchAdminBackendJsonMock } = vi.hoisted(() => ({
-  requireAdminMock: vi.fn(),
-  fetchAdminBackendJsonMock: vi.fn(),
-}));
+const { requireAdminMock, fetchAdminBackendJsonMock } = vi.hoisted(() => {
+  process.env.TRR_ADMIN_ROUTE_CACHE_DISABLED = "1";
+  return {
+    requireAdminMock: vi.fn(),
+    fetchAdminBackendJsonMock: vi.fn(),
+  };
+});
 
 vi.mock("@/lib/server/auth", () => ({
   requireAdmin: requireAdminMock,

--- a/apps/web/tests/cast-screentime-page.test.tsx
+++ b/apps/web/tests/cast-screentime-page.test.tsx
@@ -5,11 +5,13 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import CastScreentimePageClient from "@/app/admin/cast-screentime/CastScreentimePageClient";
 
 const navigationState = vi.hoisted(() => ({
+  pathname: "/admin/cast-screentime",
   search: "show_id=show-1",
 }));
 
 const mocks = vi.hoisted(() => ({
   fetchAdminWithAuth: vi.fn(),
+  clipboardWriteText: vi.fn(),
   guardState: {
     checking: false,
     hasAccess: true,
@@ -17,6 +19,10 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("next/navigation", () => ({
+  usePathname: () => navigationState.pathname,
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
   useSearchParams: () => new URLSearchParams(navigationState.search),
 }));
 
@@ -48,6 +54,14 @@ const jsonResponse = (body: unknown, status = 200): Response =>
 describe("CastScreentimePageClient", () => {
   beforeEach(() => {
     mocks.fetchAdminWithAuth.mockReset();
+    mocks.clipboardWriteText.mockReset();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: mocks.clipboardWriteText,
+      },
+    });
+    navigationState.pathname = "/admin/cast-screentime";
     navigationState.search = "show_id=show-1";
     mocks.fetchAdminWithAuth.mockImplementation((input: unknown) => {
       const url = String(input);
@@ -207,5 +221,353 @@ describe("CastScreentimePageClient", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Publish Internal Reference" })).toBeInTheDocument();
     expect(screen.getByText("6.000s")).toBeInTheDocument();
+    expect(screen.queryByText(/"run_type": "cast_screentime"/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy run link" }));
+
+    await waitFor(() => {
+      expect(mocks.clipboardWriteText).toHaveBeenCalledWith(
+        "https://admin.trr.localhost/screenalytics/runs/run-1",
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Debug details" }));
+
+    expect(await screen.findByText(/"run_type": "cast_screentime"/)).toBeInTheDocument();
+  });
+
+  it("prefills the canonical RHOBH test extra context from the screenalytics setup path", () => {
+    navigationState.pathname = "/screenalytics/rhobh/s5/e16/extras/screenalytics-test";
+    navigationState.search = "";
+
+    render(<CastScreentimePageClient />);
+
+    expect(screen.getByLabelText("Show")).toHaveValue("909ddc36-ca4d-4b09-8aa5-dd5dd34f987e");
+    expect(screen.getByLabelText("Season")).toHaveValue("98ac397a-3928-4583-92bc-25ea84c42d89");
+    expect(screen.getByLabelText("Episode")).toHaveValue("4eb4ceb4-c13d-4c29-bd0f-8bcde94b6591");
+    expect(screen.getByLabelText("Asset Type")).toHaveValue("extras");
+    expect(screen.getByLabelText("Content Type")).toHaveValue("screenalytics_test");
+    expect(screen.queryByLabelText("Owner Scope")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Owner ID")).not.toBeInTheDocument();
+  });
+
+  it("polls a queued remote import until the promoted asset is available", async () => {
+    let resolveStatus: ((response: Response) => void) | undefined;
+    mocks.fetchAdminWithAuth.mockImplementation((input: unknown) => {
+      const url = String(input);
+      if (url.endsWith("/video-assets/import")) {
+        return Promise.resolve(
+          jsonResponse(
+            {
+              upload_session_id: "import-session-1",
+              queued: true,
+              status: "queued",
+              video_asset: null,
+            },
+            202,
+          ),
+        );
+      }
+      if (url.endsWith("/upload-sessions/import-session-1")) {
+        return new Promise<Response>((resolve) => {
+          resolveStatus = resolve;
+        });
+      }
+      if (url.includes("/shows/show-1/runs")) {
+        return Promise.resolve(jsonResponse({ runs: [] }));
+      }
+      return Promise.resolve(jsonResponse({}));
+    });
+
+    render(<CastScreentimePageClient />);
+
+    fireEvent.change(screen.getByLabelText("Season"), {
+      target: { value: "98ac397a-3928-4583-92bc-25ea84c42d89" },
+    });
+    fireEvent.change(screen.getByLabelText("Source URL"), {
+      target: { value: "https://cdn.example.com/trailer.mp4" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Import Asset" }));
+
+    expect(await screen.findAllByText("Import queued...")).toHaveLength(2);
+
+    resolveStatus?.(
+      jsonResponse({
+        upload_session_id: "import-session-1",
+        status: "promoted",
+        promoted_video_asset_id: "asset-promoted-1",
+        video_asset: {
+          id: "asset-promoted-1",
+          show_id: "show-1",
+          season_id: "98ac397a-3928-4583-92bc-25ea84c42d89",
+          owner_scope: "season",
+          owner_id: "98ac397a-3928-4583-92bc-25ea84c42d89",
+          media_type: "trailer",
+          media_kind: null,
+          video_class: "promo",
+          promo_subtype: "trailer",
+          source_import_type: "external_url_import",
+          is_publishable: false,
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText("external url import").length).toBeGreaterThan(0);
+    });
+    expect(screen.getByRole("button", { name: "Launch Run" })).toBeEnabled();
+  });
+
+  it("previews, searches, paginates, downloads, and safely renders extracted source subtitles", async () => {
+    const anchorClick = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined);
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    mocks.fetchAdminWithAuth.mockImplementation((input: unknown) => {
+      const url = String(input);
+      if (url.endsWith("/video-assets/import")) {
+        return Promise.resolve(
+          jsonResponse({
+            upload_session_id: "import-complete-1",
+            status: "promoted",
+            video_asset: {
+              id: "asset-subtitles-1",
+              show_id: "show-1",
+              season_id: "season-1",
+              owner_scope: "season",
+              owner_id: "season-1",
+              media_type: "trailer",
+              source_import_type: "external_url_import",
+            },
+          }),
+        );
+      }
+      if (url.endsWith("/video-assets/asset-subtitles-1/subtitles/extract")) {
+        return Promise.resolve(jsonResponse({ status: "queued", force: true }, 202));
+      }
+      if (url.endsWith("/video-assets/asset-subtitles-1/subtitles")) {
+        return Promise.resolve(
+          jsonResponse({
+            video_asset_id: "asset-subtitles-1",
+            status: "complete",
+            attempts: 1,
+            discovered_track_count: 2,
+            eligible_track_count: 1,
+            completed_track_count: 1,
+            failed_track_count: 0,
+            primary_track_id: "track-2",
+            tracks: [
+              {
+                id: "track-2",
+                stream_index: 2,
+                codec_name: "mov_text",
+                language: "en",
+                language_raw: "eng",
+                is_default: true,
+                is_forced: false,
+                is_primary: true,
+                selection_status: "eligible_english",
+                extraction_status: "complete",
+                cue_count: 75,
+                first_cue_start_ms: 14448,
+                last_cue_end_ms: 6308702,
+                srt_size_bytes: 185615,
+                srt_sha256: "2fdf46f4e83f69d66cc5d9f041233e8d",
+              },
+            ],
+          }),
+        );
+      }
+      if (url.includes("/subtitles/track-2/cues?")) {
+        const requestUrl = new URL(url, "https://admin.trr.localhost");
+        const offset = Number(requestUrl.searchParams.get("offset") || "0");
+        const query = requestUrl.searchParams.get("q");
+        return Promise.resolve(
+          jsonResponse({
+            video_asset_id: "asset-subtitles-1",
+            track_id: "track-2",
+            offset,
+            limit: 50,
+            total_cues: 75,
+            matched_cues: query ? 1 : undefined,
+            items: [
+              {
+                ordinal: offset + 1,
+                start_ms: offset === 0 ? 14448 : 120000,
+                end_ms: offset === 0 ? 16984 : 122000,
+                text: query ? "<i><script>alert(1)</script> ALICE:</i> Hello" : "<i>ALICE:</i> Hello",
+                plain_text: query ? "<script>alert(1)</script> ALICE: Hello" : "ALICE: Hello",
+              },
+            ],
+          }),
+        );
+      }
+      if (url.endsWith("/subtitles/track-2/download-url")) {
+        return Promise.resolve(
+          jsonResponse({
+            filename: "Love Island.S08.E01.stream-2.en.srt",
+            download_url: "https://r2.example.test/signed-caption",
+          }),
+        );
+      }
+      if (url.includes("/shows/show-1/runs")) return Promise.resolve(jsonResponse({ runs: [] }));
+      return Promise.resolve(jsonResponse({}));
+    });
+
+    render(<CastScreentimePageClient />);
+    fireEvent.change(screen.getByLabelText("Season"), {
+      target: { value: "98ac397a-3928-4583-92bc-25ea84c42d89" },
+    });
+    fireEvent.change(screen.getByLabelText("Source URL"), {
+      target: { value: "https://cdn.example.com/love-island.mp4" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Import Asset" }));
+
+    expect(await screen.findByText("Ready")).toBeInTheDocument();
+    expect(screen.getByLabelText("English subtitle track")).toHaveValue("track-2");
+    expect(await screen.findByText("ALICE: Hello")).toBeInTheDocument();
+    expect(screen.getAllByText(/00:00:14\.448/).length).toBeGreaterThan(0);
+    expect(screen.getByText("181.3 KiB · 2fdf46f4e8…")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next cues" }));
+    await waitFor(() => {
+      expect(mocks.fetchAdminWithAuth).toHaveBeenCalledWith(
+        expect.stringContaining("offset=50&limit=50"),
+        undefined,
+        expect.objectContaining({ allowDevAdminBypass: true }),
+      );
+    });
+
+    fireEvent.change(screen.getByLabelText("Search subtitle cues"), { target: { value: "ALICE" } });
+    expect(await screen.findByText("<script>alert(1)</script> ALICE: Hello")).toBeInTheDocument();
+    expect(document.querySelector("script")).toBeNull();
+    await waitFor(() => {
+      expect(mocks.fetchAdminWithAuth).toHaveBeenCalledWith(
+        expect.stringContaining("q=ALICE"),
+        undefined,
+        expect.objectContaining({ allowDevAdminBypass: true }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Download SRT" }));
+    await waitFor(() => expect(anchorClick).toHaveBeenCalled());
+    expect(mocks.fetchAdminWithAuth).toHaveBeenCalledWith(
+      "/api/admin/trr-api/cast-screentime/video-assets/asset-subtitles-1/subtitles/track-2/download-url",
+      undefined,
+      expect.objectContaining({ allowDevAdminBypass: true }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Re-extract" }));
+    await waitFor(() => {
+      expect(confirm).toHaveBeenCalled();
+      expect(mocks.fetchAdminWithAuth).toHaveBeenCalledWith(
+        "/api/admin/trr-api/cast-screentime/video-assets/asset-subtitles-1/subtitles/extract",
+        expect.objectContaining({ method: "POST", body: JSON.stringify({ force: true }) }),
+        expect.objectContaining({ allowDevAdminBypass: true }),
+      );
+    });
+
+    anchorClick.mockRestore();
+    confirm.mockRestore();
+  });
+
+  it("queues first-time subtitle extraction without blocking the promoted video asset", async () => {
+    let extractionQueued = false;
+    mocks.fetchAdminWithAuth.mockImplementation((input: unknown, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/video-assets/import")) {
+        return Promise.resolve(
+          jsonResponse({
+            upload_session_id: "import-no-subtitles-1",
+            video_asset: {
+              id: "asset-not-requested-1",
+              show_id: "show-1",
+              season_id: "season-1",
+              owner_scope: "season",
+              owner_id: "season-1",
+              media_type: "trailer",
+            },
+          }),
+        );
+      }
+      if (url.endsWith("/video-assets/asset-not-requested-1/subtitles/extract")) {
+        extractionQueued = true;
+        expect(JSON.parse(String(init?.body))).toEqual({ force: false });
+        return Promise.resolve(jsonResponse({ status: "queued", already_active: false }, 202));
+      }
+      if (url.endsWith("/video-assets/asset-not-requested-1/subtitles")) {
+        return Promise.resolve(
+          jsonResponse({
+            video_asset_id: "asset-not-requested-1",
+            status: extractionQueued ? "queued" : "not_requested",
+            tracks: [],
+          }),
+        );
+      }
+      if (url.includes("/shows/show-1/runs")) return Promise.resolve(jsonResponse({ runs: [] }));
+      return Promise.resolve(jsonResponse({}));
+    });
+
+    render(<CastScreentimePageClient />);
+    fireEvent.change(screen.getByLabelText("Season"), {
+      target: { value: "98ac397a-3928-4583-92bc-25ea84c42d89" },
+    });
+    fireEvent.change(screen.getByLabelText("Source URL"), {
+      target: { value: "https://cdn.example.com/no-subtitles-yet.mp4" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Import Asset" }));
+
+    const extractButton = await screen.findByRole("button", { name: "Extract Subtitles" });
+    expect(screen.getByRole("button", { name: "Launch Run" })).toBeEnabled();
+    fireEvent.click(extractButton);
+
+    expect(await screen.findByText("Queued")).toBeInTheDocument();
+    expect(await screen.findByText(/video remains available for analysis/i)).toBeInTheDocument();
+  });
+
+  it("shows a non-blocking subtitle failure with a retry action", async () => {
+    mocks.fetchAdminWithAuth.mockImplementation((input: unknown) => {
+      const url = String(input);
+      if (url.endsWith("/video-assets/import")) {
+        return Promise.resolve(
+          jsonResponse({
+            upload_session_id: "import-failed-subtitles-1",
+            video_asset: {
+              id: "asset-failed-subtitles-1",
+              show_id: "show-1",
+              season_id: "season-1",
+              owner_scope: "season",
+              owner_id: "season-1",
+              media_type: "trailer",
+            },
+          }),
+        );
+      }
+      if (url.endsWith("/video-assets/asset-failed-subtitles-1/subtitles")) {
+        return Promise.resolve(
+          jsonResponse({
+            video_asset_id: "asset-failed-subtitles-1",
+            status: "failed",
+            error: "ffprobe could not inspect subtitle streams",
+            attempts: 1,
+            tracks: [],
+          }),
+        );
+      }
+      if (url.includes("/shows/show-1/runs")) return Promise.resolve(jsonResponse({ runs: [] }));
+      return Promise.resolve(jsonResponse({ status: "queued" }, 202));
+    });
+
+    render(<CastScreentimePageClient />);
+    fireEvent.change(screen.getByLabelText("Season"), {
+      target: { value: "98ac397a-3928-4583-92bc-25ea84c42d89" },
+    });
+    fireEvent.change(screen.getByLabelText("Source URL"), {
+      target: { value: "https://cdn.example.com/failed-subtitles.mp4" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Import Asset" }));
+
+    expect(await screen.findByText("Extraction failed")).toBeInTheDocument();
+    expect(screen.getByText("ffprobe could not inspect subtitle streams")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry Extraction" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Launch Run" })).toBeEnabled();
   });
 });

--- a/apps/web/tests/cast-screentime-page.test.tsx
+++ b/apps/web/tests/cast-screentime-page.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import CastScreentimePageClient from "@/app/admin/cast-screentime/CastScreentimePageClient";
 
@@ -53,6 +53,7 @@ const jsonResponse = (body: unknown, status = 200): Response =>
 
 describe("CastScreentimePageClient", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     mocks.fetchAdminWithAuth.mockReset();
     mocks.clipboardWriteText.mockReset();
     Object.defineProperty(navigator, "clipboard", {
@@ -569,5 +570,59 @@ describe("CastScreentimePageClient", () => {
     expect(screen.getByText("ffprobe could not inspect subtitle streams")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Retry Extraction" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Launch Run" })).toBeEnabled();
+  });
+
+  it("caps automatic subtitle polling and leaves manual refresh available", async () => {
+    vi.useFakeTimers();
+    let subtitlePollCount = 0;
+    navigationState.pathname = "/screenalytics/runs/run-1";
+    const defaultFetchImplementation = mocks.fetchAdminWithAuth.getMockImplementation();
+    if (!defaultFetchImplementation) throw new Error("Expected default Screenalytics fetch mock");
+    mocks.fetchAdminWithAuth.mockImplementation((input: unknown, ...args: unknown[]) => {
+      const url = String(input);
+      if (url.endsWith("/video-assets/asset-1/subtitles")) {
+        subtitlePollCount += 1;
+        return Promise.resolve(
+          jsonResponse({
+            video_asset_id: "asset-1",
+            status: "running",
+            tracks: [],
+          }),
+        );
+      }
+      return defaultFetchImplementation(input, ...args);
+    });
+
+    render(<CastScreentimePageClient />);
+
+    await act(async () => {
+      for (let flushAttempt = 0; flushAttempt < 10; flushAttempt += 1) {
+        await Promise.resolve();
+      }
+    });
+    for (let timerStep = 0; timerStep < 10 && subtitlePollCount < 6; timerStep += 1) {
+      await act(async () => {
+        await vi.advanceTimersToNextTimerAsync();
+        await Promise.resolve();
+      });
+    }
+
+    expect(subtitlePollCount).toBe(6);
+    expect(
+      screen.getByText(
+        "Subtitle extraction is still running. Automatic refresh paused after 6 checks; use Refresh to check again.",
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(subtitlePollCount).toBe(7);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(subtitlePollCount).toBe(7);
   });
 });

--- a/apps/web/tests/proxy-routing.test.ts
+++ b/apps/web/tests/proxy-routing.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+
+import { proxy } from "@/proxy";
+
+const trackedEnvKeys = [
+  "NODE_ENV",
+  "ADMIN_APP_ORIGIN",
+  "ADMIN_APP_HOSTS",
+  "ADMIN_ENFORCE_HOST",
+  "ADMIN_STRICT_HOST_ROUTING",
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+
+function setDefaultAdminRoutingEnv() {
+  process.env.ADMIN_APP_ORIGIN = "http://admin.localhost:3000";
+  delete process.env.ADMIN_APP_HOSTS;
+  process.env.ADMIN_ENFORCE_HOST = "true";
+  process.env.ADMIN_STRICT_HOST_ROUTING = "false";
+}
+
+function runProxy(pathname: string) {
+  return proxy(new NextRequest(`http://admin.localhost:3000${pathname}`));
+}
+
+describe("proxy route characterization", () => {
+  beforeEach(() => {
+    for (const key of trackedEnvKeys) {
+      originalEnv.set(key, process.env[key]);
+    }
+    setDefaultAdminRoutingEnv();
+  });
+
+  afterEach(() => {
+    for (const key of trackedEnvKeys) {
+      const original = originalEnv.get(key);
+      if (typeof original === "undefined") {
+        delete process.env[key];
+      } else {
+        process.env[key] = original;
+      }
+    }
+    originalEnv.clear();
+  });
+
+  it("rewrites canonical admin-host section routes to their internal admin pages", () => {
+    const response = runProxy("/social");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-middleware-rewrite")).toBe("http://admin.localhost:3000/admin/social");
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it.each([
+    [
+      "/screenlaytics?run_id=run-123&utm_source=test",
+      "http://admin.localhost:3000/screenalytics/runs/run-123?utm_source=test",
+    ],
+    [
+      "/admin/cast-screentime?run=run-456&debug=1",
+      "http://admin.localhost:3000/screenalytics/runs/run-456?debug=1",
+    ],
+  ])("redirects legacy screenalytics alias %s to the canonical URL", (pathname, expectedLocation) => {
+    const response = runProxy(pathname);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(expectedLocation);
+  });
+
+  it.each([
+    ["/rhoslc", "http://admin.localhost:3000/admin/trr-shows/rhoslc"],
+    ["/rhoslc/s6", "http://admin.localhost:3000/admin/trr-shows/rhoslc/seasons/6"],
+    ["/rhoslc/s6/fandom", "http://admin.localhost:3000/admin/trr-shows/rhoslc/seasons/6?tab=fandom"],
+    [
+      "/rhoslc/s6/social/w0/youtube",
+      "http://admin.localhost:3000/admin/trr-shows/rhoslc/seasons/6/social/week/0/youtube",
+    ],
+  ])("rewrites short show route %s to the admin workspace", (pathname, expectedRewrite) => {
+    const response = runProxy(pathname);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-middleware-rewrite")).toBe(expectedRewrite);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("does not treat reserved root segments as show routes", () => {
+    const response = runProxy("/hub");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+  });
+
+  it.each([
+    ["/brands/networks-and-streaming", "http://admin.localhost:3000/brands"],
+    ["/admin/brands/instagram", "http://admin.localhost:3000/brands/instagram"],
+  ])("redirects brand route %s to its canonical admin URL", (pathname, expectedLocation) => {
+    const response = runProxy(pathname);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(expectedLocation);
+  });
+});

--- a/apps/web/tests/season-episodes-route-parity.test.ts
+++ b/apps/web/tests/season-episodes-route-parity.test.ts
@@ -49,4 +49,16 @@ describe("season episodes route parity", () => {
     );
     expect(payload.episodes[0]).toMatchObject({ episode_number: 1, title: "Pilot" });
   });
+
+  it("rejects malformed explicit offsets before proxying", async () => {
+    const request = new NextRequest(
+      "http://localhost/api/admin/trr-api/seasons/season-1/episodes?offset=abc",
+    );
+    const response = await GET(request, { params: Promise.resolve({ seasonId: "season-1" }) });
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("offset must be an integer");
+    expect(fetchAdminBackendJsonMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/tests/show-assets-route.test.ts
+++ b/apps/web/tests/show-assets-route.test.ts
@@ -187,6 +187,37 @@ describe("show assets route", () => {
     );
   });
 
+  it("rejects malformed explicit gallery offsets before proxying", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/trr-api/shows/show-1/assets?offset=abc"),
+      { params: Promise.resolve({ showId: "show-1" }) },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("offset must be an integer");
+    expect(fetchAdminBackendJsonMock).not.toHaveBeenCalled();
+  });
+
+  it("clamps oversized gallery limits before proxying", async () => {
+    fetchAdminBackendJsonMock.mockResolvedValue({
+      status: 200,
+      data: { assets: [], pagination: { limit: 5000, offset: 0, count: 0, has_more: false, next_cursor: null, cursor: null, truncated: false, full: false } },
+      durationMs: 3,
+    });
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/trr-api/shows/show-1/assets?limit=999999"),
+      { params: Promise.resolve({ showId: "show-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchAdminBackendJsonMock).toHaveBeenCalledWith(
+      "/admin/trr-api/shows/show-1/assets?limit=5000&offset=0",
+      expect.objectContaining({ routeName: "show-assets" }),
+    );
+  });
+
   it("supports full fetch mode with truthful truncation metadata", async () => {
     fetchAdminBackendJsonMock.mockResolvedValue({
       status: 200,

--- a/apps/web/tests/show-cast-route-default-min-episodes.test.ts
+++ b/apps/web/tests/show-cast-route-default-min-episodes.test.ts
@@ -143,6 +143,18 @@ describe("show cast route proxy parity", () => {
     );
   });
 
+  it("rejects malformed pagination values before proxying", async () => {
+    const request = new NextRequest(
+      "http://localhost/api/admin/trr-api/shows/show-1/cast?limit=abc",
+    );
+    const response = await GET(request, { params: Promise.resolve({ showId: "show-1" }) });
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("limit must be an integer");
+    expect(fetchAdminBackendJsonMock).not.toHaveBeenCalled();
+  });
+
   it("returns 404 when show slug or id cannot be resolved", async () => {
     resolveAdminShowIdMock.mockResolvedValue(null);
 

--- a/apps/web/tests/show-seasons-route-episode-signal.test.ts
+++ b/apps/web/tests/show-seasons-route-episode-signal.test.ts
@@ -95,6 +95,25 @@ describe("/api/admin/trr-api/shows/[showId]/seasons include episode signal", () 
     );
   });
 
+  it("preserves 500-season requests used by the image scrape drawer", async () => {
+    fetchAdminBackendJsonMock.mockResolvedValue({
+      status: 200,
+      data: { seasons: [], pagination: { limit: 500, offset: 0, count: 0 } },
+      durationMs: 2,
+    });
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/trr-api/shows/show-1/seasons?limit=500"),
+      { params: Promise.resolve({ showId: "show-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchAdminBackendJsonMock).toHaveBeenCalledWith(
+      "/admin/trr-api/shows/show-1/seasons?limit=500&offset=0",
+      expect.objectContaining({ routeName: "show-seasons" }),
+    );
+  });
+
   it("falls back to the local seasons repository when the backend read times out", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     fetchAdminBackendJsonMock.mockRejectedValue(new Error("Admin read request timed out after 12s"));


### PR DESCRIPTION
## Summary
- canonicalize Screenalytics routes and legacy redirects
- add remote-import polling, subtitle state, run links, and review summaries
- update navigation, proxy routing, and focused UI coverage

## Validation
- 154 targeted Vitest tests passed

## Dependencies
Targets the API-input branch. Backend Screenalytics and cast subtitle PRs provide the server contracts.