### PR TITLE
Move social landing and completion reads behind backend APIs

### DIFF
--- a/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/completion-summary/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/completion-summary/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireAdmin } from "@/lib/server/auth";
+import { requireAdmin, toVerifiedAdminContext } from "@/lib/server/auth";
+import { attachAdminRouteTiming } from "@/lib/server/admin/admin-route-timing";
 import {
   buildUserScopedRouteCacheKey,
   getOrCreateRouteResponsePromise,
@@ -8,29 +9,15 @@ import {
   parseCacheTtlMs,
   setRouteResponseCache,
 } from "@/lib/server/admin/route-response-cache";
-import { query } from "@/lib/server/postgres";
-import { socialProxyErrorResponse } from "@/lib/server/trr-api/social-admin-proxy";
+import {
+  fetchSocialBackendJson,
+  socialProxyErrorResponse,
+} from "@/lib/server/trr-api/social-admin-proxy";
 
 export const dynamic = "force-dynamic";
 
 type RouteContext = {
   params: Promise<{ platform: string; handle: string }>;
-};
-
-type CompletionRow = {
-  total_posts: number | string | null;
-  total_reported_comments: number | string | null;
-  saved_comments: number | string | null;
-  missing_comments: number | string | null;
-  accounted_comments: number | string | null;
-  comments_finished: number | string | null;
-  comments_in_progress: number | string | null;
-  comments_not_started: number | string | null;
-  details_finished: number | string | null;
-  details_not_started: number | string | null;
-  media_finished: number | string | null;
-  media_in_progress: number | string | null;
-  media_not_started: number | string | null;
 };
 
 const COMPLETION_SUMMARY_CACHE_NAMESPACE = "social-account-profile-completion-summary";
@@ -42,11 +29,10 @@ const COMPLETION_SUMMARY_STALE_CACHE_TTL_MS = parseCacheTtlMs(
   process.env.TRR_ADMIN_SOCIAL_PROFILE_COMPLETION_SUMMARY_STALE_CACHE_TTL_MS,
   10 * 60_000,
 );
-
-const readCount = (value: number | string | null | undefined): number => {
-  const parsed = Number(value ?? 0);
-  return Number.isFinite(parsed) ? parsed : 0;
-};
+const COMPLETION_SUMMARY_BACKEND_TIMEOUT_MS = parseCacheTtlMs(
+  process.env.TRR_ADMIN_SOCIAL_PROFILE_COMPLETION_SUMMARY_BACKEND_TIMEOUT_MS,
+  30_000,
+);
 
 const getDefaultYear = (): number => new Date().getUTCFullYear();
 
@@ -56,310 +42,125 @@ const readYear = (request: NextRequest): number => {
   return Number.isInteger(parsed) && parsed >= 2000 && parsed <= 2100 ? parsed : fallbackYear;
 };
 
-const sqlJsonTextNonNegativeInt = (expr: string): string =>
-  `coalesce(nullif(regexp_replace(coalesce(${expr}, ''), '[^0-9]', '', 'g'), '')::bigint, 0)`;
-
-const instagramRawReportedCommentsSql = (alias: string): string => {
-  const safeAlias = alias.trim() || "p";
-  const raw = `coalesce(${safeAlias}.raw_data, '{}'::jsonb)`;
-  return `greatest(${[
-    `${raw} ->> 'comments_count'`,
-    `${raw} ->> 'comments'`,
-    `${raw} ->> 'comment_count'`,
-    `${raw} ->> 'commentsCount'`,
-    `${raw} -> 'edge_media_to_comment' ->> 'count'`,
-    `${raw} -> 'edge_media_to_parent_comment' ->> 'count'`,
-    `${raw} -> 'edge_media_preview_comment' ->> 'count'`,
-    `${raw} -> 'media' ->> 'comments_count'`,
-    `${raw} -> 'media' ->> 'comments'`,
-    `${raw} -> 'media' ->> 'comment_count'`,
-    `${raw} -> 'media' ->> 'commentsCount'`,
-    `${raw} -> 'metrics' ->> 'comments_count'`,
-    `${raw} -> 'metrics' ->> 'comments'`,
-  ]
-    .map(sqlJsonTextNonNegativeInt)
-    .join(", ")}, 0)`;
-};
-
 export async function GET(request: NextRequest, context: RouteContext) {
+  const routeStartedAt = performance.now();
+  let cacheStatus = "error";
+  let backendMs: number | null = null;
   try {
     const user = await requireAdmin(request);
+    const adminContext = toVerifiedAdminContext(user);
     const { platform, handle } = await context.params;
     const normalizedPlatform = platform.trim().toLowerCase();
     const normalizedHandle = handle.trim().toLowerCase().replace(/^@/, "");
     if (normalizedPlatform !== "instagram" || !normalizedHandle) {
-      return NextResponse.json({ error: "unsupported_profile" }, { status: 400 });
+      cacheStatus = "bypass";
+      return attachAdminRouteTiming(
+        NextResponse.json({ error: "unsupported_profile" }, { status: 400 }),
+        {
+          routeFamily: "admin-social-profile",
+          routeName: "GET completion-summary",
+          cacheStatus,
+          startedAt: routeStartedAt,
+        },
+      );
     }
+
     const year = readYear(request);
     const cacheKey = buildUserScopedRouteCacheKey(
-      String(user?.uid ?? "admin"),
+      user.uid,
       `${normalizedPlatform}:${normalizedHandle}:completion-summary`,
       new URLSearchParams([["year", String(year)]]),
     );
-    const cached = getRouteResponseCache(COMPLETION_SUMMARY_CACHE_NAMESPACE, cacheKey);
-    if (cached) {
-      return NextResponse.json(cached, { headers: { "x-trr-cache": "hit" } });
-    }
-    const stale = getStaleRouteResponseCache(COMPLETION_SUMMARY_CACHE_NAMESPACE, cacheKey);
-    const loadPayload = async () => {
-    const instagramPostReportedCommentsSql = instagramRawReportedCommentsSql("p");
-    const result = await query<CompletionRow>(
-      `
-      with target as (
-        select
-          $1::text as handle,
-          make_timestamptz($2, 1, 1, 0, 0, 0) as start_at,
-          make_timestamptz($2 + 1, 1, 1, 0, 0, 0) as end_at
-      ),
-      catalog_candidates as materialized (
-        select
-          cp.source_id as shortcode,
-          cp.posted_at,
-          coalesce(cp.comments_count, 0)::bigint as catalog_comments_count
-        from social.instagram_account_catalog_posts cp
-        cross join target t
-        where cp.posted_at >= t.start_at
-          and cp.posted_at < t.end_at
-          and nullif(cp.source_id, '') is not null
-          and (
-            nullif(regexp_replace(lower(regexp_replace(coalesce(cp.source_account, ''), '^@+', '')), '[^a-z0-9._-]+', '', 'g'), '') = t.handle
-            or nullif(regexp_replace(lower(regexp_replace(coalesce(cp.owner_username, ''), '^@+', '')), '[^a-z0-9._-]+', '', 'g'), '') = t.handle
-            or nullif(
-              regexp_replace(
-                lower(
-                  regexp_replace(
-                    coalesce(
-                      cp.raw_data ->> 'username',
-                      cp.raw_data ->> 'ownerUsername',
-                      cp.raw_data -> 'owner' ->> 'username',
-                      cp.raw_data -> 'user' ->> 'username',
-                      ''
-                    ),
-                    '^@+',
-                    ''
-                  )
-                ),
-                '[^a-z0-9._-]+',
-                '',
-                'g'
-              ),
-              ''
-            ) = t.handle
-            or exists (
-              select 1
-              from jsonb_array_elements_text(coalesce(cp.collaborators, '[]'::jsonb)) collaborator(value)
-              where nullif(
-                regexp_replace(lower(regexp_replace(coalesce(collaborator.value, ''), '^@+', '')), '[^a-z0-9._-]+', '', 'g'),
-                ''
-              ) = t.handle
-            )
-            or exists (
-              select 1
-              from jsonb_array_elements(
-                coalesce(to_jsonb(cp) -> 'collaborators_detail', cp.raw_data -> 'collaborators_detail', '[]'::jsonb)
-              ) collaborator(detail)
-              where nullif(
-                regexp_replace(
-                  lower(regexp_replace(coalesce(collaborator.detail ->> 'username', ''), '^@+', '')),
-                  '[^a-z0-9._-]+',
-                  '',
-                  'g'
-                ),
-                ''
-              ) = t.handle
-            )
-          )
-      ),
-      post_candidates as materialized (
-        select
-          p.shortcode,
-          p.id as post_id,
-          p.posted_at,
-          (${instagramPostReportedCommentsSql})::bigint as detail_comments_count,
-          lower(coalesce(p.media_mirror_status, '')) as media_mirror_status,
-          greatest(coalesce(ch.saved_comment_count, r.active_comment_count, 0), 0)::bigint as saved_comments,
-          greatest(coalesce(ch.instagram_reported_comments, (${instagramPostReportedCommentsSql}), 0), 0)::bigint as health_reported_comments,
-          greatest(
-            coalesce(
-              r.missing_comment_count,
-              greatest(
-                coalesce(ch.instagram_reported_comments, (${instagramPostReportedCommentsSql}), 0)::bigint
-                  - coalesce(ch.saved_comment_count, r.active_comment_count, 0)::bigint,
-                0
-              ),
-              0
-            ),
-            0
-          )::bigint as missing_comments
-        from social.instagram_posts p
-        left join social.instagram_post_comment_rollups r on r.post_id = p.id
-        left join social.comment_capture_health ch on ch.post_id = p.id
-        cross join target t
-        where p.posted_at >= t.start_at
-          and p.posted_at < t.end_at
-          and nullif(p.shortcode, '') is not null
-          and (
-            nullif(regexp_replace(lower(regexp_replace(coalesce(p.source_account, ''), '^@+', '')), '[^a-z0-9._-]+', '', 'g'), '') = t.handle
-            or nullif(regexp_replace(lower(regexp_replace(coalesce(p.owner_username, ''), '^@+', '')), '[^a-z0-9._-]+', '', 'g'), '') = t.handle
-            or nullif(regexp_replace(lower(regexp_replace(coalesce(p.username, ''), '^@+', '')), '[^a-z0-9._-]+', '', 'g'), '') = t.handle
-            or exists (
-              select 1
-              from jsonb_array_elements_text(coalesce(p.collaborators, '[]'::jsonb)) collaborator(value)
-              where nullif(
-                regexp_replace(lower(regexp_replace(coalesce(collaborator.value, ''), '^@+', '')), '[^a-z0-9._-]+', '', 'g'),
-                ''
-              ) = t.handle
-            )
-            or exists (
-              select 1
-              from jsonb_array_elements(
-                coalesce(to_jsonb(p) -> 'collaborators_detail', p.raw_data -> 'collaborators_detail', '[]'::jsonb)
-              ) collaborator(detail)
-              where nullif(
-                regexp_replace(
-                  lower(regexp_replace(coalesce(collaborator.detail ->> 'username', ''), '^@+', '')),
-                  '[^a-z0-9._-]+',
-                  '',
-                  'g'
-                ),
-                ''
-              ) = t.handle
-            )
-          )
-      ),
-      matched_shortcodes as materialized (
-        select shortcode from catalog_candidates
-        union
-        select shortcode from post_candidates
-      ),
-      catalog as materialized (
-        select
-          matched.shortcode,
-          max(c.catalog_comments_count)::bigint as catalog_comments_count
-        from matched_shortcodes matched
-        left join catalog_candidates c on c.shortcode = matched.shortcode
-        group by matched.shortcode
-      ),
-      latest_post as materialized (
-        select distinct on (p.shortcode)
-          p.shortcode,
-          p.post_id,
-          coalesce(p.detail_comments_count, 0)::bigint as detail_comments_count,
-          lower(coalesce(p.media_mirror_status, '')) as media_mirror_status,
-          p.saved_comments,
-          p.health_reported_comments,
-          p.missing_comments,
-          p.posted_at
-        from post_candidates p
-        order by p.shortcode, p.posted_at desc nulls last, p.post_id desc
-      ),
-      scored as (
-        select
-          matched.shortcode,
-          lp.post_id,
-          greatest(
-            coalesce(c.catalog_comments_count, 0),
-            coalesce(lp.health_reported_comments, 0),
-            coalesce(lp.detail_comments_count, 0)
-          )::bigint as reported_comments,
-          coalesce(lp.saved_comments, 0)::bigint as saved_comments,
-          greatest(
-            coalesce(
-              lp.missing_comments,
-              greatest(
-                greatest(
-                  coalesce(c.catalog_comments_count, 0),
-                  coalesce(lp.health_reported_comments, 0),
-                  coalesce(lp.detail_comments_count, 0)
-                ) - coalesce(lp.saved_comments, 0),
-                0
-              ),
-              0
-            ),
-            0
-          )::bigint as missing_comments,
-          lp.media_mirror_status
-        from matched_shortcodes matched
-        left join catalog c on c.shortcode = matched.shortcode
-        left join latest_post lp on lp.shortcode = matched.shortcode
-      )
-      select
-        count(*)::bigint as total_posts,
-        coalesce(sum(reported_comments), 0)::bigint as total_reported_comments,
-        coalesce(sum(saved_comments), 0)::bigint as saved_comments,
-        coalesce(sum(missing_comments), 0)::bigint as missing_comments,
-        coalesce(sum(saved_comments + missing_comments), 0)::bigint as accounted_comments,
-        count(*) filter (
-          where reported_comments = 0
-             or (reported_comments > 0 and missing_comments = 0 and reported_comments <= saved_comments)
-        )::bigint as comments_finished,
-        count(*) filter (
-          where reported_comments > 0 and saved_comments > 0 and missing_comments > 0
-        )::bigint as comments_in_progress,
-        count(*) filter (where reported_comments > 0 and saved_comments = 0)::bigint as comments_not_started,
-        count(*) filter (where post_id is not null)::bigint as details_finished,
-        count(*) filter (where post_id is null)::bigint as details_not_started,
-        count(*) filter (where media_mirror_status in ('complete', 'completed', 'mirrored', 'up_to_date'))::bigint as media_finished,
-        count(*) filter (where media_mirror_status in ('pending', 'partial', 'queued', 'retrying', 'running', 'failed'))::bigint as media_in_progress,
-        count(*) filter (
-          where post_id is null
-             or coalesce(media_mirror_status, '') not in ('complete', 'completed', 'mirrored', 'up_to_date', 'pending', 'partial', 'queued', 'retrying', 'running', 'failed')
-        )::bigint as media_not_started
-      from scored
-      `,
-      [normalizedHandle, year],
+    const cached = getRouteResponseCache<Record<string, unknown>>(
+      COMPLETION_SUMMARY_CACHE_NAMESPACE,
+      cacheKey,
     );
-    const row = result.rows[0] ?? ({} as CompletionRow);
-    return {
-      platform: normalizedPlatform,
-      handle: normalizedHandle,
-      year,
-      total_posts: readCount(row.total_posts),
-      total_reported_comments: readCount(row.total_reported_comments),
-      saved_comments: readCount(row.saved_comments),
-      missing_comments: readCount(row.missing_comments),
-      accounted_comments: readCount(row.accounted_comments),
-      lanes: {
-        comments: {
-          finished: readCount(row.comments_finished),
-          in_progress: readCount(row.comments_in_progress),
-          not_started: readCount(row.comments_not_started),
+    if (cached) {
+      cacheStatus = "hit";
+      return attachAdminRouteTiming(
+        NextResponse.json(cached, { headers: { "x-trr-cache": cacheStatus } }),
+        {
+          routeFamily: "admin-social-profile",
+          routeName: "GET completion-summary",
+          cacheStatus,
+          startedAt: routeStartedAt,
         },
-        details: {
-          finished: readCount(row.details_finished),
-          in_progress: 0,
-          not_started: readCount(row.details_not_started),
-        },
-        media: {
-          finished: readCount(row.media_finished),
-          in_progress: readCount(row.media_in_progress),
-          not_started: readCount(row.media_not_started),
-        },
-      },
-    };
-    };
+      );
+    }
+
+    const stale = getStaleRouteResponseCache<Record<string, unknown>>(
+      COMPLETION_SUMMARY_CACHE_NAMESPACE,
+      cacheKey,
+    );
     try {
-      const payload = await getOrCreateRouteResponsePromise(COMPLETION_SUMMARY_CACHE_NAMESPACE, cacheKey, async () => {
-        const nextPayload = await loadPayload();
-        setRouteResponseCache(
-          COMPLETION_SUMMARY_CACHE_NAMESPACE,
-          cacheKey,
-          nextPayload,
-          COMPLETION_SUMMARY_CACHE_TTL_MS,
-          COMPLETION_SUMMARY_STALE_CACHE_TTL_MS,
-        );
-        return nextPayload;
-      });
-      return NextResponse.json(payload, { headers: { "x-trr-cache": "miss" } });
+      const payload = await getOrCreateRouteResponsePromise(
+        COMPLETION_SUMMARY_CACHE_NAMESPACE,
+        cacheKey,
+        async () => {
+          const backendStartedAt = performance.now();
+          try {
+            const nextPayload = await fetchSocialBackendJson(
+              `/profiles/${encodeURIComponent(normalizedPlatform)}/${encodeURIComponent(normalizedHandle)}/completion-summary`,
+              {
+                adminContext,
+                queryString: new URLSearchParams([["year", String(year)]]).toString(),
+                fallbackError: "Failed to load social completion summary",
+                retries: 0,
+                timeoutMs: COMPLETION_SUMMARY_BACKEND_TIMEOUT_MS,
+              },
+            );
+            setRouteResponseCache(
+              COMPLETION_SUMMARY_CACHE_NAMESPACE,
+              cacheKey,
+              nextPayload,
+              COMPLETION_SUMMARY_CACHE_TTL_MS,
+              COMPLETION_SUMMARY_STALE_CACHE_TTL_MS,
+            );
+            return nextPayload;
+          } finally {
+            backendMs = performance.now() - backendStartedAt;
+          }
+        },
+      );
+      cacheStatus = "miss";
+      return attachAdminRouteTiming(
+        NextResponse.json(payload, { headers: { "x-trr-cache": cacheStatus } }),
+        {
+          routeFamily: "admin-social-profile",
+          routeName: "GET completion-summary",
+          cacheStatus,
+          backendMs,
+          startedAt: routeStartedAt,
+        },
+      );
     } catch (error) {
       if (stale) {
-        return NextResponse.json(stale, {
-          headers: { "x-trr-cache": "stale", "x-trr-cacheable": "0" },
-        });
+        cacheStatus = "stale";
+        return attachAdminRouteTiming(
+          NextResponse.json(stale, {
+            headers: { "x-trr-cache": cacheStatus, "x-trr-cacheable": "0" },
+          }),
+          {
+            routeFamily: "admin-social-profile",
+            routeName: "GET completion-summary",
+            cacheStatus,
+            backendMs,
+            startedAt: routeStartedAt,
+          },
+        );
       }
       throw error;
     }
   } catch (error) {
-    return socialProxyErrorResponse(error, "[api] Failed to load social completion summary");
+    return attachAdminRouteTiming(
+      socialProxyErrorResponse(error, "[api] Failed to load social completion summary"),
+      {
+        routeFamily: "admin-social-profile",
+        routeName: "GET completion-summary",
+        cacheStatus,
+        backendMs,
+        startedAt: routeStartedAt,
+      },
+    );
   }
 }

--- a/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/completion-summary/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/social/profiles/[platform]/[handle]/completion-summary/route.ts
@@ -51,7 +51,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
     const adminContext = toVerifiedAdminContext(user);
     const { platform, handle } = await context.params;
     const normalizedPlatform = platform.trim().toLowerCase();
-    const normalizedHandle = handle.trim().toLowerCase().replace(/^@/, "");
+    const normalizedHandle = handle.trim().toLowerCase().replace(/^@+/, "");
     if (normalizedPlatform !== "instagram" || !normalizedHandle) {
       cacheStatus = "bypass";
       return attachAdminRouteTiming(

--- a/apps/web/src/lib/server/admin/social-landing-repository.ts
+++ b/apps/web/src/lib/server/admin/social-landing-repository.ts
@@ -45,7 +45,6 @@ import {
   type CoveredShow,
 } from "@/lib/server/admin/covered-shows-repository";
 import { loadSharedAccountSourcesFromLocalDb } from "@/lib/server/admin/shared-account-sources";
-import { query, queryWithStatementTimeout } from "@/lib/server/postgres";
 import {
   ADMIN_READ_PROXY_SHORT_TIMEOUT_MS,
   fetchAdminBackendJson,
@@ -106,10 +105,6 @@ type SocialBladeRowsPayload = {
   rows?: SocialBladeSummaryRow[];
 };
 
-type SocialBladeProgressCountsPayload = {
-  rows?: SocialBladeProgressCountRow[];
-};
-
 type SocialProgressRollupPayload = {
   rows?: SocialProgressRow[];
   cache_status?: string | null;
@@ -133,14 +128,6 @@ const EMPTY_SCRAPE_JOB_HEALTH: ScrapeJobHealthSummary = {
   failure_signal_jobs: 0,
   in_failed_sql_transaction_hits: 0,
   latest_failure_at: null,
-};
-
-type SocialBladeProgressCountRow = {
-  platform: string | null;
-  account_handle: string | null;
-  socialblade_scraped_count: number | string | null;
-  socialblade_saved_count: number | string | null;
-  socialblade_supported?: boolean | null;
 };
 
 type SocialProgressRow = {
@@ -345,38 +332,10 @@ const CAST_SOCIALBLADE_PLATFORMS =
   );
 
 const SOCIAL_LANDING_PROGRESS_MAX_TARGETS = 96;
-const SOCIAL_LANDING_PROGRESS_STATEMENT_TIMEOUT_MS = 1_200;
 const SOCIAL_LANDING_OPTIONAL_ENRICHMENT_TIMEOUT_MS = parseCacheTtlMs(
   process.env.TRR_ADMIN_SOCIAL_LANDING_OPTIONAL_ENRICHMENT_TIMEOUT_MS,
   2_500,
 );
-
-const sqlJsonTextNonNegativeInt = (expr: string): string =>
-  `coalesce(nullif(regexp_replace(coalesce(${expr}, ''), '[^0-9]', '', 'g'), '')::bigint, 0)`;
-
-const instagramReportedCommentsSql = (alias: string): string => {
-  const safeAlias = alias.trim() || "p";
-  const raw = `coalesce(${safeAlias}.raw_data, '{}'::jsonb)`;
-  const rawCandidates = [
-    `${raw} ->> 'comments_count'`,
-    `${raw} ->> 'comments'`,
-    `${raw} ->> 'comment_count'`,
-    `${raw} ->> 'commentsCount'`,
-    `${raw} -> 'edge_media_to_comment' ->> 'count'`,
-    `${raw} -> 'edge_media_to_parent_comment' ->> 'count'`,
-    `${raw} -> 'edge_media_preview_comment' ->> 'count'`,
-    `${raw} -> 'media' ->> 'comments_count'`,
-    `${raw} -> 'media' ->> 'comments'`,
-    `${raw} -> 'media' ->> 'comment_count'`,
-    `${raw} -> 'media' ->> 'commentsCount'`,
-    `${raw} -> 'metrics' ->> 'comments_count'`,
-    `${raw} -> 'metrics' ->> 'comments'`,
-  ];
-
-  return `greatest(coalesce(${safeAlias}.comments_count, 0), ${rawCandidates
-    .map(sqlJsonTextNonNegativeInt)
-    .join(", ")}, 0)`;
-};
 
 const SHOW_EXTERNAL_ID_KEYS: Record<
   SupportedPersonSocialSource,
@@ -716,8 +675,8 @@ const buildProgressLanes = (
           : "No following-list snapshot",
     ),
     buildLane("posts", "Posts", row.saved_count, row.scraped_count),
-    buildLane("comments", "Comments", row.comments_saved_count, row.comments_saved_count, row.comments_total_count),
-    buildLane("media", "Media", row.media_saved_count, row.media_saved_count, row.media_total_count),
+    buildLane("comments", "Comments", row.comments_saved_count, row.comments_total_count, row.comments_total_count),
+    buildLane("media", "Media", row.media_saved_count, row.media_total_count, row.media_total_count),
   ];
 };
 
@@ -777,47 +736,6 @@ const collectSocialProgressTargets = ({
     .slice(0, SOCIAL_LANDING_PROGRESS_MAX_TARGETS);
 };
 
-const safeLoadSocialBladeProgressCounts = async (
-  targets: readonly SocialProgressTarget[],
-  adminContext?: VerifiedAdminContext,
-): Promise<CacheableValue<ReadonlyMap<string, Partial<SocialProgressRow>>>> => {
-  if (targets.length === 0) return cacheableValue(new Map());
-
-  try {
-    const payload = (await fetchSocialBackendJson("/landing-socialblade-progress-counts", {
-      adminContext,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        platforms: targets.map((target) => target.platform),
-        account_handles: targets.map((target) => target.handle),
-      }),
-      fallbackError: "Failed to fetch social landing SocialBlade progress counts",
-      retries: 0,
-      timeoutMs: ADMIN_READ_PROXY_SHORT_TIMEOUT_MS,
-    })) as SocialBladeProgressCountsPayload;
-    const rows = Array.isArray(payload.rows) ? payload.rows : [];
-    const countsByKey = new Map<string, Partial<SocialProgressRow>>();
-    for (const row of rows) {
-      const platform = normalizePlatform(row.platform ?? "");
-      const handle =
-        typeof row.account_handle === "string"
-          ? row.account_handle.trim().replace(/^@+/, "")
-          : "";
-      if (!platform || !handle) continue;
-      countsByKey.set(buildSocialProgressKey(platform, handle), {
-        socialblade_scraped_count: row.socialblade_scraped_count,
-        socialblade_saved_count: row.socialblade_saved_count,
-        socialblade_supported: row.socialblade_supported,
-      });
-    }
-    return cacheableValue(countsByKey);
-  } catch (error) {
-    console.warn("[social-landing] Failed to load SocialBlade progress counts", error);
-    return uncacheableValue(new Map());
-  }
-};
-
 const buildSocialProgressMap = (
   rows: readonly SocialProgressRow[],
   overridesByKey: ReadonlyMap<string, Partial<SocialProgressRow>> = new Map(),
@@ -843,7 +761,7 @@ const buildSocialProgressMap = (
 
 const safeLoadBackendSocialProgressRollup = async (
   targets: readonly SocialProgressTarget[],
-  adminContext: VerifiedAdminContext,
+  adminContext?: VerifiedAdminContext,
   timingCollector?: SocialLandingTimingCollector,
 ): Promise<SocialProgressSummaryResult> => {
   try {
@@ -919,267 +837,7 @@ const safeLoadSocialProgressSummaries = async (
     };
   }
 
-  if (adminContext) {
-    return safeLoadBackendSocialProgressRollup(targets, adminContext, timingCollector);
-  }
-
-  const platforms = targets.map((target) => target.platform);
-  const handles = targets.map((target) => target.handle);
-  const instagramMaterializedReportedCommentsSql =
-    instagramReportedCommentsSql("p");
-  const instagramCatalogReportedCommentsSql = instagramReportedCommentsSql("p");
-
-  try {
-    const [socialBladeCountsResult, result] = await Promise.all([
-      safeLoadSocialBladeProgressCounts(targets, adminContext),
-      queryWithStatementTimeout<SocialProgressRow>(
-        `
-        /* landing_social_progress */
-        WITH targets AS (
-          SELECT DISTINCT
-            lower(input.platform) AS platform,
-            lower(regexp_replace(input.account_handle, '^@+', '')) AS account_handle
-          FROM unnest($1::text[], $2::text[]) AS input(platform, account_handle)
-          WHERE input.platform IN ('instagram', 'tiktok', 'twitter', 'youtube', 'facebook', 'threads')
-            AND nullif(trim(input.account_handle), '') IS NOT NULL
-        ),
-        materialized_rows AS (
-          SELECT
-            'instagram'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            id,
-            nullif(shortcode, '') AS source_id,
-            (${instagramMaterializedReportedCommentsSql})::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files,
-            (
-              jsonb_array_length(coalesce(hosted_media_urls, '[]'::jsonb)) +
-              case when nullif(hosted_thumbnail_url, '') is not null then 1 else 0 end
-            )::bigint AS hosted_media_files
-          FROM social.instagram_posts p
-          UNION ALL
-          SELECT
-            'tiktok'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            id,
-            nullif(video_id, '') AS source_id,
-            greatest(coalesce(comments_count, 0), 0)::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files,
-            (
-              jsonb_array_length(coalesce(hosted_media_urls, '[]'::jsonb)) +
-              case when nullif(hosted_thumbnail_url, '') is not null then 1 else 0 end
-            )::bigint AS hosted_media_files
-          FROM social.tiktok_posts
-          UNION ALL
-          SELECT
-            'twitter'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            id,
-            nullif(tweet_id, '') AS source_id,
-            0::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files,
-            (
-              jsonb_array_length(coalesce(hosted_media_urls, '[]'::jsonb)) +
-              case when nullif(hosted_thumbnail_url, '') is not null then 1 else 0 end
-            )::bigint AS hosted_media_files
-          FROM social.twitter_tweets
-          UNION ALL
-          SELECT
-            'youtube'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            id,
-            nullif(video_id, '') AS source_id,
-            greatest(coalesce(comments_count, 0), 0)::bigint AS reported_comments,
-            0::bigint AS source_media_files,
-            case when nullif(hosted_thumbnail_url, '') is not null then 1 else 0 end::bigint AS hosted_media_files
-          FROM social.youtube_videos
-          UNION ALL
-          SELECT
-            'facebook'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            id,
-            nullif(post_id, '') AS source_id,
-            greatest(coalesce(comments_count, 0), 0)::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files,
-            (
-              jsonb_array_length(coalesce(hosted_media_urls, '[]'::jsonb)) +
-              case when nullif(hosted_thumbnail_url, '') is not null then 1 else 0 end
-            )::bigint AS hosted_media_files
-          FROM social.facebook_posts
-          UNION ALL
-          SELECT
-            'threads'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            id,
-            nullif(post_id, '') AS source_id,
-            0::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files,
-            (
-              jsonb_array_length(coalesce(hosted_media_urls, '[]'::jsonb)) +
-              case when nullif(hosted_thumbnail_url, '') is not null then 1 else 0 end
-            )::bigint AS hosted_media_files
-          FROM social.meta_threads_posts
-        ),
-        catalog_rows AS (
-          SELECT
-            'instagram'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            nullif(source_id, '') AS source_id,
-            (${instagramCatalogReportedCommentsSql})::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files
-          FROM social.instagram_account_catalog_posts p
-          UNION ALL
-          SELECT
-            'tiktok'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            nullif(source_id, '') AS source_id,
-            greatest(coalesce(comments_count, 0), 0)::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files
-          FROM social.tiktok_account_catalog_posts
-          UNION ALL
-          SELECT
-            'twitter'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            nullif(source_id, '') AS source_id,
-            greatest(coalesce(comments_count, 0), 0)::bigint + greatest(coalesce(quotes, 0), 0)::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files
-          FROM social.twitter_account_catalog_posts
-          UNION ALL
-          SELECT
-            'youtube'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            nullif(source_id, '') AS source_id,
-            greatest(coalesce(comments_count, 0), 0)::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files
-          FROM social.youtube_account_catalog_posts
-          UNION ALL
-          SELECT
-            'facebook'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            nullif(source_id, '') AS source_id,
-            greatest(coalesce(comments_count, 0), 0)::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files
-          FROM social.facebook_account_catalog_posts
-          UNION ALL
-          SELECT
-            'threads'::text AS platform,
-            lower(regexp_replace(coalesce(source_account, ''), '^@+', '')) AS account_handle,
-            nullif(source_id, '') AS source_id,
-            greatest(coalesce(comments_count, 0), 0)::bigint AS reported_comments,
-            jsonb_array_length(coalesce(media_urls, '[]'::jsonb))::bigint AS source_media_files
-          FROM social.threads_account_catalog_posts
-        ),
-        materialized_counts AS (
-          SELECT
-            rows.platform,
-            rows.account_handle,
-            count(*)::int AS saved_count,
-            sum(rows.reported_comments)::int AS comments_total_count,
-            sum(rows.hosted_media_files)::int AS media_saved_count
-          FROM materialized_rows rows
-          INNER JOIN targets
-            ON targets.platform = rows.platform
-           AND targets.account_handle = rows.account_handle
-          WHERE rows.account_handle <> ''
-          GROUP BY rows.platform, rows.account_handle
-        ),
-        catalog_counts AS (
-          SELECT
-            rows.platform,
-            rows.account_handle,
-            count(*)::int AS scraped_count,
-            sum(rows.reported_comments)::int AS comments_total_count,
-            sum(rows.source_media_files)::int AS media_total_count
-          FROM catalog_rows rows
-          INNER JOIN targets
-            ON targets.platform = rows.platform
-           AND targets.account_handle = rows.account_handle
-          WHERE rows.account_handle <> ''
-          GROUP BY rows.platform, rows.account_handle
-        ),
-        instagram_profile_targets AS (
-          SELECT DISTINCT ON (targets.account_handle)
-            targets.account_handle,
-            profiles.id AS profile_id,
-            greatest(coalesce(profiles.follows_count, 0), 0)::int AS following_total_count
-          FROM targets
-          INNER JOIN social.instagram_profiles profiles
-            ON targets.platform = 'instagram'
-           AND lower(regexp_replace(coalesce(profiles.normalized_username, profiles.username, profiles.source_account, ''), '^@+', '')) = targets.account_handle
-          ORDER BY
-            targets.account_handle,
-            profiles.last_scraped_at DESC NULLS LAST,
-            profiles.updated_at DESC NULLS LAST,
-            profiles.id
-        ),
-        following_counts AS (
-          SELECT
-            'instagram'::text AS platform,
-            profile_targets.account_handle,
-            count(relationships.id) FILTER (WHERE coalesce(relationships.is_missing, false) = false)::int AS following_saved_count,
-            max(profile_targets.following_total_count)::int AS following_total_count
-          FROM instagram_profile_targets profile_targets
-          LEFT JOIN social.instagram_profile_relationships relationships
-            ON relationships.owner_profile_id = profile_targets.profile_id
-           AND relationships.relationship_type = 'following'
-          GROUP BY profile_targets.account_handle
-        )
-        SELECT
-          targets.platform,
-          targets.account_handle,
-          coalesce(materialized_counts.saved_count, 0)::int AS saved_count,
-          coalesce(catalog_counts.scraped_count, 0)::int AS scraped_count,
-          (targets.platform IN ('instagram', 'youtube', 'tiktok'))::boolean AS socialblade_supported,
-          0::int AS socialblade_scraped_count,
-          0::int AS socialblade_saved_count,
-          coalesce(following_counts.following_saved_count, 0)::int AS following_saved_count,
-          coalesce(following_counts.following_total_count, 0)::int AS following_total_count,
-          0::int AS comments_saved_count,
-          greatest(
-            coalesce(materialized_counts.comments_total_count, 0),
-            coalesce(catalog_counts.comments_total_count, 0)
-          )::int AS comments_total_count,
-          coalesce(materialized_counts.media_saved_count, 0)::int AS media_saved_count,
-          greatest(coalesce(catalog_counts.media_total_count, 0), coalesce(materialized_counts.media_saved_count, 0))::int AS media_total_count
-        FROM targets
-        LEFT JOIN materialized_counts
-          ON materialized_counts.platform = targets.platform
-         AND materialized_counts.account_handle = targets.account_handle
-        LEFT JOIN catalog_counts
-          ON catalog_counts.platform = targets.platform
-         AND catalog_counts.account_handle = targets.account_handle
-        LEFT JOIN following_counts
-          ON following_counts.platform = targets.platform
-         AND following_counts.account_handle = targets.account_handle
-        `,
-        [platforms, handles],
-        SOCIAL_LANDING_PROGRESS_STATEMENT_TIMEOUT_MS,
-      ),
-    ]);
-
-    const socialBladeCountsByKey = socialBladeCountsResult.value;
-    return {
-      value: buildSocialProgressMap(result.rows, socialBladeCountsByKey),
-      cacheable: socialBladeCountsResult.cacheable,
-      status: {
-        source: "fallback",
-        cache_status: null,
-        generated_at: null,
-        stale: !socialBladeCountsResult.cacheable,
-      },
-    };
-  } catch (error) {
-    console.warn("[social-landing] Failed to load social progress summaries", error);
-    return {
-      ...uncacheableValue(new Map()),
-      status: {
-        source: "fallback",
-        cache_status: null,
-        generated_at: null,
-        stale: true,
-        warning: error instanceof Error ? error.message : "Failed to load social progress summaries",
-      },
-    };
-  }
+  return safeLoadBackendSocialProgressRollup(targets, adminContext, timingCollector);
 };
 
 const hydrateHandleProgress = (
@@ -1364,62 +1022,16 @@ const coerceCount = (value: number | string | null | undefined): number => {
   return Number.isFinite(parsed) ? Math.max(0, Math.trunc(parsed)) : 0;
 };
 
-const safeLoadScrapeJobHealth = async (): Promise<ScrapeJobHealthSummary> => {
+const safeLoadScrapeJobHealth = async (
+  adminContext?: VerifiedAdminContext,
+): Promise<ScrapeJobHealthSummary> => {
   try {
-    const result = await query<ScrapeJobHealthRow>(
-      `
-        /* landing_social_scrape_job_health */
-        WITH recent_jobs AS (
-          SELECT
-            status,
-            error_message,
-            last_error_code,
-            metadata,
-            created_at
-          FROM social.scrape_jobs
-          WHERE platform = ANY($2::text[])
-            AND created_at >= now() - ($1::int * interval '1 hour')
-        ),
-        job_signals AS (
-          SELECT
-            status,
-            created_at,
-            coalesce(error_message, '') || ' ' ||
-              coalesce(last_error_code, '') AS error_signal,
-            coalesce(error_message, '') || ' ' ||
-              coalesce(last_error_code, '') || ' ' ||
-              coalesce(metadata::text, '') AS diagnostic_text
-          FROM recent_jobs
-        )
-        SELECT
-          now() AS generated_at,
-          now() - ($1::int * interval '1 hour') AS window_started_at,
-          count(*)::bigint AS total_jobs,
-          count(*) FILTER (
-            WHERE status IN ('queued', 'pending', 'running', 'retrying', 'cancelling')
-          )::bigint AS active_jobs,
-          count(*) FILTER (
-            WHERE status IN ('failed', 'error')
-          )::bigint AS failed_jobs,
-          count(*) FILTER (
-            WHERE status IN ('failed', 'error')
-              OR nullif(trim(error_signal), '') IS NOT NULL
-          )::bigint AS failure_signal_jobs,
-          count(*) FILTER (
-            WHERE diagnostic_text ILIKE '%InFailedSqlTransaction%'
-          )::bigint AS in_failed_sql_transaction_hits,
-          max(created_at) FILTER (
-            WHERE status IN ('failed', 'error')
-              OR nullif(trim(error_signal), '') IS NOT NULL
-          ) AS latest_failure_at
-        FROM job_signals
-      `,
-      [
-        SCRAPE_JOB_HEALTH_WINDOW_HOURS,
-        ["instagram", "tiktok", "twitter", "youtube"],
-      ],
-    );
-    const row = result.rows[0] ?? {};
+    const row = (await fetchSocialBackendJson("/landing-scrape-job-health", {
+      adminContext,
+      fallbackError: "Failed to load social landing scrape-job health",
+      retries: 1,
+      timeoutMs: SOCIAL_PROXY_DEFAULT_TIMEOUT_MS,
+    })) as ScrapeJobHealthRow;
     return {
       window_hours: SCRAPE_JOB_HEALTH_WINDOW_HOURS,
       window_started_at: toIsoStringOrNull(row.window_started_at),
@@ -2660,7 +2272,7 @@ export async function getSocialLandingPayloadResult(
     );
   const scrapeJobHealthPromise = withSocialLandingTiming(
     "scrape job health",
-    safeLoadScrapeJobHealth(),
+    safeLoadScrapeJobHealth(adminContext),
   );
   const coveredShowIds = coveredShows.map((show) => show.trr_show_id);
   const [
@@ -2731,7 +2343,7 @@ export async function getSocialLandingPayloadResult(
     "people profiles",
     buildPeopleProfiles(coveredShows, castByShowId),
   );
-  const castSocialBladeShowsResult = await withOptionalLandingTimeout(
+  const castSocialBladeShowsPromise = withOptionalLandingTimeout(
     "cast SocialBlade",
     buildCastSocialBladeShows(
       coveredShows,
@@ -2749,7 +2361,7 @@ export async function getSocialLandingPayloadResult(
     networkSharedSources,
   );
   const sharedSourceSets = buildSharedSourceSets(sourcesByScope);
-  const progressResult = await withOptionalLandingTimeout(
+  const progressPromise = withOptionalLandingTimeout(
     "social progress",
     safeLoadSocialProgressSummaries(
       collectSocialProgressTargets({
@@ -2761,7 +2373,11 @@ export async function getSocialLandingPayloadResult(
       timingCollector,
     ),
     new Map(),
-  ) as SocialProgressSummaryResult;
+  ) as Promise<SocialProgressSummaryResult>;
+  const [castSocialBladeShowsResult, progressResult] = await Promise.all([
+    castSocialBladeShowsPromise,
+    progressPromise,
+  ]);
   const progressByKey = progressResult.value;
   const hydratedNetworkSets = networkSets.map((set) =>
     hydrateNetworkSetProgress(set, progressByKey),

--- a/apps/web/tests/social-account-profile-completion-summary-route.test.ts
+++ b/apps/web/tests/social-account-profile-completion-summary-route.test.ts
@@ -1,33 +1,78 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
-const { requireAdminMock, queryMock, socialProxyErrorResponseMock } = vi.hoisted(() => ({
+const {
+  fetchSocialBackendJsonMock,
+  requireAdminMock,
+  socialProxyErrorResponseMock,
+  toVerifiedAdminContextMock,
+} = vi.hoisted(() => ({
+  fetchSocialBackendJsonMock: vi.fn(),
   requireAdminMock: vi.fn(),
-  queryMock: vi.fn(),
   socialProxyErrorResponseMock: vi.fn(),
+  toVerifiedAdminContextMock: vi.fn(),
 }));
 
 vi.mock("@/lib/server/auth", () => ({
   requireAdmin: requireAdminMock,
-}));
-
-vi.mock("@/lib/server/postgres", () => ({
-  query: queryMock,
+  toVerifiedAdminContext: toVerifiedAdminContextMock,
 }));
 
 vi.mock("@/lib/server/trr-api/social-admin-proxy", () => ({
+  fetchSocialBackendJson: fetchSocialBackendJsonMock,
   socialProxyErrorResponse: socialProxyErrorResponseMock,
 }));
 
 import { GET } from "@/app/api/admin/trr-api/social/profiles/[platform]/[handle]/completion-summary/route";
+import { invalidateRouteResponseCache } from "@/lib/server/admin/route-response-cache";
+
+const CACHE_NAMESPACE = "social-account-profile-completion-summary";
+
+const completionPayload = {
+  platform: "instagram",
+  handle: "bravotv",
+  year: 2026,
+  total_posts: 3,
+  total_reported_comments: 1200,
+  saved_comments: 780,
+  missing_comments: 420,
+  accounted_comments: 1200,
+  lanes: {
+    comments: { finished: 1, in_progress: 2, not_started: 0 },
+    details: { finished: 2, in_progress: 0, not_started: 1 },
+    media: { finished: 1, in_progress: 1, not_started: 1 },
+  },
+};
+
+const requestCompletionSummary = (
+  url = "http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary",
+  params = { platform: "instagram", handle: "bravotv" },
+) => GET(new NextRequest(url), { params: Promise.resolve(params) });
+
+const expectTimingHeaders = (response: Response) => {
+  expect(response.headers.get("server-timing")).toContain("trr_admin_route;dur=");
+  expect(response.headers.get("x-trr-admin-route-ms")).toMatch(/^\d+$/);
+};
 
 describe("social account profile completion summary route", () => {
   beforeEach(() => {
+    invalidateRouteResponseCache(CACHE_NAMESPACE);
     requireAdminMock.mockReset();
-    queryMock.mockReset();
+    toVerifiedAdminContextMock.mockReset();
+    fetchSocialBackendJsonMock.mockReset();
     socialProxyErrorResponseMock.mockReset();
 
-    requireAdminMock.mockResolvedValue({ uid: "admin-1", provider: "firebase" });
+    requireAdminMock.mockResolvedValue({
+      uid: "admin-1",
+      email: "admin@example.com",
+      provider: "firebase",
+    });
+    toVerifiedAdminContextMock.mockReturnValue({
+      uid: "admin-1",
+      email: "admin@example.com",
+      verifiedAt: 1_750_000_000_000,
+    });
+    fetchSocialBackendJsonMock.mockResolvedValue(completionPayload);
     socialProxyErrorResponseMock.mockImplementation((error: unknown) =>
       Response.json({ error: String(error), code: "BACKEND_UNREACHABLE" }, { status: 502 }),
     );
@@ -37,116 +82,130 @@ describe("social account profile completion summary route", () => {
     vi.useRealTimers();
   });
 
-  it("defaults to the current year and counts collab comment gaps from health-aware matches", async () => {
+  it("normalizes the profile, defaults to the current year, and proxies the exact payload", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-29T12:00:00Z"));
 
-    queryMock.mockResolvedValue({
-      rows: [
-        {
-          total_posts: "3",
-          total_reported_comments: "1200",
-          saved_comments: "780",
-          missing_comments: "420",
-          accounted_comments: "1200",
-          comments_finished: "1",
-          comments_in_progress: "2",
-          comments_not_started: "0",
-          details_finished: "2",
-          details_not_started: "1",
-          media_finished: "1",
-          media_in_progress: "1",
-          media_not_started: "1",
-        },
-      ],
-    });
-
-    const response = await GET(
-      new NextRequest("http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary"),
-      { params: Promise.resolve({ platform: "instagram", handle: "bravotv" }) },
+    const response = await requestCompletionSummary(
+      "http://localhost/api/admin/trr-api/social/profiles/Instagram/%40BravoTV/completion-summary",
+      { platform: " Instagram ", handle: " @BravoTV " },
     );
-    const body = (await response.json()) as {
-      year: number;
-      total_posts: number;
-      total_reported_comments: number;
-      saved_comments: number;
-      missing_comments: number;
-      lanes: {
-        comments: { finished: number; in_progress: number; not_started: number };
-      };
-    };
 
     expect(response.status).toBe(200);
-    expect(body.year).toBe(2026);
-    expect(body.total_posts).toBe(3);
-    expect(body.total_reported_comments).toBe(1200);
-    expect(body.saved_comments).toBe(780);
-    expect(body.missing_comments).toBe(420);
-    expect(body.lanes.comments).toEqual({
-      finished: 1,
-      in_progress: 2,
-      not_started: 0,
-    });
-
-    expect(queryMock).toHaveBeenCalledWith(expect.any(String), ["bravotv", 2026]);
-    const sql = String(queryMock.mock.calls[0]?.[0] ?? "");
-    expect(sql).toContain("social.comment_capture_health");
-    expect(sql).toContain("cp.owner_username");
-    expect(sql).toContain("p.owner_username");
-    expect(sql).toContain("p.username");
-    expect(sql).toContain("cp.collaborators");
-    expect(sql).toContain("p.collaborators");
-    expect(sql).toContain("source_account");
-    expect(sql).toContain("p.raw_data");
-    expect(sql).not.toMatch(/\bp\.comments_count\b/);
+    expect(await response.json()).toEqual(completionPayload);
+    expect(response.headers.get("x-trr-cache")).toBe("miss");
+    expect(response.headers.get("x-trr-admin-backend-ms")).toMatch(/^\d+$/);
+    expectTimingHeaders(response);
+    expect(fetchSocialBackendJsonMock).toHaveBeenCalledWith(
+      "/profiles/instagram/bravotv/completion-summary",
+      expect.objectContaining({
+        adminContext: expect.objectContaining({ uid: "admin-1" }),
+        queryString: "year=2026",
+        fallbackError: "Failed to load social completion summary",
+        retries: 0,
+        timeoutMs: 30_000,
+      }),
+    );
   });
 
   it("falls back to the current year when the year query param is invalid", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-01T12:00:00Z"));
-    queryMock.mockResolvedValue({ rows: [] });
 
-    const response = await GET(
-      new NextRequest("http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary?year=nope"),
-      { params: Promise.resolve({ platform: "instagram", handle: "@bravotv" }) },
+    const response = await requestCompletionSummary(
+      "http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary?year=nope",
+      { platform: "instagram", handle: "@bravotv" },
     );
-    const body = (await response.json()) as { year: number; handle: string; total_posts: number };
 
     expect(response.status).toBe(200);
-    expect(body.year).toBe(2026);
-    expect(body.handle).toBe("bravotv");
-    expect(body.total_posts).toBe(0);
-    expect(queryMock).toHaveBeenCalledWith(expect.any(String), ["bravotv", 2026]);
+    expect(fetchSocialBackendJsonMock).toHaveBeenCalledWith(
+      "/profiles/instagram/bravotv/completion-summary",
+      expect.objectContaining({ queryString: "year=2026" }),
+    );
   });
 
-  it("rejects unsupported platforms before querying completion data", async () => {
-    const response = await GET(
-      new NextRequest("http://localhost/api/admin/trr-api/social/profiles/tiktok/bravotv/completion-summary"),
-      { params: Promise.resolve({ platform: "tiktok", handle: "bravotv" }) },
+  it("preserves user-scoped cache miss and hit behavior", async () => {
+    const miss = await requestCompletionSummary(
+      "http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary?year=2026",
     );
-    const body = (await response.json()) as { error: string };
+    const hit = await requestCompletionSummary(
+      "http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary?year=2026",
+    );
+
+    requireAdminMock.mockResolvedValueOnce({
+      uid: "admin-2",
+      email: "other@example.com",
+      provider: "firebase",
+    });
+    toVerifiedAdminContextMock.mockReturnValueOnce({
+      uid: "admin-2",
+      email: "other@example.com",
+      verifiedAt: 1_750_000_000_001,
+    });
+    const otherUserMiss = await requestCompletionSummary(
+      "http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary?year=2026",
+    );
+
+    expect(miss.headers.get("x-trr-cache")).toBe("miss");
+    expect(hit.headers.get("x-trr-cache")).toBe("hit");
+    expect(otherUserMiss.headers.get("x-trr-cache")).toBe("miss");
+    expect(fetchSocialBackendJsonMock).toHaveBeenCalledTimes(2);
+    expectTimingHeaders(hit);
+  });
+
+  it("serves stale cached data when the bounded backend request times out", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-13T12:00:00Z"));
+    await requestCompletionSummary(
+      "http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary?year=2026",
+    );
+    vi.advanceTimersByTime(5 * 60_000 + 1);
+    fetchSocialBackendJsonMock.mockRejectedValueOnce(new Error("upstream request timed out"));
+
+    const response = await requestCompletionSummary(
+      "http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary?year=2026",
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(completionPayload);
+    expect(response.headers.get("x-trr-cache")).toBe("stale");
+    expect(response.headers.get("x-trr-cacheable")).toBe("0");
+    expect(fetchSocialBackendJsonMock).toHaveBeenLastCalledWith(
+      "/profiles/instagram/bravotv/completion-summary",
+      expect.objectContaining({ timeoutMs: 30_000 }),
+    );
+    expectTimingHeaders(response);
+  });
+
+  it("rejects unsupported platforms before requesting completion data", async () => {
+    const response = await requestCompletionSummary(
+      "http://localhost/api/admin/trr-api/social/profiles/tiktok/bravotv/completion-summary",
+      { platform: "tiktok", handle: "bravotv" },
+    );
 
     expect(response.status).toBe(400);
-    expect(body.error).toBe("unsupported_profile");
-    expect(queryMock).not.toHaveBeenCalled();
+    expect(await response.json()).toEqual({ error: "unsupported_profile" });
+    expect(fetchSocialBackendJsonMock).not.toHaveBeenCalled();
+    expectTimingHeaders(response);
   });
 
-  it("returns the shared proxy error response when the completion query fails", async () => {
-    const error = new Error("column p.comments_count does not exist");
-    queryMock.mockRejectedValue(error);
+  it("preserves the shared upstream error envelope when no stale value exists", async () => {
+    const error = new Error("backend unavailable");
+    fetchSocialBackendJsonMock.mockRejectedValue(error);
 
-    const response = await GET(
-      new NextRequest("http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary?year=2026"),
-      { params: Promise.resolve({ platform: "instagram", handle: "bravotv" }) },
+    const response = await requestCompletionSummary(
+      "http://localhost/api/admin/trr-api/social/profiles/instagram/bravotv/completion-summary?year=2026",
     );
-    const body = (await response.json()) as { error: string; code: string };
 
     expect(response.status).toBe(502);
-    expect(body.code).toBe("BACKEND_UNREACHABLE");
-    expect(body.error).toContain("column p.comments_count does not exist");
+    expect(await response.json()).toEqual({
+      error: "Error: backend unavailable",
+      code: "BACKEND_UNREACHABLE",
+    });
     expect(socialProxyErrorResponseMock).toHaveBeenCalledWith(
       error,
       "[api] Failed to load social completion summary",
     );
+    expectTimingHeaders(response);
   });
 });

--- a/apps/web/tests/social-account-profile-completion-summary-route.test.ts
+++ b/apps/web/tests/social-account-profile-completion-summary-route.test.ts
@@ -88,7 +88,7 @@ describe("social account profile completion summary route", () => {
 
     const response = await requestCompletionSummary(
       "http://localhost/api/admin/trr-api/social/profiles/Instagram/%40BravoTV/completion-summary",
-      { platform: " Instagram ", handle: " @BravoTV " },
+      { platform: " Instagram ", handle: " @@BravoTV " },
     );
 
     expect(response.status).toBe(200);

--- a/apps/web/tests/social-landing-repository.test.ts
+++ b/apps/web/tests/social-landing-repository.test.ts
@@ -173,6 +173,20 @@ describe("social landing repository", () => {
     ]);
 
     fetchSocialBackendJsonMock.mockImplementation(async (path: string) => {
+      if (path === "/landing-scrape-job-health") {
+        return {
+          window_hours: 8,
+          window_started_at: null,
+          generated_at: null,
+          total_jobs: 0,
+          active_jobs: 0,
+          failed_jobs: 0,
+          failure_signal_jobs: 0,
+          in_failed_sql_transaction_hits: 0,
+          latest_failure_at: null,
+        };
+      }
+
       if (path === "/landing-progress-rollup") {
         return { rows: [] };
       }
@@ -669,82 +683,65 @@ describe("social landing repository", () => {
       show_count: expect.any(Number),
     });
   });
-
-  it("sums Instagram landing comments from post-detail reported counts", async () => {
-    await getSocialLandingPayload();
-
-    const landingCall = queryMock.mock.calls.find(([sql]) =>
-      String(sql).includes("landing_social_progress"),
-    );
-    const sql = String(landingCall?.[0] ?? "");
-
-    expect(sql).toContain("FROM social.instagram_posts p");
-    expect(sql).toContain("FROM social.instagram_account_catalog_posts p");
-    expect(sql).toContain("greatest(coalesce(p.comments_count, 0),");
-    expect(sql).toContain("p.raw_data");
-    expect(sql).toContain("-> 'metrics' ->> 'comments_count'");
-    expect(sql).toContain(
-      "sum(rows.reported_comments)::int AS comments_total_count",
-    );
-    expect(sql).toContain("coalesce(materialized_counts.comments_total_count, 0)");
-  });
-
-  it("loads SocialBlade progress counts through the backend instead of direct app SQL", async () => {
+  it("loads unauthenticated social progress through the backend rollup without direct SQL", async () => {
     const defaultSocialBackend = fetchSocialBackendJsonMock.getMockImplementation();
     if (!defaultSocialBackend) throw new Error("Missing default social backend mock");
     fetchSocialBackendJsonMock.mockImplementation(async (path: string, options?: unknown) => {
-      if (path === "/landing-socialblade-progress-counts") {
+      if (path === "/landing-progress-rollup") {
         return {
           rows: [
             {
               platform: "instagram",
               account_handle: "bravotv",
+              saved_count: 7,
+              scraped_count: 9,
               socialblade_supported: true,
               socialblade_scraped_count: 1,
               socialblade_saved_count: 1,
+              following_saved_count: 25,
+              following_total_count: 30,
+              comments_saved_count: 100,
+              comments_total_count: 120,
+              media_saved_count: 4,
+              media_total_count: 6,
             },
           ],
+          cache_status: "miss",
+          generated_at: "2026-07-13T12:00:00.000Z",
+          stale: false,
         };
       }
       return defaultSocialBackend(path, options);
     });
-    queryMock.mockImplementation(async (sql: string) => {
-      if (String(sql).includes("landing_social_progress")) {
-        return {
-          rows: [
-            {
-              platform: "instagram",
-              account_handle: "bravotv",
-              saved_count: 0,
-              scraped_count: 0,
-              socialblade_supported: true,
-            },
-          ],
-        };
-      }
-      return { rows: [] };
-    });
 
-    const payload = await getSocialLandingPayload();
+    const result = await getSocialLandingPayloadResult();
 
-    const landingCall = queryMock.mock.calls.find(([sql]) =>
-      String(sql).includes("landing_social_progress"),
-    );
-    const sql = String(landingCall?.[0] ?? "");
     const progressCall = fetchSocialBackendJsonMock.mock.calls.find(
-      ([path]) => path === "/landing-socialblade-progress-counts",
+      ([path]) => path === "/landing-progress-rollup",
     );
-    const progressOptions = progressCall?.[1] as { body?: string; method?: string } | undefined;
+    const progressOptions = progressCall?.[1] as
+      | { body?: string; method?: string; adminContext?: unknown }
+      | undefined;
     const progressBody = JSON.parse(progressOptions?.body ?? "{}") as {
       platforms?: string[];
       account_handles?: string[];
     };
 
-    expect(sql).not.toContain("pipeline.socialblade_growth_data");
     expect(progressOptions?.method).toBe("POST");
+    expect(progressOptions?.adminContext).toBeUndefined();
     expect(progressBody.platforms?.length).toBe(progressBody.account_handles?.length);
     expect(progressBody.account_handles).toEqual(expect.arrayContaining(["bravotv"]));
-    expect(payload.network_sets[0]?.handles).toEqual(
+    expect(
+      queryMock.mock.calls.some(([sql]) => String(sql).includes("landing_social_progress")),
+    ).toBe(false);
+    expect(result.cacheable).toBe(true);
+    expect(result.payload.social_progress_status).toEqual({
+      source: "backend",
+      cache_status: "miss",
+      generated_at: "2026-07-13T12:00:00.000Z",
+      stale: false,
+    });
+    expect(result.payload.network_sets[0]?.handles).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           platform: "instagram",
@@ -752,10 +749,17 @@ describe("social landing repository", () => {
           progress: expect.objectContaining({
             lanes: expect.arrayContaining([
               expect.objectContaining({
+                key: "comments",
+                saved_count: 100,
+                scraped_count: 120,
+                total_count: 120,
+              }),
+              expect.objectContaining({
                 key: "socialblade",
                 status: "ready",
-                saved_count: 1,
-                scraped_count: 1,
+                saved_count: 26,
+                scraped_count: 26,
+                total_count: 31,
               }),
             ]),
           }),
@@ -825,6 +829,45 @@ describe("social landing repository", () => {
     expect(rollupOptions?.method).toBe("POST");
     expect(rollupBody.platforms?.length).toBe(rollupBody.account_handles?.length);
     expect(rollupBody.account_handles).toEqual(expect.arrayContaining(["bravotv"]));
+    const bravotvHandle = result.payload.network_sets[0]?.handles.find(
+      (handle) => handle.platform === "instagram" && handle.handle === "bravotv",
+    );
+    if (!bravotvHandle?.progress) {
+      throw new Error("Expected bravotv progress from the backend rollup");
+    }
+    const postsLane = bravotvHandle.progress.lanes.find((lane) => lane.key === "posts");
+    const commentsLane = bravotvHandle.progress.lanes.find((lane) => lane.key === "comments");
+    const mediaLane = bravotvHandle.progress.lanes.find((lane) => lane.key === "media");
+    if (!postsLane || !commentsLane || !mediaLane) {
+      throw new Error("Expected posts, comments, and media progress lanes");
+    }
+
+    expect(postsLane).toEqual(
+      expect.objectContaining({
+        key: "posts",
+        saved_count: 7,
+        scraped_count: 9,
+        total_count: 9,
+      }),
+    );
+    expect(commentsLane).toEqual(
+      expect.objectContaining({
+        key: "comments",
+        saved_count: 100,
+        scraped_count: 120,
+        total_count: 120,
+      }),
+    );
+    expect(commentsLane.scraped_percent).toBeGreaterThan(0);
+    expect(mediaLane).toEqual(
+      expect.objectContaining({
+        key: "media",
+        saved_count: 4,
+        scraped_count: 6,
+        total_count: 6,
+      }),
+    );
+    expect(mediaLane.saved_percent).toBeLessThan(mediaLane.scraped_percent);
     expect(result.payload.network_sets[0]?.handles).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -847,24 +890,22 @@ describe("social landing repository", () => {
   });
 
   it("includes recent scrape job health for the social landing badge", async () => {
-    queryMock.mockImplementation(async (sql: string) => {
-      if (String(sql).includes("landing_social_scrape_job_health")) {
+    const defaultSocialBackend = fetchSocialBackendJsonMock.getMockImplementation();
+    if (!defaultSocialBackend) throw new Error("Missing default social backend mock");
+    fetchSocialBackendJsonMock.mockImplementation(async (path: string, options?: unknown) => {
+      if (path === "/landing-scrape-job-health") {
         return {
-          rows: [
-            {
-              generated_at: "2026-05-18T12:00:00.000Z",
-              window_started_at: "2026-05-18T04:00:00.000Z",
-              total_jobs: "9",
-              active_jobs: "1",
-              failed_jobs: "2",
-              failure_signal_jobs: "3",
-              in_failed_sql_transaction_hits: "1",
-              latest_failure_at: "2026-05-18T11:45:00.000Z",
-            },
-          ],
+          generated_at: "2026-05-18T12:00:00.000Z",
+          window_started_at: "2026-05-18T04:00:00.000Z",
+          total_jobs: "9",
+          active_jobs: "1",
+          failed_jobs: "2",
+          failure_signal_jobs: "3",
+          in_failed_sql_transaction_hits: "1",
+          latest_failure_at: "2026-05-18T11:45:00.000Z",
         };
       }
-      return { rows: [] };
+      return defaultSocialBackend(path, options);
     });
 
     const payload = await getSocialLandingPayload();
@@ -880,6 +921,48 @@ describe("social landing repository", () => {
       in_failed_sql_transaction_hits: 1,
       latest_failure_at: "2026-05-18T11:45:00.000Z",
     });
+    expect(fetchSocialBackendJsonMock).toHaveBeenCalledWith(
+      "/landing-scrape-job-health",
+      expect.objectContaining({
+        fallbackError: "Failed to load social landing scrape-job health",
+        retries: 1,
+        timeoutMs: 25_000,
+      }),
+    );
+    expect(
+      queryMock.mock.calls.some(([sql]) =>
+        String(sql).includes("landing_social_scrape_job_health"),
+      ),
+    ).toBe(false);
+  });
+
+  it("degrades scrape job health to the empty summary when the backend read fails", async () => {
+    const expectedWarn = captureExpectedConsoleWarn(
+      /^\[social-landing\] Failed to load scrape job health /,
+    );
+    const defaultSocialBackend = fetchSocialBackendJsonMock.getMockImplementation();
+    if (!defaultSocialBackend) throw new Error("Missing default social backend mock");
+    fetchSocialBackendJsonMock.mockImplementation(async (path: string, options?: unknown) => {
+      if (path === "/landing-scrape-job-health") {
+        throw new Error("health backend unavailable");
+      }
+      return defaultSocialBackend(path, options);
+    });
+
+    const payload = await getSocialLandingPayload();
+
+    expect(payload.scrape_job_health).toEqual({
+      window_hours: 8,
+      window_started_at: null,
+      generated_at: null,
+      total_jobs: 0,
+      active_jobs: 0,
+      failed_jobs: 0,
+      failure_signal_jobs: 0,
+      in_failed_sql_transaction_hits: 0,
+      latest_failure_at: null,
+    });
+    expectedWarn.restore();
   });
 
   it("labels assigned YouTube playlist show handles with playlist metadata", async () => {
@@ -1004,6 +1087,44 @@ describe("social landing repository", () => {
       }),
     ]);
     expect(result.cacheable).toBe(true);
+  });
+
+  it("starts social progress before cast SocialBlade rows resolve", async () => {
+    const events: string[] = [];
+    let resolveCastSocialBladeRows!: () => void;
+    const castSocialBladeRowsPromise = new Promise<{ rows: [] }>((resolve) => {
+      resolveCastSocialBladeRows = () => resolve({ rows: [] });
+    });
+    const defaultSocialBackend = fetchSocialBackendJsonMock.getMockImplementation();
+    if (!defaultSocialBackend) throw new Error("Missing default social backend mock");
+
+    fetchSocialBackendJsonMock.mockImplementation(async (path: string, options?: unknown) => {
+      if (path === "/landing-socialblade-rows") {
+        events.push("cast-socialblade-started");
+        return castSocialBladeRowsPromise;
+      }
+      if (path === "/landing-progress-rollup") {
+        events.push("social-progress-started");
+        return { rows: [] };
+      }
+      return defaultSocialBackend(path, options);
+    });
+
+    const resultPromise = getSocialLandingPayloadResult();
+    while (!events.includes("cast-socialblade-started")) {
+      await delay(0);
+    }
+    await delay(0);
+
+    expect(events).toContain("social-progress-started");
+    expect(events.indexOf("social-progress-started")).toBeGreaterThan(
+      events.indexOf("cast-socialblade-started"),
+    );
+
+    resolveCastSocialBladeRows();
+    const result = await resultPromise;
+
+    expect(result.payload.cast_socialblade_shows).toEqual([]);
   });
 
   it("falls back to local shared-source rows when backend shared-source reads fail", async () => {
@@ -1135,7 +1256,49 @@ describe("social landing repository", () => {
       }
       if (path.startsWith("/shared/ingest/runs")) return [];
       if (path.startsWith("/shared/review-queue")) return { items: [] };
-      if (path === "/landing-socialblade-progress-counts") return { rows: [] };
+      if (path === "/landing-scrape-job-health") {
+        return {
+          window_hours: 8,
+          window_started_at: null,
+          generated_at: null,
+          total_jobs: 0,
+          active_jobs: 0,
+          failed_jobs: 0,
+          failure_signal_jobs: 0,
+          in_failed_sql_transaction_hits: 0,
+          latest_failure_at: null,
+        };
+      }
+      if (path === "/landing-progress-rollup") {
+        return {
+          rows: [
+            {
+              platform: "instagram",
+              account_handle: "bravotv",
+              saved_count: 90,
+              scraped_count: 75,
+            },
+            {
+              platform: "instagram",
+              account_handle: "thetraitorsus",
+              saved_count: 442,
+              scraped_count: 442,
+            },
+            {
+              platform: "tiktok",
+              account_handle: "thetraitorsus",
+              saved_count: 275,
+              scraped_count: 275,
+            },
+            {
+              platform: "twitter",
+              account_handle: "thetraitorsus",
+              saved_count: 5227,
+              scraped_count: 285,
+            },
+          ],
+        };
+      }
       if (path.startsWith("/profiles/") && path.endsWith("/summary")) {
         const [platform, rawHandle] = path
           .replace(/^\/profiles\//, "")
@@ -1176,40 +1339,6 @@ describe("social landing repository", () => {
         ],
       ]),
     );
-    queryMock.mockImplementation(async (sql: string) => {
-      if (String(sql).includes("landing_social_progress")) {
-        return {
-          rows: [
-            {
-              platform: "instagram",
-              account_handle: "bravotv",
-              saved_count: 90,
-              scraped_count: 75,
-            },
-            {
-              platform: "instagram",
-              account_handle: "thetraitorsus",
-              saved_count: 442,
-              scraped_count: 442,
-            },
-            {
-              platform: "tiktok",
-              account_handle: "thetraitorsus",
-              saved_count: 275,
-              scraped_count: 275,
-            },
-            {
-              platform: "twitter",
-              account_handle: "thetraitorsus",
-              saved_count: 5227,
-              scraped_count: 285,
-            },
-          ],
-        };
-      }
-      return { rows: [] };
-    });
-
     const result = await getSocialLandingPayloadResult();
     const networkSet = result.payload.network_sets[0];
     const traitors = result.payload.show_sets.find(


### PR DESCRIPTION
## Summary
- remove app-owned direct SQL for landing progress, scrape health, and completion summaries
- preserve stale/cache behavior and timing headers through backend proxy calls

## Validation
- 40 targeted Vitest tests passed

## Dependencies
Backend landing-progress, scrape-health, and completion-summary routes must land first.