### PR TITLE
Harden app admin runtime security

### DIFF
--- a/apps/web/src/app/api/admin/check/route.ts
+++ b/apps/web/src/app/api/admin/check/route.ts
@@ -4,11 +4,15 @@ import { requireAdmin } from "@/lib/server/auth";
 
 export const dynamic = "force-dynamic";
 
+const NO_STORE_RESPONSE_INIT = {
+  headers: { "Cache-Control": "no-store" },
+} as const;
+
 export async function GET(request: NextRequest) {
   try {
     await requireAdmin(request);
-    return NextResponse.json({ hasAccess: true });
+    return NextResponse.json({ hasAccess: true }, NO_STORE_RESPONSE_INIT);
   } catch {
-    return NextResponse.json({ hasAccess: false });
+    return NextResponse.json({ hasAccess: false }, NO_STORE_RESPONSE_INIT);
   }
 }

--- a/apps/web/src/app/api/admin/check/route.ts
+++ b/apps/web/src/app/api/admin/check/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireAdmin } from "@/lib/server/auth";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  try {
+    await requireAdmin(request);
+    return NextResponse.json({ hasAccess: true });
+  } catch {
+    return NextResponse.json({ hasAccess: false });
+  }
+}

--- a/apps/web/src/app/api/admin/trr-api/bravotv/images/people/[personId]/stream/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/bravotv/images/people/[personId]/stream/route.ts
@@ -3,6 +3,7 @@ import { requireAdmin } from "@/lib/server/auth";
 import {
   cleanupStaleGettyPrefetchFiles,
   hydrateGettyPrefetchPayload,
+  InvalidGettyPrefetchTokenError,
 } from "@/lib/server/admin/getty-local-scrape";
 import { getBackendApiUrl } from "@/lib/server/trr-api/backend";
 import { getInternalAdminBearerToken } from "@/lib/server/trr-api/internal-admin-auth";
@@ -36,7 +37,14 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     ? await request.text().catch(() => "")
     : "";
   if (body.trim()) {
-    body = await hydrateGettyPrefetchPayload(body);
+    try {
+      body = await hydrateGettyPrefetchPayload(body);
+    } catch (error) {
+      if (error instanceof InvalidGettyPrefetchTokenError) {
+        return Response.json({ error: error.message }, { status: 400 });
+      }
+      throw error;
+    }
     cleanupStaleGettyPrefetchFiles().catch(() => {});
   }
   const backendResponse = await fetch(backendUrl, {

--- a/apps/web/src/app/api/admin/trr-api/bravotv/images/shows/[showId]/stream/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/bravotv/images/shows/[showId]/stream/route.ts
@@ -3,6 +3,7 @@ import { requireAdmin } from "@/lib/server/auth";
 import {
   cleanupStaleGettyPrefetchFiles,
   hydrateGettyPrefetchPayload,
+  InvalidGettyPrefetchTokenError,
 } from "@/lib/server/admin/getty-local-scrape";
 import { getBackendApiUrl } from "@/lib/server/trr-api/backend";
 import { getInternalAdminBearerToken } from "@/lib/server/trr-api/internal-admin-auth";
@@ -36,7 +37,14 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     ? await request.text().catch(() => "")
     : "";
   if (body.trim()) {
-    body = await hydrateGettyPrefetchPayload(body);
+    try {
+      body = await hydrateGettyPrefetchPayload(body);
+    } catch (error) {
+      if (error instanceof InvalidGettyPrefetchTokenError) {
+        return Response.json({ error: error.message }, { status: 400 });
+      }
+      throw error;
+    }
     cleanupStaleGettyPrefetchFiles().catch(() => {});
   }
   const backendResponse = await fetch(backendUrl, {

--- a/apps/web/src/app/api/admin/trr-api/people/[personId]/refresh-images/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/people/[personId]/refresh-images/route.ts
@@ -5,6 +5,7 @@ import { getInternalAdminBearerToken } from "@/lib/server/trr-api/internal-admin
 import {
   hydrateGettyPrefetchPayload,
   cleanupStaleGettyPrefetchFiles,
+  InvalidGettyPrefetchTokenError,
 } from "@/lib/server/admin/getty-local-scrape";
 
 export const dynamic = "force-dynamic";
@@ -80,7 +81,14 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       if (!bodyText.trim()) {
         bodyText = "{}";
       } else {
-        bodyText = await hydrateGettyPrefetchPayload(bodyText);
+        try {
+          bodyText = await hydrateGettyPrefetchPayload(bodyText);
+        } catch (error) {
+          if (error instanceof InvalidGettyPrefetchTokenError) {
+            return NextResponse.json({ error: error.message }, { status: 400 });
+          }
+          throw error;
+        }
         cleanupStaleGettyPrefetchFiles().catch(() => {});
       }
     }

--- a/apps/web/src/app/api/admin/trr-api/people/[personId]/refresh-images/stream/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/people/[personId]/refresh-images/stream/route.ts
@@ -4,6 +4,7 @@ import { getBackendApiUrl } from "@/lib/server/trr-api/backend";
 import {
   hydrateGettyPrefetchPayload,
   cleanupStaleGettyPrefetchFiles,
+  InvalidGettyPrefetchTokenError,
 } from "@/lib/server/admin/getty-local-scrape";
 import { getInternalAdminBearerToken } from "@/lib/server/trr-api/internal-admin-auth";
 import {
@@ -229,7 +230,21 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       if (!bodyText.trim()) {
         bodyText = "{}";
       } else {
-        bodyText = await hydrateGettyPrefetchPayload(bodyText);
+        try {
+          bodyText = await hydrateGettyPrefetchPayload(bodyText);
+        } catch (error) {
+          if (error instanceof InvalidGettyPrefetchTokenError) {
+            return buildErrorResponse(
+              {
+                stage: "proxy",
+                error: error.message,
+                ...(requestId ? { request_id: requestId } : {}),
+              },
+              400,
+            );
+          }
+          throw error;
+        }
         // Best-effort cleanup of stale prefetch state files.
         cleanupStaleGettyPrefetchFiles().catch(() => {});
       }

--- a/apps/web/src/app/api/debug-log/route.ts
+++ b/apps/web/src/app/api/debug-log/route.ts
@@ -3,8 +3,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireAdmin } from "@/lib/server/auth";
 
 const REDACTED = "[REDACTED]";
+const INVALID_JSON_BODY = Symbol("invalid_json_body");
 const MAX_DEPTH = 6;
 const MAX_DEBUG_LOG_BODY_BYTES = 64 * 1024;
+const TOO_LARGE_BODY = Symbol("too_large_body");
 const SENSITIVE_KEY_RE =
   /(token|secret|password|cookie|authorization|api[_-]?key|session|credential|jwt|bearer|email|uid|user[_-]?id)/i;
 
@@ -50,17 +52,23 @@ function parseContentLength(request: NextRequest): number | null {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
 }
 
-async function readJsonBodyWithLimit(request: NextRequest): Promise<unknown | "too_large"> {
+async function readJsonBodyWithLimit(
+  request: NextRequest,
+): Promise<unknown | typeof INVALID_JSON_BODY | typeof TOO_LARGE_BODY> {
   const contentLength = parseContentLength(request);
   if (contentLength !== null && contentLength > MAX_DEBUG_LOG_BODY_BYTES) {
-    return "too_large";
+    return TOO_LARGE_BODY;
   }
 
   const rawBody = await request.text();
   if (Buffer.byteLength(rawBody, "utf8") > MAX_DEBUG_LOG_BODY_BYTES) {
-    return "too_large";
+    return TOO_LARGE_BODY;
   }
-  return JSON.parse(rawBody) as unknown;
+  try {
+    return JSON.parse(rawBody) as unknown;
+  } catch {
+    return INVALID_JSON_BODY;
+  }
 }
 
 function redactPayload(value: unknown, depth = 0): unknown {
@@ -101,8 +109,11 @@ export async function POST(request: NextRequest) {
     }
 
     const logEntry = await readJsonBodyWithLimit(request);
-    if (logEntry === "too_large") {
+    if (logEntry === TOO_LARGE_BODY) {
       return NextResponse.json({ error: "payload_too_large" }, { status: 413 });
+    }
+    if (logEntry === INVALID_JSON_BODY) {
+      return NextResponse.json({ error: "invalid_json" }, { status: 400 });
     }
 
     if (!(await isAuthorized(request))) {

--- a/apps/web/src/app/api/debug-log/route.ts
+++ b/apps/web/src/app/api/debug-log/route.ts
@@ -1,8 +1,10 @@
+import { timingSafeEqual } from "node:crypto";
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAdmin } from "@/lib/server/auth";
 
 const REDACTED = "[REDACTED]";
 const MAX_DEPTH = 6;
+const MAX_DEBUG_LOG_BODY_BYTES = 64 * 1024;
 const SENSITIVE_KEY_RE =
   /(token|secret|password|cookie|authorization|api[_-]?key|session|credential|jwt|bearer|email|uid|user[_-]?id)/i;
 
@@ -29,6 +31,38 @@ function remoteDebugLoggingEnabled(request: NextRequest): boolean {
   return envFlag("TRR_REMOTE_DEBUG_LOG_ENABLED");
 }
 
+function timingSafeStringEqual(left: string, right: string): boolean {
+  const leftBytes = Buffer.from(left);
+  const rightBytes = Buffer.from(right);
+  if (leftBytes.length !== rightBytes.length) {
+    const paddedLeft = Buffer.alloc(rightBytes.length);
+    leftBytes.copy(paddedLeft, 0, 0, Math.min(leftBytes.length, rightBytes.length));
+    timingSafeEqual(paddedLeft, rightBytes);
+    return false;
+  }
+  return timingSafeEqual(leftBytes, rightBytes);
+}
+
+function parseContentLength(request: NextRequest): number | null {
+  const rawContentLength = request.headers.get("content-length")?.trim();
+  if (!rawContentLength) return null;
+  const parsed = Number.parseInt(rawContentLength, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+async function readJsonBodyWithLimit(request: NextRequest): Promise<unknown | "too_large"> {
+  const contentLength = parseContentLength(request);
+  if (contentLength !== null && contentLength > MAX_DEBUG_LOG_BODY_BYTES) {
+    return "too_large";
+  }
+
+  const rawBody = await request.text();
+  if (Buffer.byteLength(rawBody, "utf8") > MAX_DEBUG_LOG_BODY_BYTES) {
+    return "too_large";
+  }
+  return JSON.parse(rawBody) as unknown;
+}
+
 function redactPayload(value: unknown, depth = 0): unknown {
   if (depth > MAX_DEPTH) return "[TRUNCATED]";
   if (value === null || value === undefined) return value;
@@ -49,7 +83,7 @@ async function isAuthorized(request: NextRequest): Promise<boolean> {
     request.headers.get("x-trr-internal-admin-secret")?.trim() ||
     request.headers.get("x-internal-admin-secret")?.trim() ||
     "";
-  if (sharedSecretAuthEnabled && sharedSecret && providedSecret && providedSecret === sharedSecret) {
+  if (sharedSecretAuthEnabled && sharedSecret && providedSecret && timingSafeStringEqual(providedSecret, sharedSecret)) {
     return true;
   }
   try {
@@ -66,11 +100,15 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "remote_debug_logging_disabled" }, { status: 404 });
     }
 
+    const logEntry = await readJsonBodyWithLimit(request);
+    if (logEntry === "too_large") {
+      return NextResponse.json({ error: "payload_too_large" }, { status: 413 });
+    }
+
     if (!(await isAuthorized(request))) {
       return NextResponse.json({ error: "forbidden" }, { status: 403 });
     }
 
-    const logEntry = await request.json();
     const redacted = redactPayload(logEntry);
 
     console.log('[PRODUCTION DEBUG]', JSON.stringify(redacted, null, 2));

--- a/apps/web/src/app/api/debug-log/route.ts
+++ b/apps/web/src/app/api/debug-log/route.ts
@@ -60,10 +60,22 @@ async function readJsonBodyWithLimit(
     return TOO_LARGE_BODY;
   }
 
-  const rawBody = await request.text();
-  if (Buffer.byteLength(rawBody, "utf8") > MAX_DEBUG_LOG_BODY_BYTES) {
-    return TOO_LARGE_BODY;
+  const reader = request.body?.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  if (reader) {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_DEBUG_LOG_BODY_BYTES) {
+        await reader.cancel();
+        return TOO_LARGE_BODY;
+      }
+      chunks.push(value);
+    }
   }
+  const rawBody = Buffer.concat(chunks, totalBytes).toString("utf8");
   try {
     return JSON.parse(rawBody) as unknown;
   } catch {

--- a/apps/web/src/app/api/design-system/typography/route.ts
+++ b/apps/web/src/app/api/design-system/typography/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getTypographyState } from "@/lib/server/admin/typography-repository";
+import { buildTypographyStateSnapshot } from "@/lib/server/admin/typography-seed";
 import {
   getOrCreateRouteResponsePromise,
   getRouteResponseCache,
@@ -9,6 +10,7 @@ import {
   TYPOGRAPHY_PUBLIC_CACHE_NAMESPACE,
   TYPOGRAPHY_PUBLIC_CACHE_TTL_MS,
 } from "@/lib/server/admin/typography-route-cache";
+import { resolvePostgresConnectionCandidates } from "@/lib/server/postgres";
 
 export const dynamic = "force-dynamic";
 const TYPOGRAPHY_CACHE_KEY = "state";
@@ -21,6 +23,12 @@ export async function GET() {
     );
     if (cached) {
       return NextResponse.json(cached, { headers: { "x-trr-cache": "hit" } });
+    }
+
+    if (resolvePostgresConnectionCandidates(process.env).length === 0) {
+      const state = buildTypographyStateSnapshot();
+      setRouteResponseCache(TYPOGRAPHY_PUBLIC_CACHE_NAMESPACE, TYPOGRAPHY_CACHE_KEY, state, TYPOGRAPHY_PUBLIC_CACHE_TTL_MS);
+      return NextResponse.json(state);
     }
 
     const payload = await getOrCreateRouteResponsePromise(

--- a/apps/web/src/lib/admin/api-references/generated/inventory.ts
+++ b/apps/web/src/lib/admin/api-references/generated/inventory.ts
@@ -3,8 +3,8 @@ import type { AdminApiReferenceInventory } from "@/lib/admin/api-references/type
 export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
   "inventorySchemaVersion": "1.0.0",
   "generatorVersion": "1.0.0",
-  "generatedAt": "2026-07-05T23:35:29.612Z",
-  "sourceCommitSha": "b4198ec471d55204af3f5bbeca194ac0a9706ab7",
+  "generatedAt": "2026-07-13T21:29:30.120Z",
+  "sourceCommitSha": "3e649da9d5af986171f929adef6947875004073f",
   "overrideDigest": "cd85a76fd2fc977cbc691ccab80ce844f9ea783e118af35eb3d9766e5d61fd36",
   "nodes": [
     {
@@ -7189,6 +7189,37 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       ],
       "staticOnly": false,
       "payloadRisk": "high",
+      "fanoutRisk": "low"
+    },
+    {
+      "id": "route:GET:/api/admin/check",
+      "kind": "api_route",
+      "title": "GET /api/admin/check",
+      "pathPattern": "/api/admin/check",
+      "symbol": "GET",
+      "sourceFile": "src/app/api/admin/check/route.ts",
+      "sourceLocator": {
+        "line": 7,
+        "symbol": "GET"
+      },
+      "provenance": "static_scan",
+      "confidence": "high",
+      "verificationStatus": "verified",
+      "basis": [
+        "static_scan:app_api_route"
+      ],
+      "usageTier": "manual",
+      "polls": false,
+      "pollCadenceMs": null,
+      "automatic": false,
+      "loadsLargeDatasets": false,
+      "usesPagination": false,
+      "returnsWideRowsOrBlobsOrRawJson": false,
+      "fansOutQueries": false,
+      "postgresAccess": "none",
+      "viewKinds": [],
+      "staticOnly": false,
+      "payloadRisk": "low",
       "fanoutRisk": "low"
     },
     {
@@ -23521,6 +23552,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
         "route:GET:/api/admin/auth/status",
         "route:GET:/api/admin/auth/status/drill-report",
         "route:GET:/api/admin/brands/profile",
+        "route:GET:/api/admin/check",
         "route:GET:/api/admin/colors/image-proxy",
         "route:GET:/api/admin/covered-shows",
         "route:GET:/api/admin/covered-shows/[showId]",
@@ -24245,11 +24277,11 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "renders_view": []
     },
     "summary": {
-      "totalNodes": 584,
+      "totalNodes": 585,
       "totalEdges": 204,
       "nodesByKind": {
         "ui_surface": 57,
-        "api_route": 400,
+        "api_route": 401,
         "backend_endpoint": 121,
         "repository_surface": 2,
         "polling_loop": 4

--- a/apps/web/src/lib/admin/api-references/generated/inventory.ts
+++ b/apps/web/src/lib/admin/api-references/generated/inventory.ts
@@ -3,8 +3,8 @@ import type { AdminApiReferenceInventory } from "@/lib/admin/api-references/type
 export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
   "inventorySchemaVersion": "1.0.0",
   "generatorVersion": "1.0.0",
-  "generatedAt": "2026-07-13T21:29:30.120Z",
-  "sourceCommitSha": "3e649da9d5af986171f929adef6947875004073f",
+  "generatedAt": "2026-07-13T21:45:30.476Z",
+  "sourceCommitSha": "2ad56aefd4f0f9f1f7bc1a6e67ed620ccef51886",
   "overrideDigest": "cd85a76fd2fc977cbc691ccab80ce844f9ea783e118af35eb3d9766e5d61fd36",
   "nodes": [
     {
@@ -7199,7 +7199,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/check/route.ts",
       "sourceLocator": {
-        "line": 7,
+        "line": 11,
         "symbol": "GET"
       },
       "provenance": "static_scan",

--- a/apps/web/src/lib/admin/api-references/generated/inventory.ts
+++ b/apps/web/src/lib/admin/api-references/generated/inventory.ts
@@ -3,8 +3,8 @@ import type { AdminApiReferenceInventory } from "@/lib/admin/api-references/type
 export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
   "inventorySchemaVersion": "1.0.0",
   "generatorVersion": "1.0.0",
-  "generatedAt": "2026-07-13T21:45:30.476Z",
-  "sourceCommitSha": "2ad56aefd4f0f9f1f7bc1a6e67ed620ccef51886",
+  "generatedAt": "2026-07-13T21:51:22.814Z",
+  "sourceCommitSha": "8cb8ada50ff8b01db41d596ff10a22cbb90bf52b",
   "overrideDigest": "cd85a76fd2fc977cbc691ccab80ce844f9ea783e118af35eb3d9766e5d61fd36",
   "nodes": [
     {
@@ -2038,7 +2038,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "POST",
       "sourceFile": "src/app/api/admin/trr-api/bravotv/images/people/[personId]/stream/route.ts",
       "sourceLocator": {
-        "line": 20,
+        "line": 21,
         "matchedText": "`/admin/bravotv/images/people/${personId}/stream`"
       },
       "provenance": "static_scan",
@@ -2213,7 +2213,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "POST",
       "sourceFile": "src/app/api/admin/trr-api/bravotv/images/shows/[showId]/stream/route.ts",
       "sourceLocator": {
-        "line": 20,
+        "line": 21,
         "matchedText": "`/admin/bravotv/images/shows/${showId}/stream`"
       },
       "provenance": "static_scan",
@@ -2823,7 +2823,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "POST",
       "sourceFile": "src/app/api/admin/trr-api/people/[personId]/refresh-images/route.ts",
       "sourceLocator": {
-        "line": 88,
+        "line": 96,
         "matchedText": "`/admin/person/${personId}/refresh-images`"
       },
       "provenance": "static_scan",
@@ -2892,7 +2892,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "POST",
       "sourceFile": "src/app/api/admin/trr-api/people/[personId]/refresh-images/stream/route.ts",
       "sourceLocator": {
-        "line": 238,
+        "line": 253,
         "matchedText": "`/admin/person/${personId}/refresh-images/stream`"
       },
       "provenance": "static_scan",
@@ -15458,7 +15458,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "POST",
       "sourceFile": "src/app/api/admin/trr-api/bravotv/images/people/[personId]/stream/route.ts",
       "sourceLocator": {
-        "line": 17,
+        "line": 18,
         "symbol": "POST"
       },
       "provenance": "static_scan",
@@ -15633,7 +15633,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "POST",
       "sourceFile": "src/app/api/admin/trr-api/bravotv/images/shows/[showId]/stream/route.ts",
       "sourceLocator": {
-        "line": 17,
+        "line": 18,
         "symbol": "POST"
       },
       "provenance": "static_scan",
@@ -16276,7 +16276,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "POST",
       "sourceFile": "src/app/api/admin/trr-api/people/[personId]/refresh-images/route.ts",
       "sourceLocator": {
-        "line": 63,
+        "line": 64,
         "symbol": "POST"
       },
       "provenance": "static_scan",
@@ -16346,7 +16346,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "POST",
       "sourceFile": "src/app/api/admin/trr-api/people/[personId]/refresh-images/stream/route.ts",
       "sourceLocator": {
-        "line": 206,
+        "line": 207,
         "symbol": "POST"
       },
       "provenance": "static_scan",
@@ -22419,7 +22419,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/api/admin/trr-api/bravotv/images/people/[personId]/stream/route.ts",
       "sourceLocator": {
-        "line": 20,
+        "line": 21,
         "matchedText": "`/admin/bravotv/images/people/${personId}/stream`"
       },
       "provenance": "static_scan",
@@ -22509,7 +22509,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/api/admin/trr-api/bravotv/images/shows/[showId]/stream/route.ts",
       "sourceLocator": {
-        "line": 20,
+        "line": 21,
         "matchedText": "`/admin/bravotv/images/shows/${showId}/stream`"
       },
       "provenance": "static_scan",
@@ -22797,7 +22797,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/api/admin/trr-api/people/[personId]/refresh-images/route.ts",
       "sourceLocator": {
-        "line": 88,
+        "line": 96,
         "matchedText": "`/admin/person/${personId}/refresh-images`"
       },
       "provenance": "static_scan",
@@ -22833,7 +22833,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/api/admin/trr-api/people/[personId]/refresh-images/stream/route.ts",
       "sourceLocator": {
-        "line": 238,
+        "line": 253,
         "matchedText": "`/admin/person/${personId}/refresh-images/stream`"
       },
       "provenance": "static_scan",

--- a/apps/web/src/lib/admin/client-access.ts
+++ b/apps/web/src/lib/admin/client-access.ts
@@ -1,35 +1,55 @@
 import type { User } from "firebase/auth";
-import { DEFAULT_ADMIN_UIDS } from "./constants";
 
-const parseAllowlist = (raw?: string | null, lowercase = false): string[] => {
-  const entries = (raw ?? "")
-    .split(",")
-    .map((entry) => (lowercase ? entry.trim().toLowerCase() : entry.trim()))
-    .filter(Boolean);
-  return entries;
+type AdminCheckResponse = {
+  hasAccess?: unknown;
 };
 
-const allowedAdminEmails = new Set(
-  parseAllowlist(process.env.NEXT_PUBLIC_ADMIN_EMAILS, true),
-);
-
-const allowedAdminUids = new Set<string>([
-  ...DEFAULT_ADMIN_UIDS,
-  ...parseAllowlist(process.env.NEXT_PUBLIC_ADMIN_UIDS, false),
-]);
+const ADMIN_CHECK_TIMEOUT_MS = 5000;
 
 export function isClientAdmin(user: User | null): boolean {
+  void user;
+  return false;
+}
+
+export async function checkServerAdminAccess(user: User | null): Promise<boolean> {
   if (!user) return false;
-  const email = user.email?.toLowerCase();
-  const emailAllowed = Boolean(email && user.emailVerified && allowedAdminEmails.has(email));
-  const uidAllowed = user.uid ? allowedAdminUids.has(user.uid) : false;
-  return emailAllowed || uidAllowed;
+
+  let token: string | null = null;
+  try {
+    token = await user.getIdToken();
+  } catch {
+    token = null;
+  }
+
+  const headers = new Headers({ accept: "application/json" });
+  if (token) {
+    headers.set("authorization", `Bearer ${token}`);
+  }
+
+  const abortController = new AbortController();
+  const timeoutId = window.setTimeout(() => abortController.abort(), ADMIN_CHECK_TIMEOUT_MS);
+  try {
+    const response = await fetch("/api/admin/check", {
+      method: "GET",
+      headers,
+      credentials: "same-origin",
+      cache: "no-store",
+      signal: abortController.signal,
+    });
+    if (!response.ok) return false;
+    const payload = (await response.json()) as AdminCheckResponse;
+    return payload.hasAccess === true;
+  } catch {
+    return false;
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
 }
 
 export function getAllowedAdminEmails(): string[] {
-  return Array.from(allowedAdminEmails);
+  return [];
 }
 
 export function getAllowedAdminUids(): string[] {
-  return Array.from(allowedAdminUids);
+  return [];
 }

--- a/apps/web/src/lib/admin/client-access.ts
+++ b/apps/web/src/lib/admin/client-access.ts
@@ -27,7 +27,7 @@ export async function checkServerAdminAccess(user: User | null): Promise<boolean
   }
 
   const abortController = new AbortController();
-  const timeoutId = window.setTimeout(() => abortController.abort(), ADMIN_CHECK_TIMEOUT_MS);
+  const timeoutId = setTimeout(() => abortController.abort(), ADMIN_CHECK_TIMEOUT_MS);
   try {
     const response = await fetch("/api/admin/check", {
       method: "GET",
@@ -42,7 +42,7 @@ export async function checkServerAdminAccess(user: User | null): Promise<boolean
   } catch {
     return false;
   } finally {
-    window.clearTimeout(timeoutId);
+    clearTimeout(timeoutId);
   }
 }
 

--- a/apps/web/src/lib/admin/client-access.ts
+++ b/apps/web/src/lib/admin/client-access.ts
@@ -4,6 +4,8 @@ type AdminCheckResponse = {
   hasAccess?: unknown;
 };
 
+export type ServerAdminAccessResult = "allowed" | "denied" | "unavailable";
+
 const ADMIN_CHECK_TIMEOUT_MS = 5000;
 
 export function isClientAdmin(user: User | null): boolean {
@@ -11,13 +13,27 @@ export function isClientAdmin(user: User | null): boolean {
   return false;
 }
 
-export async function checkServerAdminAccess(user: User | null): Promise<boolean> {
-  if (!user) return false;
+export async function checkServerAdminAccess(user: User | null): Promise<ServerAdminAccessResult> {
+  if (!user) return "denied";
+
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(() => abortController.abort(), ADMIN_CHECK_TIMEOUT_MS);
+  const abortPromise = new Promise<never>((_, reject) => {
+    abortController.signal.addEventListener(
+      "abort",
+      () => reject(new DOMException("Admin access check timed out", "AbortError")),
+      { once: true },
+    );
+  });
 
   let token: string | null = null;
   try {
-    token = await user.getIdToken();
+    token = await Promise.race([user.getIdToken(), abortPromise]);
   } catch {
+    if (abortController.signal.aborted) {
+      clearTimeout(timeoutId);
+      return "unavailable";
+    }
     token = null;
   }
 
@@ -26,21 +42,29 @@ export async function checkServerAdminAccess(user: User | null): Promise<boolean
     headers.set("authorization", `Bearer ${token}`);
   }
 
-  const abortController = new AbortController();
-  const timeoutId = setTimeout(() => abortController.abort(), ADMIN_CHECK_TIMEOUT_MS);
   try {
-    const response = await fetch("/api/admin/check", {
-      method: "GET",
-      headers,
-      credentials: "same-origin",
-      cache: "no-store",
-      signal: abortController.signal,
-    });
-    if (!response.ok) return false;
-    const payload = (await response.json()) as AdminCheckResponse;
-    return payload.hasAccess === true;
+    const response = await Promise.race([
+      fetch("/api/admin/check", {
+        method: "GET",
+        headers,
+        credentials: "same-origin",
+        cache: "no-store",
+        signal: abortController.signal,
+      }),
+      abortPromise,
+    ]);
+    if (!response.ok) return "unavailable";
+    let payload: AdminCheckResponse;
+    try {
+      payload = (await Promise.race([response.json(), abortPromise])) as AdminCheckResponse;
+    } catch {
+      return "unavailable";
+    }
+    if (payload.hasAccess === true) return "allowed";
+    if (payload.hasAccess === false) return "denied";
+    return "unavailable";
   } catch {
-    return false;
+    return "unavailable";
   } finally {
     clearTimeout(timeoutId);
   }

--- a/apps/web/src/lib/admin/constants.ts
+++ b/apps/web/src/lib/admin/constants.ts
@@ -8,6 +8,3 @@ export const DEFAULT_ADMIN_DISPLAY_NAMES = [
 ] as const;
 
 export type DefaultAdminDisplayName = (typeof DEFAULT_ADMIN_DISPLAY_NAMES)[number];
-
-export const DEFAULT_ADMIN_UIDS = ["MyoUFNjl9VP5iVGBi7tVqxUb8np2"] as const;
-export type DefaultAdminUid = (typeof DEFAULT_ADMIN_UIDS)[number];

--- a/apps/web/src/lib/admin/useAdminGuard.ts
+++ b/apps/web/src/lib/admin/useAdminGuard.ts
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { User } from "firebase/auth";
 import { auth } from "@/lib/firebase";
-import { isClientAdmin } from "./client-access";
+import { checkServerAdminAccess } from "./client-access";
 import { isDevAdminBypassEnabledClient, isLocalDevHostname } from "./dev-admin-bypass";
 
 const TRANSIENT_UNAUTH_GRACE_MS = 2500;
@@ -111,6 +111,8 @@ export function useAdminGuard() {
     let hadAuthenticatedSession = false;
     let transientUnauthTimer: ReturnType<typeof setTimeout> | null = null;
     let authReadyFallbackTimer: ReturnType<typeof setTimeout> | null = null;
+    let accessCheckId = 0;
+    let accessCheckPending = false;
 
     const clearTransientUnauthTimer = () => {
       if (!transientUnauthTimer) return;
@@ -126,13 +128,13 @@ export function useAdminGuard() {
 
     const finishCheckingIfReady = () => {
       if (!mounted) return;
-      if (receivedAuthEmission) {
+      if (receivedAuthEmission && !accessCheckPending) {
         setChecking(false);
       }
     };
 
     const evaluateInitialRedirect = () => {
-      if (!mounted || !authReady || !receivedAuthEmission || hasEvaluatedRedirect) {
+      if (!mounted || !authReady || !receivedAuthEmission || accessCheckPending || hasEvaluatedRedirect) {
         return;
       }
       hasEvaluatedRedirect = true;
@@ -144,75 +146,13 @@ export function useAdminGuard() {
       lastHasAccess = pendingHasAccess;
     };
 
-    const markAuthReady = () => {
-      if (authReady) return;
-      authReady = true;
-      clearAuthReadyFallbackTimer();
-      if (!receivedAuthEmission) {
-        const snapshotUser = auth.currentUser;
-        const snapshotUserKey = buildUserKey(snapshotUser);
-        const snapshotHasAccess = Boolean(snapshotUser && isClientAdmin(snapshotUser));
-        receivedAuthEmission = true;
-        pendingUserKey = snapshotUserKey;
-        pendingHasAccess = snapshotHasAccess;
-        lastUserKey = snapshotUserKey;
-        lastHasAccess = snapshotHasAccess;
-        hadAuthenticatedSession = Boolean(snapshotUserKey);
-        setUser(snapshotUser);
-        setUserKey(snapshotUserKey);
-        setHasAccess(snapshotHasAccess);
-      }
-      finishCheckingIfReady();
-      evaluateInitialRedirect();
-    };
-
-    authReadyFallbackTimer = setTimeout(markAuthReady, getAdminAuthReadyTimeoutMs());
-    const authStateReady = (auth as { authStateReady?: () => Promise<void> }).authStateReady;
-    const authReadyPromise =
-      typeof authStateReady === "function"
-        ? Promise.resolve(authStateReady.call(auth)).catch(() => undefined)
-        : Promise.resolve();
-    void authReadyPromise.finally(markAuthReady);
-
-    const unsubscribe = auth.onAuthStateChanged((currentUser) => {
+    const applyResolvedAccess = (
+      nextUserKey: string | null,
+      prevUserKey: string | null,
+      nextHasAccess: boolean,
+    ) => {
       if (!mounted) return;
-
-      receivedAuthEmission = true;
-      const nextUserKey = buildUserKey(currentUser);
-      const prevUserKey = lastUserKey;
-      const nextHasAccess = Boolean(currentUser && isClientAdmin(currentUser));
-      pendingUserKey = nextUserKey;
       pendingHasAccess = nextHasAccess;
-
-      if (!currentUser && hadAuthenticatedSession && authReady) {
-        clearTransientUnauthTimer();
-        transientUnauthTimer = setTimeout(() => {
-          if (!mounted) return;
-          if (buildUserKey(auth.currentUser)) return;
-          lastUserKey = null;
-          lastHasAccess = false;
-          pendingUserKey = null;
-          pendingHasAccess = false;
-          setUser(null);
-          setUserKey(null);
-          setHasAccess(false);
-          setChecking(false);
-          router.replace("/");
-        }, TRANSIENT_UNAUTH_GRACE_MS);
-        return;
-      }
-
-      if (currentUser) {
-        hadAuthenticatedSession = true;
-        clearTransientUnauthTimer();
-      }
-
-      if (nextUserKey !== prevUserKey) {
-        lastUserKey = nextUserKey;
-        setUser(currentUser);
-        setUserKey(nextUserKey);
-      }
-
       setHasAccess((previous) => (previous === nextHasAccess ? previous : nextHasAccess));
 
       finishCheckingIfReady();
@@ -235,7 +175,94 @@ export function useAdminGuard() {
       }
 
       lastHasAccess = nextHasAccess;
-    });
+    };
+
+    const handleAuthUser = (currentUser: User | null) => {
+      if (!mounted) return;
+
+      receivedAuthEmission = true;
+      const nextUserKey = buildUserKey(currentUser);
+      const prevUserKey = lastUserKey;
+      pendingUserKey = nextUserKey;
+
+      if (!currentUser) {
+        accessCheckId += 1;
+        accessCheckPending = false;
+        pendingHasAccess = false;
+
+        if (hadAuthenticatedSession && authReady) {
+          clearTransientUnauthTimer();
+          transientUnauthTimer = setTimeout(() => {
+            if (!mounted) return;
+            if (buildUserKey(auth.currentUser)) return;
+            accessCheckId += 1;
+            accessCheckPending = false;
+            lastUserKey = null;
+            lastHasAccess = false;
+            pendingUserKey = null;
+            pendingHasAccess = false;
+            setUser(null);
+            setUserKey(null);
+            setHasAccess(false);
+            setChecking(false);
+            router.replace("/");
+          }, TRANSIENT_UNAUTH_GRACE_MS);
+          return;
+        }
+
+        if (nextUserKey !== prevUserKey) {
+          lastUserKey = nextUserKey;
+          setUser(null);
+          setUserKey(null);
+        }
+        applyResolvedAccess(nextUserKey, prevUserKey, false);
+        return;
+      }
+
+      hadAuthenticatedSession = true;
+      clearTransientUnauthTimer();
+
+      if (nextUserKey !== prevUserKey) {
+        lastUserKey = nextUserKey;
+        setUser(currentUser);
+        setUserKey(nextUserKey);
+      }
+
+      const currentAccessCheckId = accessCheckId + 1;
+      accessCheckId = currentAccessCheckId;
+      accessCheckPending = true;
+      pendingHasAccess = false;
+      setChecking(true);
+
+      void checkServerAdminAccess(currentUser).then((nextHasAccess) => {
+        if (!mounted || accessCheckId !== currentAccessCheckId || pendingUserKey !== nextUserKey) {
+          return;
+        }
+        accessCheckPending = false;
+        applyResolvedAccess(nextUserKey, prevUserKey, nextHasAccess);
+      });
+    };
+
+    const markAuthReady = () => {
+      if (authReady) return;
+      authReady = true;
+      clearAuthReadyFallbackTimer();
+      if (!receivedAuthEmission) {
+        handleAuthUser(auth.currentUser);
+      }
+      finishCheckingIfReady();
+      evaluateInitialRedirect();
+    };
+
+    authReadyFallbackTimer = setTimeout(markAuthReady, getAdminAuthReadyTimeoutMs());
+    const authStateReady = (auth as { authStateReady?: () => Promise<void> }).authStateReady;
+    const authReadyPromise =
+      typeof authStateReady === "function"
+        ? Promise.resolve(authStateReady.call(auth)).catch(() => undefined)
+        : Promise.resolve();
+    void authReadyPromise.finally(markAuthReady);
+
+    const unsubscribe = auth.onAuthStateChanged(handleAuthUser);
 
     return () => {
       mounted = false;

--- a/apps/web/src/lib/admin/useAdminGuard.ts
+++ b/apps/web/src/lib/admin/useAdminGuard.ts
@@ -113,6 +113,7 @@ export function useAdminGuard() {
     let authReadyFallbackTimer: ReturnType<typeof setTimeout> | null = null;
     let accessCheckId = 0;
     let accessCheckPending = false;
+    let accessCheckUnavailable = false;
 
     const clearTransientUnauthTimer = () => {
       if (!transientUnauthTimer) return;
@@ -134,7 +135,14 @@ export function useAdminGuard() {
     };
 
     const evaluateInitialRedirect = () => {
-      if (!mounted || !authReady || !receivedAuthEmission || accessCheckPending || hasEvaluatedRedirect) {
+      if (
+        !mounted ||
+        !authReady ||
+        !receivedAuthEmission ||
+        accessCheckPending ||
+        accessCheckUnavailable ||
+        hasEvaluatedRedirect
+      ) {
         return;
       }
       hasEvaluatedRedirect = true;
@@ -188,6 +196,7 @@ export function useAdminGuard() {
       if (!currentUser) {
         accessCheckId += 1;
         accessCheckPending = false;
+        accessCheckUnavailable = false;
         pendingHasAccess = false;
 
         if (hadAuthenticatedSession && authReady) {
@@ -231,15 +240,21 @@ export function useAdminGuard() {
       const currentAccessCheckId = accessCheckId + 1;
       accessCheckId = currentAccessCheckId;
       accessCheckPending = true;
+      accessCheckUnavailable = false;
       pendingHasAccess = false;
       setChecking(true);
 
-      void checkServerAdminAccess(currentUser).then((nextHasAccess) => {
+      void checkServerAdminAccess(currentUser).then((result) => {
         if (!mounted || accessCheckId !== currentAccessCheckId || pendingUserKey !== nextUserKey) {
           return;
         }
         accessCheckPending = false;
-        applyResolvedAccess(nextUserKey, prevUserKey, nextHasAccess);
+        if (result === "unavailable") {
+          accessCheckUnavailable = true;
+          setChecking(false);
+          return;
+        }
+        applyResolvedAccess(nextUserKey, prevUserKey, result === "allowed");
       });
     };
 

--- a/apps/web/src/lib/server/admin/getty-local-scrape.ts
+++ b/apps/web/src/lib/server/admin/getty-local-scrape.ts
@@ -17,6 +17,13 @@ const normalizeGettyPrefetchToken = (token: string): string | null => {
   return GETTY_PREFETCH_TOKEN_RE.test(trimmed) ? trimmed : null;
 };
 
+export class InvalidGettyPrefetchTokenError extends Error {
+  constructor() {
+    super("getty_prefetch_token must be a UUID");
+    this.name = "InvalidGettyPrefetchTokenError";
+  }
+}
+
 export type GettyLocalScrapePayload = {
   person_name?: string;
   merged?: unknown[];
@@ -950,13 +957,11 @@ export const hydrateGettyPrefetchPayload = async (
   rawBody: string,
 ): Promise<string> => {
   const parsed = JSON.parse(rawBody) as Record<string, unknown>;
-  const prefetchToken =
-    typeof parsed.getty_prefetch_token === "string"
-      ? normalizeGettyPrefetchToken(parsed.getty_prefetch_token)
-      : null;
-  if (!prefetchToken) {
+  if (typeof parsed.getty_prefetch_token !== "string") {
     return rawBody;
   }
+  const prefetchToken = normalizeGettyPrefetchToken(parsed.getty_prefetch_token);
+  if (!prefetchToken) throw new InvalidGettyPrefetchTokenError();
   if (
     Array.isArray(parsed.getty_prefetched_assets) ||
     Array.isArray(parsed.getty_prefetched_events)

--- a/apps/web/src/lib/server/admin/getty-local-scrape.ts
+++ b/apps/web/src/lib/server/admin/getty-local-scrape.ts
@@ -8,6 +8,14 @@ const DEFAULT_GETTY_LOCAL_URL = "http://127.0.0.1:3456";
 const SCRAPE_TIMEOUT_MS = 600_000;
 const SUBPROCESS_MAX_BUFFER = 100 * 1024 * 1024;
 const GETTY_PREFETCH_TMP_DIR = path.join(os.tmpdir(), "trr-getty-prefetch");
+// Prefetch tokens are always randomUUID() values. Reject anything else so a
+// request-supplied token can never traverse out of GETTY_PREFETCH_TMP_DIR.
+const GETTY_PREFETCH_TOKEN_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const normalizeGettyPrefetchToken = (token: string): string | null => {
+  const trimmed = token.trim();
+  return GETTY_PREFETCH_TOKEN_RE.test(trimmed) ? trimmed : null;
+};
 
 export type GettyLocalScrapePayload = {
   person_name?: string;
@@ -708,7 +716,7 @@ export const storeGettyPrefetchPayload = async (
 export const readGettyPrefetchPayload = async (
   token: string
 ): Promise<GettyPrefetchState | null> => {
-  const normalizedToken = token.trim();
+  const normalizedToken = normalizeGettyPrefetchToken(token);
   if (!normalizedToken) return null;
   try {
     const raw = await readFile(path.join(GETTY_PREFETCH_TMP_DIR, `${normalizedToken}.json`), "utf8");
@@ -722,7 +730,7 @@ export const updateGettyPrefetchPayload = async (
   token: string,
   payload: GettyLocalScrapePayload
 ): Promise<GettyPrefetchState | null> => {
-  const normalizedToken = token.trim();
+  const normalizedToken = normalizeGettyPrefetchToken(token);
   if (!normalizedToken) return null;
   const existing = await readGettyPrefetchPayload(normalizedToken);
   if (!existing) return null;
@@ -766,9 +774,7 @@ export const createGettyPrefetchJob = async (
   await mkdir(GETTY_PREFETCH_TMP_DIR, { recursive: true });
   const mode = options?.mode === "full" ? "full" : "discovery";
   const requestedToken =
-    typeof options?.prefetchToken === "string" && options.prefetchToken.trim().length > 0
-      ? options.prefetchToken.trim()
-      : "";
+    typeof options?.prefetchToken === "string" ? normalizeGettyPrefetchToken(options.prefetchToken) : null;
   const token = requestedToken || randomUUID();
   const state = createGettyPrefetchJobState(token, personName.trim(), showName, mode);
   if (typeof options?.transportMode === "string" && options.transportMode.trim().length > 0) {
@@ -788,7 +794,7 @@ export const startGettyPrefetchJob = async (
   showName?: string | null,
   options?: { mode?: "discovery" | "full"; transportMode?: string | null }
 ): Promise<GettyPrefetchState> => {
-  const normalizedToken = token.trim();
+  const normalizedToken = normalizeGettyPrefetchToken(token);
   if (!normalizedToken) {
     throw new Error("Getty prefetch token is required.");
   }
@@ -923,7 +929,7 @@ export const getGettyRemoteReadiness = async (): Promise<GettyRemoteReadiness> =
 };
 
 export const deleteGettyPrefetchPayload = async (token: string): Promise<void> => {
-  const normalizedToken = token.trim();
+  const normalizedToken = normalizeGettyPrefetchToken(token);
   if (!normalizedToken) return;
   try {
     await rm(path.join(GETTY_PREFETCH_TMP_DIR, `${normalizedToken}.json`), { force: true });
@@ -946,8 +952,8 @@ export const hydrateGettyPrefetchPayload = async (
   const parsed = JSON.parse(rawBody) as Record<string, unknown>;
   const prefetchToken =
     typeof parsed.getty_prefetch_token === "string"
-      ? parsed.getty_prefetch_token.trim()
-      : "";
+      ? normalizeGettyPrefetchToken(parsed.getty_prefetch_token)
+      : null;
   if (!prefetchToken) {
     return rawBody;
   }

--- a/apps/web/src/lib/server/auth.ts
+++ b/apps/web/src/lib/server/auth.ts
@@ -15,7 +15,7 @@ import { dirname, resolve } from "node:path";
 import type { NextRequest } from "next/server";
 import type { DecodedIdToken } from "firebase-admin/auth";
 import { adminAuth } from "@/lib/firebaseAdmin";
-import { DEFAULT_ADMIN_DISPLAY_NAMES, DEFAULT_ADMIN_UIDS } from "@/lib/admin/constants";
+import { DEFAULT_ADMIN_DISPLAY_NAMES } from "@/lib/admin/constants";
 import { normalizeDisplayNameKey } from "@/lib/admin/display-names";
 import {
   isLoopbackAdminHost,
@@ -67,6 +67,7 @@ type SupabaseVerificationClient = {
 
 const DEV_ADMIN_BYPASS_UID = "dev-admin-bypass";
 const DEV_ADMIN_BYPASS_EMAIL = "codex@thereality.report";
+const DEFAULT_SERVER_ADMIN_UIDS = ["MyoUFNjl9VP5iVGBi7tVqxUb8np2"] as const;
 const DEFAULT_DEV_ADMIN_ALLOWED_HOSTS = ["admin.localhost", "localhost", "127.0.0.1", "[::1]", "::1"];
 const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
 const FIREBASE_AUTH_PROVIDER: AuthProvider = "firebase";
@@ -654,7 +655,7 @@ const allowedEmails = new Set<string>([
 ]);
 
 const allowedUids = new Set<string>([
-  ...DEFAULT_ADMIN_UIDS,
+  ...DEFAULT_SERVER_ADMIN_UIDS,
   ...parseAllowlist(process.env.ADMIN_UID_ALLOWLIST, false),
   ...parseAllowlist(process.env.NEXT_PUBLIC_ADMIN_UIDS, false),
 ]);

--- a/apps/web/src/lib/server/auth.ts
+++ b/apps/web/src/lib/server/auth.ts
@@ -657,7 +657,6 @@ const allowedEmails = new Set<string>([
 const allowedUids = new Set<string>([
   ...DEFAULT_SERVER_ADMIN_UIDS,
   ...parseAllowlist(process.env.ADMIN_UID_ALLOWLIST, false),
-  ...parseAllowlist(process.env.NEXT_PUBLIC_ADMIN_UIDS, false),
 ]);
 
 // Diagnostics/observability only — display names are NOT an authorization

--- a/apps/web/tests/admin-check-route.test.ts
+++ b/apps/web/tests/admin-check-route.test.ts
@@ -25,6 +25,7 @@ describe("/api/admin/check route", () => {
     const response = await GET(request);
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
     await expect(response.json()).resolves.toEqual({ hasAccess: true });
     expect(requireAdminMock).toHaveBeenCalledWith(request);
   });
@@ -38,6 +39,7 @@ describe("/api/admin/check route", () => {
     const response = await GET(request);
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
     await expect(response.json()).resolves.toEqual({ hasAccess: false });
   });
 });

--- a/apps/web/tests/admin-check-route.test.ts
+++ b/apps/web/tests/admin-check-route.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { requireAdminMock } = vi.hoisted(() => ({
+  requireAdminMock: vi.fn(),
+}));
+
+vi.mock("@/lib/server/auth", () => ({
+  requireAdmin: requireAdminMock,
+}));
+
+import { GET } from "@/app/api/admin/check/route";
+
+describe("/api/admin/check route", () => {
+  beforeEach(() => {
+    requireAdminMock.mockReset();
+  });
+
+  it("returns hasAccess true when server auth accepts the request", async () => {
+    requireAdminMock.mockResolvedValue({ uid: "admin-user" });
+
+    const request = new NextRequest("http://admin.localhost/api/admin/check", {
+      headers: { authorization: "Bearer client-id-token" },
+    });
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ hasAccess: true });
+    expect(requireAdminMock).toHaveBeenCalledWith(request);
+  });
+
+  it("returns hasAccess false when server auth rejects the request", async () => {
+    requireAdminMock.mockRejectedValue(new Error("forbidden"));
+
+    const request = new NextRequest("http://admin.localhost/api/admin/check", {
+      headers: { authorization: "Bearer non-admin-client-token" },
+    });
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ hasAccess: false });
+  });
+});

--- a/apps/web/tests/bravotv-image-routes.test.ts
+++ b/apps/web/tests/bravotv-image-routes.test.ts
@@ -11,9 +11,14 @@ const { getInternalAdminBearerTokenMock } = vi.hoisted(() => ({
 const { buildInternalAdminHeadersMock } = vi.hoisted(() => ({
   buildInternalAdminHeadersMock: vi.fn(),
 }));
-const { hydrateGettyPrefetchPayloadMock, cleanupStaleGettyPrefetchFilesMock } = vi.hoisted(() => ({
+const {
+  hydrateGettyPrefetchPayloadMock,
+  cleanupStaleGettyPrefetchFilesMock,
+  InvalidGettyPrefetchTokenError,
+} = vi.hoisted(() => ({
   hydrateGettyPrefetchPayloadMock: vi.fn(),
   cleanupStaleGettyPrefetchFilesMock: vi.fn(),
+  InvalidGettyPrefetchTokenError: class InvalidGettyPrefetchTokenError extends Error {},
 }));
 
 vi.mock("@/lib/server/auth", () => ({
@@ -32,6 +37,7 @@ vi.mock("@/lib/server/trr-api/internal-admin-auth", () => ({
 vi.mock("@/lib/server/admin/getty-local-scrape", () => ({
   hydrateGettyPrefetchPayload: hydrateGettyPrefetchPayloadMock,
   cleanupStaleGettyPrefetchFiles: cleanupStaleGettyPrefetchFilesMock,
+  InvalidGettyPrefetchTokenError,
 }));
 
 import { GET as getArtifactPreview } from "@/app/api/admin/trr-api/bravotv/images/runs/[runId]/artifacts/[...artifactName]/route";
@@ -240,6 +246,32 @@ describe("bravotv image admin proxy routes", () => {
         }),
       }),
     );
+  });
+
+  it.each([
+    ["person", startPersonStream, { personId: "person-1" }],
+    ["show", startShowStream, { showId: "show-1" }],
+  ] as const)("returns 400 for an invalid Getty token on %s streams", async (kind, handler, params) => {
+    hydrateGettyPrefetchPayloadMock.mockRejectedValue(
+      new InvalidGettyPrefetchTokenError("getty_prefetch_token must be a UUID"),
+    );
+    vi.stubGlobal("fetch", vi.fn());
+    const request = new NextRequest(
+      `http://localhost/api/admin/trr-api/bravotv/images/${kind === "person" ? "people/person-1" : "shows/show-1"}/stream`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ getty_prefetch_token: "bad/token" }),
+      },
+    );
+
+    const response = await handler(request, { params: Promise.resolve(params) } as never);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "getty_prefetch_token must be a UUID",
+    });
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it("joins artifact catch-all segments and preserves pagination query strings", async () => {

--- a/apps/web/tests/client-admin-access.test.ts
+++ b/apps/web/tests/client-admin-access.test.ts
@@ -111,4 +111,17 @@ describe("client admin access", () => {
     await expect(accessPromise).resolves.toBe(false);
     expect(observedSignal?.aborted).toBe(true);
   });
+
+  it("works without a browser window global", async () => {
+    vi.stubGlobal("window", undefined);
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ hasAccess: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const { checkServerAdminAccess } = await import("@/lib/admin/client-access");
+
+    await expect(checkServerAdminAccess(buildUser({ uid: "user-1" }))).resolves.toBe(true);
+  });
 });

--- a/apps/web/tests/client-admin-access.test.ts
+++ b/apps/web/tests/client-admin-access.test.ts
@@ -63,7 +63,7 @@ describe("client admin access", () => {
     const user = buildUser({ uid: "user-1" });
     const { checkServerAdminAccess } = await import("@/lib/admin/client-access");
 
-    await expect(checkServerAdminAccess(user)).resolves.toBe(true);
+    await expect(checkServerAdminAccess(user)).resolves.toBe("allowed");
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/admin/check",
@@ -90,7 +90,7 @@ describe("client admin access", () => {
       checkServerAdminAccess(
         buildUser({ uid: "seeded-admin-uid", email: "admin@example.com", emailVerified: true }),
       ),
-    ).resolves.toBe(false);
+    ).resolves.toBe("denied");
   });
 
   it("aborts a hung server check and fails closed", async () => {
@@ -108,7 +108,7 @@ describe("client admin access", () => {
     const accessPromise = checkServerAdminAccess(buildUser({ uid: "user-1" }));
     await vi.advanceTimersByTimeAsync(5000);
 
-    await expect(accessPromise).resolves.toBe(false);
+    await expect(accessPromise).resolves.toBe("unavailable");
     expect(observedSignal?.aborted).toBe(true);
   });
 
@@ -122,6 +122,27 @@ describe("client admin access", () => {
     );
     const { checkServerAdminAccess } = await import("@/lib/admin/client-access");
 
-    await expect(checkServerAdminAccess(buildUser({ uid: "user-1" }))).resolves.toBe(true);
+    await expect(checkServerAdminAccess(buildUser({ uid: "user-1" }))).resolves.toBe("allowed");
+  });
+
+  it("bounds token acquisition with the same deadline and does not fetch after timeout", async () => {
+    vi.useFakeTimers();
+    const user = buildUser({ getIdToken: vi.fn(() => new Promise<string>(() => {})) });
+    const { checkServerAdminAccess } = await import("@/lib/admin/client-access");
+
+    const accessPromise = checkServerAdminAccess(user);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    await expect(accessPromise).resolves.toBe("unavailable");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("reports network and malformed-response failures as unavailable", async () => {
+    const { checkServerAdminAccess } = await import("@/lib/admin/client-access");
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("offline"));
+    await expect(checkServerAdminAccess(buildUser({}))).resolves.toBe("unavailable");
+
+    vi.mocked(fetch).mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    await expect(checkServerAdminAccess(buildUser({}))).resolves.toBe("unavailable");
   });
 });

--- a/apps/web/tests/client-admin-access.test.ts
+++ b/apps/web/tests/client-admin-access.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { User } from "firebase/auth";
 
 function buildUser(overrides: Partial<User>): User {
@@ -16,7 +16,7 @@ function buildUser(overrides: Partial<User>): User {
     refreshToken: "refresh-token",
     tenantId: null,
     delete: vi.fn(),
-    getIdToken: vi.fn(),
+    getIdToken: vi.fn().mockResolvedValue("client-id-token"),
     getIdTokenResult: vi.fn(),
     reload: vi.fn(),
     toJSON: vi.fn(),
@@ -30,38 +30,85 @@ describe("client admin access", () => {
     delete process.env.NEXT_PUBLIC_ADMIN_EMAILS;
     delete process.env.NEXT_PUBLIC_ADMIN_UIDS;
     delete process.env.NEXT_PUBLIC_ADMIN_DISPLAY_NAMES;
+    vi.stubGlobal("fetch", vi.fn());
   });
 
-  it("no longer treats a seeded admin display name as admin-capable", async () => {
-    const { isClientAdmin } = await import("@/lib/admin/client-access");
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
 
-    // Display name is attacker-controllable, so it must never grant admin.
+  it("does not grant admin access from client-visible identity fields", async () => {
+    process.env.NEXT_PUBLIC_ADMIN_EMAILS = "admin@example.com";
+    process.env.NEXT_PUBLIC_ADMIN_UIDS = "seeded-admin-uid";
+    const { getAllowedAdminEmails, getAllowedAdminUids, isClientAdmin } = await import("@/lib/admin/client-access");
+
+    expect(isClientAdmin(buildUser({ uid: "seeded-admin-uid" }))).toBe(false);
+    expect(isClientAdmin(buildUser({ email: "admin@example.com", emailVerified: true }))).toBe(false);
     expect(isClientAdmin(buildUser({ displayName: "Codex Huli" }))).toBe(false);
     expect(isClientAdmin(buildUser({ displayName: "@codex_huli" }))).toBe(false);
     expect(isClientAdmin(buildUser({ displayName: "codex_huli" }))).toBe(false);
+    expect(getAllowedAdminEmails()).toEqual([]);
+    expect(getAllowedAdminUids()).toEqual([]);
   });
 
-  it("treats the seeded admin uid as admin-capable", async () => {
-    const { isClientAdmin } = await import("@/lib/admin/client-access");
+  it("returns true only when the server check returns a positive response", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ hasAccess: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const user = buildUser({ uid: "user-1" });
+    const { checkServerAdminAccess } = await import("@/lib/admin/client-access");
 
-    expect(isClientAdmin(buildUser({ uid: "MyoUFNjl9VP5iVGBi7tVqxUb8np2" }))).toBe(true);
+    await expect(checkServerAdminAccess(user)).resolves.toBe(true);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/admin/check",
+      expect.objectContaining({
+        method: "GET",
+        credentials: "same-origin",
+        cache: "no-store",
+      }),
+    );
+    const headers = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+    expect(headers.get("authorization")).toBe("Bearer client-id-token");
   });
 
-  it("treats an allowlisted verified email as admin-capable", async () => {
-    process.env.NEXT_PUBLIC_ADMIN_EMAILS = "admin@example.com";
-    const { isClientAdmin } = await import("@/lib/admin/client-access");
+  it("returns false when the server check rejects the user", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ hasAccess: false }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const { checkServerAdminAccess } = await import("@/lib/admin/client-access");
 
-    expect(
-      isClientAdmin(buildUser({ uid: "non-admin-uid", email: "admin@example.com", emailVerified: true })),
-    ).toBe(true);
+    await expect(
+      checkServerAdminAccess(
+        buildUser({ uid: "seeded-admin-uid", email: "admin@example.com", emailVerified: true }),
+      ),
+    ).resolves.toBe(false);
   });
 
-  it("rejects an allowlisted email that is not verified", async () => {
-    process.env.NEXT_PUBLIC_ADMIN_EMAILS = "admin@example.com";
-    const { isClientAdmin } = await import("@/lib/admin/client-access");
+  it("aborts a hung server check and fails closed", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.mocked(fetch);
+    let observedSignal: AbortSignal | undefined;
+    fetchMock.mockImplementation((_, init) => {
+      observedSignal = init?.signal as AbortSignal | undefined;
+      return new Promise<Response>((_, reject) => {
+        observedSignal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+      });
+    });
+    const { checkServerAdminAccess } = await import("@/lib/admin/client-access");
 
-    expect(
-      isClientAdmin(buildUser({ uid: "non-admin-uid", email: "admin@example.com", emailVerified: false })),
-    ).toBe(false);
+    const accessPromise = checkServerAdminAccess(buildUser({ uid: "user-1" }));
+    await vi.advanceTimersByTimeAsync(5000);
+
+    await expect(accessPromise).resolves.toBe(false);
+    expect(observedSignal?.aborted).toBe(true);
   });
 });

--- a/apps/web/tests/debug-log-route.test.ts
+++ b/apps/web/tests/debug-log-route.test.ts
@@ -207,6 +207,21 @@ describe("/api/debug-log route", () => {
     expect(requireAdminMock).not.toHaveBeenCalled();
   });
 
+  it("stops reading an oversized chunked body without a content-length header", async () => {
+    const request = new NextRequest("http://localhost/api/debug-log", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message: "x".repeat(70 * 1024) }),
+    });
+    expect(request.headers.get("content-length")).toBeNull();
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({ error: "payload_too_large" });
+    expect(requireAdminMock).not.toHaveBeenCalled();
+  });
+
   it("returns 400 for malformed JSON before auth", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const request = new NextRequest("http://localhost/api/debug-log", {

--- a/apps/web/tests/debug-log-route.test.ts
+++ b/apps/web/tests/debug-log-route.test.ts
@@ -162,4 +162,48 @@ describe("/api/debug-log route", () => {
 
     logSpy.mockRestore();
   });
+
+  it("rejects an invalid same-length shared secret and falls back to admin auth", async () => {
+    process.env.TRR_INTERNAL_ADMIN_SHARED_SECRET = "shared-secret-value";
+    process.env.TRR_DEBUG_LOG_SHARED_SECRET_ENABLED = "true";
+    requireAdminMock.mockRejectedValue(new Error("forbidden"));
+
+    const request = new NextRequest("http://localhost/api/debug-log", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-trr-internal-admin-secret": "shared-secret-wrong",
+      },
+      body: JSON.stringify({ message: "wrong shared secret" }),
+    });
+
+    const response = await POST(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(payload).toEqual({ error: "forbidden" });
+    expect(requireAdminMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects oversized bodies before auth or JSON parsing", async () => {
+    process.env.TRR_INTERNAL_ADMIN_SHARED_SECRET = "shared-secret-value";
+    process.env.TRR_DEBUG_LOG_SHARED_SECRET_ENABLED = "true";
+
+    const request = new NextRequest("http://localhost/api/debug-log", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": String(70 * 1024),
+        "x-trr-internal-admin-secret": "shared-secret-value",
+      },
+      body: JSON.stringify({ message: "oversized debug payload" }),
+    });
+
+    const response = await POST(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(413);
+    expect(payload).toEqual({ error: "payload_too_large" });
+    expect(requireAdminMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/tests/debug-log-route.test.ts
+++ b/apps/web/tests/debug-log-route.test.ts
@@ -206,4 +206,21 @@ describe("/api/debug-log route", () => {
     expect(payload).toEqual({ error: "payload_too_large" });
     expect(requireAdminMock).not.toHaveBeenCalled();
   });
+
+  it("returns 400 for malformed JSON before auth", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const request = new NextRequest("http://localhost/api/debug-log", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{not-json",
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "invalid_json" });
+    expect(requireAdminMock).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
 });

--- a/apps/web/tests/design-system-typography-routes.test.ts
+++ b/apps/web/tests/design-system-typography-routes.test.ts
@@ -10,6 +10,8 @@ const {
   updateTypographySetMock,
   deleteTypographySetMock,
   upsertTypographyAssignmentMock,
+  resolvePostgresConnectionCandidatesMock,
+  buildTypographyStateSnapshotMock,
 } = vi.hoisted(() => ({
   requireAdminMock: vi.fn(),
   getTypographyStateMock: vi.fn(),
@@ -17,6 +19,8 @@ const {
   updateTypographySetMock: vi.fn(),
   deleteTypographySetMock: vi.fn(),
   upsertTypographyAssignmentMock: vi.fn(),
+  resolvePostgresConnectionCandidatesMock: vi.fn(),
+  buildTypographyStateSnapshotMock: vi.fn(),
 }));
 
 vi.mock("@/lib/server/auth", () => ({
@@ -29,6 +33,14 @@ vi.mock("@/lib/server/admin/typography-repository", () => ({
   updateTypographySet: updateTypographySetMock,
   deleteTypographySet: deleteTypographySetMock,
   upsertTypographyAssignment: upsertTypographyAssignmentMock,
+}));
+
+vi.mock("@/lib/server/postgres", () => ({
+  resolvePostgresConnectionCandidates: resolvePostgresConnectionCandidatesMock,
+}));
+
+vi.mock("@/lib/server/admin/typography-seed", () => ({
+  buildTypographyStateSnapshot: buildTypographyStateSnapshotMock,
 }));
 
 import { GET as getTypography } from "@/app/api/admin/design-system/typography/route";
@@ -49,7 +61,11 @@ describe("design system typography routes", () => {
     updateTypographySetMock.mockReset();
     deleteTypographySetMock.mockReset();
     upsertTypographyAssignmentMock.mockReset();
+    resolvePostgresConnectionCandidatesMock.mockReset();
+    buildTypographyStateSnapshotMock.mockReset();
     requireAdminMock.mockResolvedValue({ uid: "admin-user" });
+    resolvePostgresConnectionCandidatesMock.mockReturnValue(["configured"]);
+    buildTypographyStateSnapshotMock.mockReturnValue({ sets: [], assignments: [] });
   });
 
   it("returns typography state", async () => {
@@ -73,6 +89,25 @@ describe("design system typography routes", () => {
     expect(payload).toEqual({ sets: [], assignments: [] });
     expect(requireAdminMock).not.toHaveBeenCalled();
     expect(getTypographyStateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns seeded public typography without the repository when no runtime database is configured", async () => {
+    resolvePostgresConnectionCandidatesMock.mockReturnValue([]);
+    buildTypographyStateSnapshotMock.mockReturnValue({
+      sets: [{ id: "seeded-set" }],
+      assignments: [{ id: "seeded-assignment" }],
+    });
+
+    const response = await getPublicTypography();
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({
+      sets: [{ id: "seeded-set" }],
+      assignments: [{ id: "seeded-assignment" }],
+    });
+    expect(requireAdminMock).not.toHaveBeenCalled();
+    expect(getTypographyStateMock).not.toHaveBeenCalled();
   });
 
   it("caches admin and public typography GET responses", async () => {

--- a/apps/web/tests/getty-prefetch-token.test.ts
+++ b/apps/web/tests/getty-prefetch-token.test.ts
@@ -1,0 +1,108 @@
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createGettyPrefetchJob,
+  hydrateGettyPrefetchPayload,
+  readGettyPrefetchPayload,
+} from "@/lib/server/admin/getty-local-scrape";
+
+const {
+  accessMock,
+  mkdirMock,
+  readFileMock,
+  rmMock,
+  writeFileMock,
+} = vi.hoisted(() => ({
+  accessMock: vi.fn(),
+  mkdirMock: vi.fn(),
+  readFileMock: vi.fn(),
+  rmMock: vi.fn(),
+  writeFileMock: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  access: accessMock,
+  default: {
+    access: accessMock,
+    mkdir: mkdirMock,
+    readFile: readFileMock,
+    rm: rmMock,
+    writeFile: writeFileMock,
+  },
+  mkdir: mkdirMock,
+  readFile: readFileMock,
+  rm: rmMock,
+  writeFile: writeFileMock,
+}));
+
+const GETTY_PREFETCH_TOKEN_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const GETTY_PREFETCH_TMP_DIR = path.join(os.tmpdir(), "trr-getty-prefetch");
+const VALID_TOKEN = "123e4567-e89b-12d3-a456-426614174000";
+
+describe("Getty prefetch token validation", () => {
+  beforeEach(() => {
+    accessMock.mockReset();
+    mkdirMock.mockReset();
+    readFileMock.mockReset();
+    rmMock.mockReset();
+    writeFileMock.mockReset();
+    mkdirMock.mockResolvedValue(undefined);
+    writeFileMock.mockResolvedValue(undefined);
+  });
+
+  it("rejects traversal tokens before reading from disk", async () => {
+    await expect(readGettyPrefetchPayload("../../evil")).resolves.toBeNull();
+
+    expect(readFileMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-UUID tokens before reading from disk", async () => {
+    await expect(readGettyPrefetchPayload("not-a-uuid")).resolves.toBeNull();
+
+    expect(readFileMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid UUID tokens when reading payloads", async () => {
+    const storedPayload = {
+      person_name: "Jane Doe",
+      revision: 3,
+      status: "completed",
+    };
+    readFileMock.mockResolvedValue(JSON.stringify(storedPayload));
+
+    await expect(readGettyPrefetchPayload(VALID_TOKEN)).resolves.toEqual(storedPayload);
+
+    expect(readFileMock).toHaveBeenCalledWith(
+      path.join(GETTY_PREFETCH_TMP_DIR, `${VALID_TOKEN}.json`),
+      "utf8",
+    );
+  });
+
+  it("falls back to a fresh UUID for invalid requested job tokens", async () => {
+    const result = await createGettyPrefetchJob("Jane Doe", null, {
+      prefetchToken: "../evil",
+    });
+
+    expect(result.token).toMatch(GETTY_PREFETCH_TOKEN_RE);
+    expect(result.token).not.toBe("../evil");
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    const writePath = writeFileMock.mock.calls[0]?.[0];
+    expect(typeof writePath).toBe("string");
+    const writePathString = String(writePath);
+    expect(writePathString).not.toContain("..");
+    expect(path.dirname(writePathString)).toBe(GETTY_PREFETCH_TMP_DIR);
+    expect(writePathString).toBe(
+      path.join(GETTY_PREFETCH_TMP_DIR, `${result.token}.json`),
+    );
+  });
+
+  it("short-circuits invalid body tokens during hydration", async () => {
+    const rawBody = JSON.stringify({ getty_prefetch_token: "a/b" });
+
+    await expect(hydrateGettyPrefetchPayload(rawBody)).resolves.toBe(rawBody);
+
+    expect(readFileMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/getty-prefetch-token.test.ts
+++ b/apps/web/tests/getty-prefetch-token.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createGettyPrefetchJob,
   hydrateGettyPrefetchPayload,
+  InvalidGettyPrefetchTokenError,
   readGettyPrefetchPayload,
 } from "@/lib/server/admin/getty-local-scrape";
 
@@ -101,7 +102,9 @@ describe("Getty prefetch token validation", () => {
   it("short-circuits invalid body tokens during hydration", async () => {
     const rawBody = JSON.stringify({ getty_prefetch_token: "a/b" });
 
-    await expect(hydrateGettyPrefetchPayload(rawBody)).resolves.toBe(rawBody);
+    await expect(hydrateGettyPrefetchPayload(rawBody)).rejects.toBeInstanceOf(
+      InvalidGettyPrefetchTokenError,
+    );
 
     expect(readFileMock).not.toHaveBeenCalled();
   });

--- a/apps/web/tests/person-refresh-images-stream-route.test.ts
+++ b/apps/web/tests/person-refresh-images-stream-route.test.ts
@@ -5,9 +5,14 @@ const { requireAdminMock, getBackendApiUrlMock } = vi.hoisted(() => ({
   requireAdminMock: vi.fn(),
   getBackendApiUrlMock: vi.fn(),
 }));
-const { hydrateGettyPrefetchPayloadMock, cleanupStaleGettyPrefetchFilesMock } = vi.hoisted(() => ({
+const {
+  hydrateGettyPrefetchPayloadMock,
+  cleanupStaleGettyPrefetchFilesMock,
+  InvalidGettyPrefetchTokenError,
+} = vi.hoisted(() => ({
   hydrateGettyPrefetchPayloadMock: vi.fn(),
   cleanupStaleGettyPrefetchFilesMock: vi.fn(),
+  InvalidGettyPrefetchTokenError: class InvalidGettyPrefetchTokenError extends Error {},
 }));
 
 vi.mock("@/lib/server/auth", () => ({
@@ -21,6 +26,7 @@ vi.mock("@/lib/server/trr-api/backend", () => ({
 vi.mock("@/lib/server/admin/getty-local-scrape", () => ({
   hydrateGettyPrefetchPayload: hydrateGettyPrefetchPayloadMock,
   cleanupStaleGettyPrefetchFiles: cleanupStaleGettyPrefetchFilesMock,
+  InvalidGettyPrefetchTokenError,
 }));
 
 import { POST } from "@/app/api/admin/trr-api/people/[personId]/refresh-images/stream/route";
@@ -294,6 +300,23 @@ describe("person refresh-images stream proxy route", () => {
     expect((forwarded.getty_prefetched_events as unknown[]).length).toBe(1);
     expect(forwarded.getty_prefetch_token).toBeUndefined();
     expect(hydrateGettyPrefetchPayloadMock).toHaveBeenCalled();
+  });
+
+  it("returns 400 without contacting the backend for an invalid Getty token", async () => {
+    hydrateGettyPrefetchPayloadMock.mockRejectedValue(
+      new InvalidGettyPrefetchTokenError("getty_prefetch_token must be a UUID"),
+    );
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST(
+      makeRequest("req-invalid-getty-token", { getty_prefetch_token: "bad/token" }),
+      { params: Promise.resolve({ personId: "person-1" }) },
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("getty_prefetch_token must be a UUID");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("hydrates discovery manifests via the shared hydration helper", async () => {

--- a/apps/web/tests/server-auth-adapter.test.ts
+++ b/apps/web/tests/server-auth-adapter.test.ts
@@ -61,6 +61,8 @@ describe("server auth adapter", () => {
     process.env.NEXT_PUBLIC_USE_FIREBASE_EMULATORS = "true";
     process.env.NEXT_PUBLIC_FIREBASE_API_KEY = "";
     process.env.ADMIN_EMAIL_ALLOWLIST = "";
+    delete process.env.ADMIN_UID_ALLOWLIST;
+    delete process.env.NEXT_PUBLIC_ADMIN_UIDS;
     process.env.TRR_CORE_SUPABASE_URL = "https://example.supabase.co";
     process.env.TRR_CORE_SUPABASE_SERVICE_ROLE_KEY = "service-role";
     process.env.ADMIN_APP_HOSTS = "localhost,127.0.0.1";
@@ -674,6 +676,24 @@ describe("server auth adapter", () => {
       uid: "MyoUFNjl9VP5iVGBi7tVqxUb8np2",
       provider: "firebase",
     });
+  });
+
+  it("does not authorize a uid configured only in client-visible environment", async () => {
+    delete process.env.ADMIN_APP_HOSTS;
+    process.env.NEXT_PUBLIC_ADMIN_UIDS = "public-only-admin";
+    verifyIdTokenMock.mockResolvedValue({
+      uid: "public-only-admin",
+      email: "unverified@example.com",
+      email_verified: false,
+    });
+
+    const auth = await import("@/lib/server/auth");
+
+    await expect(
+      auth.requireAdmin(
+        requestWithBearerAt("https://trr-app.vercel.app/api/test", "token-public-uid"),
+      ),
+    ).rejects.toThrow("forbidden");
   });
 
   it("never honors the dev admin bypass on production deployments (VERCEL_ENV=production)", async () => {

--- a/apps/web/tests/use-admin-guard-stability.test.tsx
+++ b/apps/web/tests/use-admin-guard-stability.test.tsx
@@ -13,7 +13,7 @@ const mocks = vi.hoisted(() => {
   return {
     router,
     replace: router.replace,
-    isClientAdmin: vi.fn(() => true),
+    checkServerAdminAccess: vi.fn(() => Promise.resolve(true)),
     isDevAdminBypassEnabledClient: vi.fn(() => false),
     isLocalDevHostname: vi.fn(() => false),
     getCurrentUser: () => currentUser,
@@ -48,8 +48,8 @@ const mocks = vi.hoisted(() => {
       readyResolver = null;
       currentUser = null;
       this.replace.mockReset();
-      this.isClientAdmin.mockReset();
-      this.isClientAdmin.mockReturnValue(true);
+      this.checkServerAdminAccess.mockReset();
+      this.checkServerAdminAccess.mockResolvedValue(true);
       this.isDevAdminBypassEnabledClient.mockReset();
       this.isDevAdminBypassEnabledClient.mockReturnValue(false);
       this.isLocalDevHostname.mockReset();
@@ -78,8 +78,8 @@ vi.mock("@/lib/firebase", () => ({
 }));
 
 vi.mock("@/lib/admin/client-access", () => ({
-  isClientAdmin: (...args: unknown[]) =>
-    (mocks.isClientAdmin as (...inner: unknown[]) => unknown)(...args),
+  checkServerAdminAccess: (...args: unknown[]) =>
+    (mocks.checkServerAdminAccess as (...inner: unknown[]) => unknown)(...args),
 }));
 
 vi.mock("@/lib/admin/dev-admin-bypass", () => ({
@@ -213,7 +213,7 @@ describe("useAdminGuard stability", () => {
   });
 
   it("redirects non-admin authenticated users to /hub", async () => {
-    mocks.isClientAdmin.mockReturnValue(false);
+    mocks.checkServerAdminAccess.mockResolvedValue(false);
     render(<GuardObserver onUserKey={() => undefined} />);
 
     await act(async () => {
@@ -228,7 +228,7 @@ describe("useAdminGuard stability", () => {
   });
 
   it("does not redirect valid admin users", async () => {
-    mocks.isClientAdmin.mockReturnValue(true);
+    mocks.checkServerAdminAccess.mockResolvedValue(true);
     render(<GuardObserver onUserKey={() => undefined} />);
 
     await act(async () => {

--- a/apps/web/tests/use-admin-guard-stability.test.tsx
+++ b/apps/web/tests/use-admin-guard-stability.test.tsx
@@ -13,7 +13,7 @@ const mocks = vi.hoisted(() => {
   return {
     router,
     replace: router.replace,
-    checkServerAdminAccess: vi.fn(() => Promise.resolve(true)),
+    checkServerAdminAccess: vi.fn(() => Promise.resolve("allowed")),
     isDevAdminBypassEnabledClient: vi.fn(() => false),
     isLocalDevHostname: vi.fn(() => false),
     getCurrentUser: () => currentUser,
@@ -49,7 +49,7 @@ const mocks = vi.hoisted(() => {
       currentUser = null;
       this.replace.mockReset();
       this.checkServerAdminAccess.mockReset();
-      this.checkServerAdminAccess.mockResolvedValue(true);
+      this.checkServerAdminAccess.mockResolvedValue("allowed");
       this.isDevAdminBypassEnabledClient.mockReset();
       this.isDevAdminBypassEnabledClient.mockReturnValue(false);
       this.isLocalDevHostname.mockReset();
@@ -213,7 +213,7 @@ describe("useAdminGuard stability", () => {
   });
 
   it("redirects non-admin authenticated users to /hub", async () => {
-    mocks.checkServerAdminAccess.mockResolvedValue(false);
+    mocks.checkServerAdminAccess.mockResolvedValue("denied");
     render(<GuardObserver onUserKey={() => undefined} />);
 
     await act(async () => {
@@ -228,7 +228,7 @@ describe("useAdminGuard stability", () => {
   });
 
   it("does not redirect valid admin users", async () => {
-    mocks.checkServerAdminAccess.mockResolvedValue(true);
+    mocks.checkServerAdminAccess.mockResolvedValue("allowed");
     render(<GuardObserver onUserKey={() => undefined} />);
 
     await act(async () => {
@@ -239,6 +239,21 @@ describe("useAdminGuard stability", () => {
     await waitFor(() => {
       expect(screen.getByTestId("guard-state")).toHaveAttribute("data-checking", "0");
       expect(screen.getByTestId("guard-state")).toHaveAttribute("data-access", "1");
+    });
+    expect(mocks.replace).not.toHaveBeenCalled();
+  });
+
+  it("does not redirect an authenticated user when the server check is unavailable", async () => {
+    mocks.checkServerAdminAccess.mockResolvedValue("unavailable");
+    render(<GuardObserver onUserKey={() => undefined} />);
+
+    await act(async () => {
+      mocks.emit({ uid: "u-unavailable", email: "admin@example.com", displayName: "Admin User" });
+      mocks.resolveAuthReady();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("guard-state")).toHaveAttribute("data-checking", "0");
     });
     expect(mocks.replace).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- add a server-authoritative admin check route and guard flow
- enforce server-only admin UID policy
- harden debug-log secret comparison and payload size
- protect Getty prefetch tokens and paths

## Validation
- 41 targeted Vitest tests passed
- git diff check passed

Foundation of the app recovery stack.