### PR TITLE
Validate admin API inputs and typography fallbacks

### DIFF
--- a/apps/web/src/app/api/admin/trr-api/people/[personId]/credits/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/people/[personId]/credits/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/server/auth";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 import {
   getEpisodeCreditsByPersonId,
   type PersonShowEpisodeCredit,
@@ -340,10 +341,25 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     const { searchParams } = new URL(request.url);
-    const parsedLimit = Number.parseInt(searchParams.get("limit") ?? "50", 10);
-    const parsedOffset = Number.parseInt(searchParams.get("offset") ?? "0", 10);
-    const limit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : 50;
-    const offset = Number.isFinite(parsedOffset) && parsedOffset >= 0 ? parsedOffset : 0;
+    const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: 50,
+      min: 1,
+      max: 500,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const offsetResult = parseBoundedIntegerParam(searchParams.get("offset"), {
+      name: "offset",
+      defaultValue: 0,
+      min: 0,
+    });
+    if (!offsetResult.ok) {
+      return NextResponse.json({ error: offsetResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
+    const offset = offsetResult.value;
     const showIdRaw = searchParams.get("showId");
     const showId =
       typeof showIdRaw === "string" && showIdRaw.trim().length > 0

--- a/apps/web/src/app/api/admin/trr-api/people/[personId]/photos/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/people/[personId]/photos/route.ts
@@ -82,13 +82,23 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const requestRole =
       requestRoleRaw === "primary" || requestRoleRaw === "polling" ? requestRoleRaw : "secondary";
 
-    const requestedLimit = limit;
-    const cacheSearchParams = new URLSearchParams(searchParams);
-    cacheSearchParams.delete("request_role");
+    const backendParams = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+    });
+    if (sources.length > 0) {
+      backendParams.set("sources", sources.join(","));
+    }
+    if (includeBroken) {
+      backendParams.set("include_broken", "true");
+    }
+    if (!includeTotalCount) {
+      backendParams.set("include_total_count", "false");
+    }
     const cacheKey = buildUserScopedRouteCacheKey(
       user.uid,
       `${personId}:photos`,
-      cacheSearchParams,
+      backendParams,
     );
     const cachedPayload = getRouteResponseCache<{
       photos: Array<Record<string, unknown>>;
@@ -110,19 +120,6 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       PERSON_PHOTOS_CACHE_NAMESPACE,
       cacheKey,
       async () => {
-        const backendParams = new URLSearchParams({
-          limit: String(requestedLimit),
-          offset: String(offset),
-        });
-        if (sources.length > 0) {
-          backendParams.set("sources", sources.join(","));
-        }
-        if (includeBroken) {
-          backendParams.set("include_broken", "true");
-        }
-        if (!includeTotalCount) {
-          backendParams.set("include_total_count", "false");
-        }
         const upstream = await fetchAdminBackendJson(
           `/admin/people/${personId}/gallery?${backendParams.toString()}`,
           {
@@ -170,7 +167,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
         const nextPayload = {
           photos: pagePhotos,
           pagination: {
-            limit: requestedLimit,
+            limit,
             offset,
             count: pagePhotos.length,
             total_count:

--- a/apps/web/src/app/api/admin/trr-api/people/[personId]/photos/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/people/[personId]/photos/route.ts
@@ -13,6 +13,7 @@ import {
   fetchAdminBackendJson,
   ADMIN_READ_PROXY_GALLERY_TIMEOUT_MS,
 } from "@/lib/server/trr-api/admin-read-proxy";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 
 export const dynamic = "force-dynamic";
 const PERSON_PHOTOS_CACHE_NAMESPACE = "admin-person-photos";
@@ -50,10 +51,25 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     const { searchParams } = new URL(request.url);
-    const parsedLimit = parseInt(searchParams.get("limit") ?? "100", 10);
-    const parsedOffset = parseInt(searchParams.get("offset") ?? "0", 10);
-    const limit = Number.isFinite(parsedLimit) ? parsedLimit : 100;
-    const offset = Number.isFinite(parsedOffset) ? parsedOffset : 0;
+    const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: 100,
+      min: 1,
+      max: 500,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const offsetResult = parseBoundedIntegerParam(searchParams.get("offset"), {
+      name: "offset",
+      defaultValue: 0,
+      min: 0,
+    });
+    if (!offsetResult.ok) {
+      return NextResponse.json({ error: offsetResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
+    const offset = offsetResult.value;
     const sources = (searchParams.get("sources") ?? "")
       .split(",")
       .map((value) => value.trim())
@@ -66,7 +82,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const requestRole =
       requestRoleRaw === "primary" || requestRoleRaw === "polling" ? requestRoleRaw : "secondary";
 
-    const requestedLimit = Math.max(1, Math.min(limit, 500));
+    const requestedLimit = limit;
     const cacheSearchParams = new URLSearchParams(searchParams);
     cacheSearchParams.delete("request_role");
     const cacheKey = buildUserScopedRouteCacheKey(

--- a/apps/web/src/app/api/admin/trr-api/people/home/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/people/home/route.ts
@@ -35,7 +35,8 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: limitResult.error }, { status: 400 });
     }
     const limit = limitResult.value;
-    const cacheKey = buildUserScopedRouteCacheKey(user.uid, "people-home", request.nextUrl.searchParams);
+    const upstreamParams = new URLSearchParams({ limit: String(limit) });
+    const cacheKey = buildUserScopedRouteCacheKey(user.uid, "people-home", upstreamParams);
     const cached = getRouteResponseCache<Record<string, unknown>>(TRR_PEOPLE_HOME_CACHE_NAMESPACE, cacheKey);
     if (cached) {
       return NextResponse.json(cached, { headers: { "x-trr-cache": "hit" } });
@@ -46,9 +47,7 @@ export async function GET(request: NextRequest) {
       cacheKey,
       async () => {
         const upstream = await fetchAdminBackendJson(
-          `/admin/trr-api/people/home?${new URLSearchParams({
-            limit: String(limit),
-          }).toString()}`,
+          `/admin/trr-api/people/home?${upstreamParams.toString()}`,
           {
             headers: {
               "X-TRR-Admin-User-Uid": user.uid,

--- a/apps/web/src/app/api/admin/trr-api/people/home/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/people/home/route.ts
@@ -15,21 +15,26 @@ import {
   TRR_PEOPLE_HOME_CACHE_NAMESPACE,
   TRR_PEOPLE_HOME_CACHE_TTL_MS,
 } from "@/lib/server/trr-api/trr-show-read-route-cache";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 
 export const dynamic = "force-dynamic";
 
 const DEFAULT_SECTION_LIMIT = 12;
 const MAX_SECTION_LIMIT = 24;
-const parseLimit = (raw: string | null): number => {
-  const parsed = Number.parseInt(raw ?? String(DEFAULT_SECTION_LIMIT), 10);
-  if (!Number.isFinite(parsed)) return DEFAULT_SECTION_LIMIT;
-  return Math.min(Math.max(parsed, 1), MAX_SECTION_LIMIT);
-};
 
 export async function GET(request: NextRequest) {
   try {
     const user = await requireAdmin(request);
-    const limit = parseLimit(request.nextUrl.searchParams.get("limit"));
+    const limitResult = parseBoundedIntegerParam(request.nextUrl.searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: DEFAULT_SECTION_LIMIT,
+      min: 1,
+      max: MAX_SECTION_LIMIT,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
     const cacheKey = buildUserScopedRouteCacheKey(user.uid, "people-home", request.nextUrl.searchParams);
     const cached = getRouteResponseCache<Record<string, unknown>>(TRR_PEOPLE_HOME_CACHE_NAMESPACE, cacheKey);
     if (cached) {

--- a/apps/web/src/app/api/admin/trr-api/people/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/people/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/server/auth";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 import { searchPeople } from "@/lib/server/trr-api/trr-shows-repository";
 
 export const dynamic = "force-dynamic";
@@ -23,8 +24,23 @@ export async function GET(request: NextRequest) {
 
     const { searchParams } = new URL(request.url);
     const query = searchParams.get("q")?.trim() ?? "";
-    const rawLimit = parseInt(searchParams.get("limit") ?? "10", 10);
-    const offset = parseInt(searchParams.get("offset") ?? "0", 10);
+    const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: 10,
+      min: 1,
+      max: MAX_LIMIT,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const offsetResult = parseBoundedIntegerParam(searchParams.get("offset"), {
+      name: "offset",
+      defaultValue: 0,
+      min: 0,
+    });
+    if (!offsetResult.ok) {
+      return NextResponse.json({ error: offsetResult.error }, { status: 400 });
+    }
 
     // Enforce min query length to avoid full table scans
     if (query.length < MIN_QUERY_LENGTH) {
@@ -34,8 +50,8 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Cap limit to prevent abuse
-    const limit = Math.min(Math.max(1, rawLimit), MAX_LIMIT);
+    const limit = limitResult.value;
+    const offset = offsetResult.value;
 
     const people = await searchPeople(query, { limit, offset });
 

--- a/apps/web/src/app/api/admin/trr-api/search/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/search/route.ts
@@ -45,7 +45,8 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: limitResult.error }, { status: 400 });
     }
     const limit = limitResult.value;
-    const cacheKey = buildUserScopedRouteCacheKey(user.uid, "search", request.nextUrl.searchParams);
+    const upstreamParams = new URLSearchParams({ q: query, limit: String(limit) });
+    const cacheKey = buildUserScopedRouteCacheKey(user.uid, "search", upstreamParams);
     const cached = getRouteResponseCache<Record<string, unknown>>(TRR_SEARCH_CACHE_NAMESPACE, cacheKey);
     if (cached) {
       return NextResponse.json(cached, { headers: { "x-trr-cache": "hit" } });
@@ -56,7 +57,7 @@ export async function GET(request: NextRequest) {
       cacheKey,
       async () => {
         const upstream = await fetchAdminBackendJson(
-          `/admin/trr-api/search?${new URLSearchParams({ q: query, limit: String(limit) }).toString()}`,
+          `/admin/trr-api/search?${upstreamParams.toString()}`,
           {
             timeoutMs: ADMIN_READ_PROXY_SHORT_TIMEOUT_MS,
             routeName: "admin-global-search",

--- a/apps/web/src/app/api/admin/trr-api/search/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/search/route.ts
@@ -15,17 +15,13 @@ import {
   TRR_SEARCH_CACHE_NAMESPACE,
   TRR_SEARCH_CACHE_TTL_MS,
 } from "@/lib/server/trr-api/trr-show-read-route-cache";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 
 export const dynamic = "force-dynamic";
 
 const MIN_QUERY_LENGTH = 3;
 const DEFAULT_LIMIT = 8;
 const MAX_LIMIT = 20;
-const parseLimit = (raw: string | null): number => {
-  const parsed = Number.parseInt(raw ?? String(DEFAULT_LIMIT), 10);
-  if (!Number.isFinite(parsed)) return DEFAULT_LIMIT;
-  return Math.min(Math.max(parsed, 1), MAX_LIMIT);
-};
 
 export async function GET(request: NextRequest) {
   try {
@@ -39,7 +35,16 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const limit = parseLimit(request.nextUrl.searchParams.get("limit"));
+    const limitResult = parseBoundedIntegerParam(request.nextUrl.searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: DEFAULT_LIMIT,
+      min: 1,
+      max: MAX_LIMIT,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
     const cacheKey = buildUserScopedRouteCacheKey(user.uid, "search", request.nextUrl.searchParams);
     const cached = getRouteResponseCache<Record<string, unknown>>(TRR_SEARCH_CACHE_NAMESPACE, cacheKey);
     if (cached) {

--- a/apps/web/src/app/api/admin/trr-api/seasons/[seasonId]/episodes/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/seasons/[seasonId]/episodes/route.ts
@@ -15,6 +15,7 @@ import {
   TRR_SEASON_EPISODES_CACHE_NAMESPACE,
   TRR_SEASON_EPISODES_CACHE_TTL_MS,
 } from "@/lib/server/trr-api/trr-show-read-route-cache";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 
 export const dynamic = "force-dynamic";
 
@@ -32,8 +33,25 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     const { searchParams } = new URL(request.url);
-    const limit = parseInt(searchParams.get("limit") ?? "20", 10);
-    const offset = parseInt(searchParams.get("offset") ?? "0", 10);
+    const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: 20,
+      min: 1,
+      max: 500,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const offsetResult = parseBoundedIntegerParam(searchParams.get("offset"), {
+      name: "offset",
+      defaultValue: 0,
+      min: 0,
+    });
+    if (!offsetResult.ok) {
+      return NextResponse.json({ error: offsetResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
+    const offset = offsetResult.value;
     const cacheKey = buildUserScopedRouteCacheKey(
       user.uid,
       `season-episodes:${seasonId}`,

--- a/apps/web/src/app/api/admin/trr-api/seasons/[seasonId]/episodes/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/seasons/[seasonId]/episodes/route.ts
@@ -52,10 +52,14 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
     const limit = limitResult.value;
     const offset = offsetResult.value;
+    const upstreamParams = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+    });
     const cacheKey = buildUserScopedRouteCacheKey(
       user.uid,
       `season-episodes:${seasonId}`,
-      request.nextUrl.searchParams,
+      upstreamParams,
     );
     const cached = getRouteResponseCache<Record<string, unknown>>(TRR_SEASON_EPISODES_CACHE_NAMESPACE, cacheKey);
     if (cached) {
@@ -67,10 +71,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       cacheKey,
       async () => {
         const upstream = await fetchAdminBackendJson(
-          `/admin/trr-api/seasons/${seasonId}/episodes?${new URLSearchParams({
-            limit: String(limit),
-            offset: String(offset),
-          }).toString()}`,
+          `/admin/trr-api/seasons/${seasonId}/episodes?${upstreamParams.toString()}`,
           {
             timeoutMs: ADMIN_READ_PROXY_SHORT_TIMEOUT_MS,
             routeName: "season-episodes",

--- a/apps/web/src/app/api/admin/trr-api/shows/[showId]/assets/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/[showId]/assets/route.ts
@@ -17,6 +17,7 @@ import {
   TRR_SHOW_ASSETS_CACHE_NAMESPACE,
   TRR_SHOW_ASSETS_CACHE_TTL_MS,
 } from "@/lib/server/trr-api/trr-show-read-route-cache";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 
 export const dynamic = "force-dynamic";
 const DEFAULT_VISIBLE_ASSET_LIMIT = 48;
@@ -42,10 +43,25 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
     }
 
     const { searchParams } = new URL(_request.url);
-    const parsedLimit = parseInt(searchParams.get("limit") ?? String(DEFAULT_VISIBLE_ASSET_LIMIT), 10);
-    const parsedOffset = parseInt(searchParams.get("offset") ?? "0", 10);
-    const limit = Number.isFinite(parsedLimit) ? parsedLimit : DEFAULT_VISIBLE_ASSET_LIMIT;
-    const offset = Number.isFinite(parsedOffset) ? parsedOffset : 0;
+    const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: DEFAULT_VISIBLE_ASSET_LIMIT,
+      min: 1,
+      max: FULL_FETCH_LIMIT,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const offsetResult = parseBoundedIntegerParam(searchParams.get("offset"), {
+      name: "offset",
+      defaultValue: 0,
+      min: 0,
+    });
+    if (!offsetResult.ok) {
+      return NextResponse.json({ error: offsetResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
+    const offset = offsetResult.value;
     const cursor = searchParams.get("cursor")?.trim() || null;
     const full =
       searchParams.get("full") === "1" ||

--- a/apps/web/src/app/api/admin/trr-api/shows/[showId]/cast/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/[showId]/cast/route.ts
@@ -16,6 +16,7 @@ import {
   TRR_SHOW_CAST_CACHE_NAMESPACE,
   TRR_SHOW_CAST_CACHE_TTL_MS,
 } from "@/lib/server/trr-api/trr-show-read-route-cache";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 
 export const dynamic = "force-dynamic";
 
@@ -47,8 +48,25 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json(cached, { headers: { "x-trr-cache": "hit" } });
     }
 
-    const limit = parseInt(searchParams.get("limit") ?? "20", 10);
-    const offset = parseInt(searchParams.get("offset") ?? "0", 10);
+    const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: 20,
+      min: 1,
+      max: 500,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const offsetResult = parseBoundedIntegerParam(searchParams.get("offset"), {
+      name: "offset",
+      defaultValue: 0,
+      min: 0,
+    });
+    if (!offsetResult.ok) {
+      return NextResponse.json({ error: offsetResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
+    const offset = offsetResult.value;
     const minEpisodes = searchParams.get("minEpisodes");
     const excludeZeroEpisodeMembers =
       String(searchParams.get("exclude_zero_episode_members") ?? "").trim().toLowerCase() === "1" ||

--- a/apps/web/src/app/api/admin/trr-api/shows/[showId]/cast/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/[showId]/cast/route.ts
@@ -42,12 +42,6 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     const { searchParams } = new URL(request.url);
-    const cacheKey = buildUserScopedRouteCacheKey(user.uid, `${showId}:cast`, request.nextUrl.searchParams);
-    const cached = getRouteResponseCache<Record<string, unknown>>(TRR_SHOW_CAST_CACHE_NAMESPACE, cacheKey);
-    if (cached) {
-      return NextResponse.json(cached, { headers: { "x-trr-cache": "hit" } });
-    }
-
     const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
       name: "limit",
       defaultValue: 20,
@@ -83,25 +77,30 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const photoFallbackMode = parsePhotoFallbackMode(searchParams.get("photo_fallback"));
     const eligibilityModeRaw = String(searchParams.get("eligibility_mode") ?? "").trim().toLowerCase();
     const eligibilityMode: CastEligibilityMode = eligibilityModeRaw === "links" ? "links" : "default";
+    const upstreamParams = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+      roster_mode: rosterMode,
+      photo_fallback: photoFallbackMode,
+    });
+    if (typeof minEpisodes === "string" && minEpisodes.trim().length > 0) {
+      upstreamParams.set("minEpisodes", minEpisodes.trim());
+    }
+    if (excludeZeroEpisodeMembers) upstreamParams.set("exclude_zero_episode_members", "true");
+    if (requireImage === "true" || requireImage === "1") upstreamParams.set("requireImage", "true");
+    if (!includePhotos) upstreamParams.set("include_photos", "false");
+    if (eligibilityMode === "links") upstreamParams.set("eligibility_mode", "links");
+
+    const cacheKey = buildUserScopedRouteCacheKey(user.uid, `${showId}:cast`, upstreamParams);
+    const cached = getRouteResponseCache<Record<string, unknown>>(TRR_SHOW_CAST_CACHE_NAMESPACE, cacheKey);
+    if (cached) {
+      return NextResponse.json(cached, { headers: { "x-trr-cache": "hit" } });
+    }
 
     const payload = await getOrCreateRouteResponsePromise(
       TRR_SHOW_CAST_CACHE_NAMESPACE,
       cacheKey,
       async () => {
-        const upstreamParams = new URLSearchParams({
-          limit: String(limit),
-          offset: String(offset),
-          roster_mode: rosterMode,
-          photo_fallback: photoFallbackMode,
-        });
-        if (typeof minEpisodes === "string" && minEpisodes.trim().length > 0) {
-          upstreamParams.set("minEpisodes", minEpisodes.trim());
-        }
-        if (excludeZeroEpisodeMembers) upstreamParams.set("exclude_zero_episode_members", "true");
-        if (requireImage === "true" || requireImage === "1") upstreamParams.set("requireImage", "true");
-        if (!includePhotos) upstreamParams.set("include_photos", "false");
-        if (eligibilityMode === "links") upstreamParams.set("eligibility_mode", "links");
-
         const upstream = await fetchAdminBackendJson(
           `/admin/trr-api/shows/${showId}/cast?${upstreamParams.toString()}`,
           {

--- a/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/assets/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/assets/route.ts
@@ -17,6 +17,7 @@ import {
   TRR_SEASON_ASSETS_CACHE_NAMESPACE,
   TRR_SEASON_ASSETS_CACHE_TTL_MS,
 } from "@/lib/server/trr-api/trr-show-read-route-cache";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 
 export const dynamic = "force-dynamic";
 const DEFAULT_VISIBLE_ASSET_LIMIT = 48;
@@ -54,10 +55,25 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     const { searchParams } = new URL(request.url);
-    const parsedLimit = parseInt(searchParams.get("limit") ?? String(DEFAULT_VISIBLE_ASSET_LIMIT), 10);
-    const parsedOffset = parseInt(searchParams.get("offset") ?? "0", 10);
-    const limit = Number.isFinite(parsedLimit) ? parsedLimit : DEFAULT_VISIBLE_ASSET_LIMIT;
-    const offset = Number.isFinite(parsedOffset) ? parsedOffset : 0;
+    const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: DEFAULT_VISIBLE_ASSET_LIMIT,
+      min: 1,
+      max: FULL_FETCH_LIMIT,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const offsetResult = parseBoundedIntegerParam(searchParams.get("offset"), {
+      name: "offset",
+      defaultValue: 0,
+      min: 0,
+    });
+    if (!offsetResult.ok) {
+      return NextResponse.json({ error: offsetResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
+    const offset = offsetResult.value;
     const cursor = searchParams.get("cursor")?.trim() || null;
     const full =
       searchParams.get("full") === "1" ||

--- a/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/cast/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/cast/route.ts
@@ -15,6 +15,7 @@ import {
   TRR_SEASON_CAST_CACHE_NAMESPACE,
   TRR_SEASON_CAST_CACHE_TTL_MS,
 } from "@/lib/server/trr-api/trr-show-read-route-cache";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 
 export const dynamic = "force-dynamic";
 
@@ -40,10 +41,25 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     const { searchParams } = new URL(request.url);
-    const limitParam = parseInt(searchParams.get("limit") ?? "500", 10);
-    const offsetParam = parseInt(searchParams.get("offset") ?? "0", 10);
-    const limit = Number.isFinite(limitParam) ? Math.min(limitParam, 500) : 500;
-    const offset = Number.isFinite(offsetParam) ? Math.max(offsetParam, 0) : 0;
+    const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: 500,
+      min: 1,
+      max: 500,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const offsetResult = parseBoundedIntegerParam(searchParams.get("offset"), {
+      name: "offset",
+      defaultValue: 0,
+      min: 0,
+    });
+    if (!offsetResult.ok) {
+      return NextResponse.json({ error: offsetResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
+    const offset = offsetResult.value;
     const includeArchiveOnly = (searchParams.get("include_archive_only") ?? "").toLowerCase() === "true";
     const photoFallbackMode = parsePhotoFallbackMode(searchParams.get("photo_fallback"));
 

--- a/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/cast/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/cast/route.ts
@@ -62,11 +62,19 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const offset = offsetResult.value;
     const includeArchiveOnly = (searchParams.get("include_archive_only") ?? "").toLowerCase() === "true";
     const photoFallbackMode = parsePhotoFallbackMode(searchParams.get("photo_fallback"));
+    const upstreamParams = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+      photo_fallback: photoFallbackMode,
+    });
+    if (includeArchiveOnly) {
+      upstreamParams.set("include_archive_only", "true");
+    }
 
     const cacheKey = buildUserScopedRouteCacheKey(
       user.uid,
       `season-cast:${showId}:${seasonNum}`,
-      request.nextUrl.searchParams,
+      upstreamParams,
     );
     const cached = getRouteResponseCache<Record<string, unknown>>(TRR_SEASON_CAST_CACHE_NAMESPACE, cacheKey);
     if (cached) {
@@ -77,14 +85,6 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       TRR_SEASON_CAST_CACHE_NAMESPACE,
       cacheKey,
       async () => {
-        const upstreamParams = new URLSearchParams({
-          limit: String(limit),
-          offset: String(offset),
-          photo_fallback: photoFallbackMode,
-        });
-        if (includeArchiveOnly) {
-          upstreamParams.set("include_archive_only", "true");
-        }
         const upstream = await fetchAdminBackendJson(
           `/admin/trr-api/shows/${showId}/seasons/${seasonNum}/cast?${upstreamParams.toString()}`,
           {

--- a/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/route.ts
@@ -15,6 +15,7 @@ import {
   TRR_SHOW_SEASONS_CACHE_NAMESPACE,
   TRR_SHOW_SEASONS_CACHE_TTL_MS,
 } from "@/lib/server/trr-api/trr-show-read-route-cache";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 import { getSeasonsByShowId } from "@/lib/server/trr-api/trr-shows-repository";
 
 export const dynamic = "force-dynamic";
@@ -73,8 +74,25 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     const { searchParams } = new URL(request.url);
-    const limit = parseInt(searchParams.get("limit") ?? "20", 10);
-    const offset = parseInt(searchParams.get("offset") ?? "0", 10);
+    const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: 20,
+      min: 1,
+      max: 100,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const offsetResult = parseBoundedIntegerParam(searchParams.get("offset"), {
+      name: "offset",
+      defaultValue: 0,
+      min: 0,
+    });
+    if (!offsetResult.ok) {
+      return NextResponse.json({ error: offsetResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
+    const offset = offsetResult.value;
     const includeEpisodeSignal = parseBoolean(searchParams.get("include_episode_signal"));
 
     const cacheKey = buildUserScopedRouteCacheKey(

--- a/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/[showId]/seasons/route.ts
@@ -57,7 +57,7 @@ const buildLocalSeasonsPayload = async (
  * Ordered by season_number DESC (newest first).
  *
  * Query params:
- * - limit: max results (default 20, max 100)
+ * - limit: max results (default 20, max 500)
  * - offset: pagination offset (default 0)
  */
 export async function GET(request: NextRequest, { params }: RouteParams) {
@@ -78,7 +78,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       name: "limit",
       defaultValue: 20,
       min: 1,
-      max: 100,
+      max: 500,
     });
     if (!limitResult.ok) {
       return NextResponse.json({ error: limitResult.error }, { status: 400 });
@@ -94,11 +94,18 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const limit = limitResult.value;
     const offset = offsetResult.value;
     const includeEpisodeSignal = parseBoolean(searchParams.get("include_episode_signal"));
+    const upstreamParams = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+    });
+    if (includeEpisodeSignal) {
+      upstreamParams.set("include_episode_signal", "true");
+    }
 
     const cacheKey = buildUserScopedRouteCacheKey(
       user.uid,
       `${showId}:list`,
-      request.nextUrl.searchParams,
+      upstreamParams,
     );
     const cached = getRouteResponseCache<Record<string, unknown>>(TRR_SHOW_SEASONS_CACHE_NAMESPACE, cacheKey);
     if (cached) {
@@ -109,13 +116,6 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       TRR_SHOW_SEASONS_CACHE_NAMESPACE,
       cacheKey,
       async () => {
-        const upstreamParams = new URLSearchParams({
-          limit: String(limit),
-          offset: String(offset),
-        });
-        if (includeEpisodeSignal) {
-          upstreamParams.set("include_episode_signal", "true");
-        }
         try {
           const upstream = await fetchAdminBackendJson(
             `/admin/trr-api/shows/${showId}/seasons?${upstreamParams.toString()}`,

--- a/apps/web/src/app/api/admin/trr-api/shows/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/route.ts
@@ -15,6 +15,7 @@ import {
   TRR_SHOWS_CACHE_NAMESPACE,
   TRR_SHOWS_CACHE_TTL_MS,
 } from "@/lib/server/trr-api/trr-show-read-route-cache";
+import { parseBoundedIntegerParam } from "@/lib/server/trr-api/query-integer-params";
 
 export const dynamic = "force-dynamic";
 
@@ -34,8 +35,25 @@ export async function GET(request: NextRequest) {
 
     const { searchParams } = new URL(request.url);
     const query = searchParams.get("q") ?? "";
-    const limit = parseInt(searchParams.get("limit") ?? "20", 10);
-    const offset = parseInt(searchParams.get("offset") ?? "0", 10);
+    const limitResult = parseBoundedIntegerParam(searchParams.get("limit"), {
+      name: "limit",
+      defaultValue: 20,
+      min: 1,
+      max: 100,
+    });
+    if (!limitResult.ok) {
+      return NextResponse.json({ error: limitResult.error }, { status: 400 });
+    }
+    const offsetResult = parseBoundedIntegerParam(searchParams.get("offset"), {
+      name: "offset",
+      defaultValue: 0,
+      min: 0,
+    });
+    if (!offsetResult.ok) {
+      return NextResponse.json({ error: offsetResult.error }, { status: 400 });
+    }
+    const limit = limitResult.value;
+    const offset = offsetResult.value;
 
     if (!query.trim()) {
       return NextResponse.json(

--- a/apps/web/src/app/api/admin/trr-api/shows/route.ts
+++ b/apps/web/src/app/api/admin/trr-api/shows/route.ts
@@ -62,7 +62,12 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const cacheKey = buildUserScopedRouteCacheKey(user.uid, "shows", searchParams);
+    const upstreamParams = new URLSearchParams({
+      q: query,
+      limit: String(limit),
+      offset: String(offset),
+    });
+    const cacheKey = buildUserScopedRouteCacheKey(user.uid, "shows", upstreamParams);
     const cached = getRouteResponseCache<Record<string, unknown>>(TRR_SHOWS_CACHE_NAMESPACE, cacheKey);
     if (cached) {
       return NextResponse.json(cached, { headers: { "x-trr-cache": "hit" } });
@@ -73,11 +78,7 @@ export async function GET(request: NextRequest) {
       cacheKey,
       async () => {
         const upstream = await fetchAdminBackendJson(
-          `/admin/trr-api/shows?${new URLSearchParams({
-            q: query,
-            limit: String(limit),
-            offset: String(offset),
-          }).toString()}`,
+          `/admin/trr-api/shows?${upstreamParams.toString()}`,
           {
             timeoutMs: ADMIN_READ_PROXY_SHORT_TIMEOUT_MS,
             routeName: "admin-shows",

--- a/apps/web/src/lib/admin/api-references/generated/inventory.ts
+++ b/apps/web/src/lib/admin/api-references/generated/inventory.ts
@@ -3,8 +3,8 @@ import type { AdminApiReferenceInventory } from "@/lib/admin/api-references/type
 export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
   "inventorySchemaVersion": "1.0.0",
   "generatorVersion": "1.0.0",
-  "generatedAt": "2026-07-13T21:51:22.814Z",
-  "sourceCommitSha": "8cb8ada50ff8b01db41d596ff10a22cbb90bf52b",
+  "generatedAt": "2026-07-13T21:52:10.426Z",
+  "sourceCommitSha": "33a9d40cd3eaa0d4f179ebe01d7cbd1b9ed816e3",
   "overrideDigest": "cd85a76fd2fc977cbc691ccab80ce844f9ea783e118af35eb3d9766e5d61fd36",
   "nodes": [
     {
@@ -10255,7 +10255,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/people/route.ts",
       "sourceLocator": {
-        "line": 20,
+        "line": 21,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -10358,7 +10358,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/people/[personId]/credits/route.ts",
       "sourceLocator": {
-        "line": 329,
+        "line": 330,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -10460,7 +10460,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/people/[personId]/photos/route.ts",
       "sourceLocator": {
-        "line": 39,
+        "line": 40,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -10529,7 +10529,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/people/home/route.ts",
       "sourceLocator": {
-        "line": 29,
+        "line": 25,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -10597,7 +10597,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/search/route.ts",
       "sourceLocator": {
-        "line": 30,
+        "line": 26,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -10631,7 +10631,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/seasons/[seasonId]/episodes/route.ts",
       "sourceLocator": {
-        "line": 25,
+        "line": 26,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -10698,7 +10698,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/shows/route.ts",
       "sourceLocator": {
-        "line": 31,
+        "line": 32,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -10766,7 +10766,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/shows/[showId]/assets/route.ts",
       "sourceLocator": {
-        "line": 34,
+        "line": 35,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -10870,7 +10870,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/shows/[showId]/cast/route.ts",
       "sourceLocator": {
-        "line": 32,
+        "line": 33,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -11109,7 +11109,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/shows/[showId]/seasons/route.ts",
       "sourceLocator": {
-        "line": 62,
+        "line": 63,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -11143,7 +11143,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/assets/route.ts",
       "sourceLocator": {
-        "line": 34,
+        "line": 35,
         "symbol": "GET"
       },
       "provenance": "static_scan",
@@ -11178,7 +11178,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "symbol": "GET",
       "sourceFile": "src/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/cast/route.ts",
       "sourceLocator": {
-        "line": 28,
+        "line": 29,
         "symbol": "GET"
       },
       "provenance": "static_scan",

--- a/apps/web/src/lib/server/trr-api/query-integer-params.ts
+++ b/apps/web/src/lib/server/trr-api/query-integer-params.ts
@@ -1,0 +1,37 @@
+export type BoundedIntegerParamOptions = {
+  name: string;
+  defaultValue: number;
+  min?: number;
+  max?: number;
+};
+
+export type BoundedIntegerParamResult =
+  | { ok: true; value: number }
+  | { ok: false; error: string };
+
+const INTEGER_RE = /^[+-]?\d+$/;
+
+export function parseBoundedIntegerParam(
+  rawValue: string | null,
+  options: BoundedIntegerParamOptions,
+): BoundedIntegerParamResult {
+  const { name, defaultValue, min, max } = options;
+  if (rawValue === null) {
+    return { ok: true, value: defaultValue };
+  }
+
+  const trimmed = rawValue.trim();
+  if (!INTEGER_RE.test(trimmed)) {
+    return { ok: false, error: `${name} must be an integer` };
+  }
+
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed)) {
+    return { ok: false, error: `${name} must be a safe integer` };
+  }
+
+  let value = parsed;
+  if (typeof min === "number") value = Math.max(value, min);
+  if (typeof max === "number") value = Math.min(value, max);
+  return { ok: true, value };
+}

--- a/apps/web/tests/admin-global-search-route.test.ts
+++ b/apps/web/tests/admin-global-search-route.test.ts
@@ -90,4 +90,15 @@ describe("/api/admin/trr-api/search", () => {
       show_slug: "the-traitors-us",
     });
   });
+
+  it("rejects malformed explicit limits before proxying", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/trr-api/search?q=ala&limit=abc"),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("limit must be an integer");
+    expect(fetchAdminBackendJsonMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/tests/admin-people-route.test.ts
+++ b/apps/web/tests/admin-people-route.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { requireAdminMock, searchPeopleMock } = vi.hoisted(() => ({
+  requireAdminMock: vi.fn(),
+  searchPeopleMock: vi.fn(),
+}));
+
+vi.mock("@/lib/server/auth", () => ({
+  requireAdmin: requireAdminMock,
+}));
+
+vi.mock("@/lib/server/trr-api/trr-shows-repository", () => ({
+  searchPeople: searchPeopleMock,
+}));
+
+import { GET } from "@/app/api/admin/trr-api/people/route";
+
+describe("/api/admin/trr-api/people", () => {
+  beforeEach(() => {
+    requireAdminMock.mockReset();
+    searchPeopleMock.mockReset();
+    requireAdminMock.mockResolvedValue({ uid: "admin-user" });
+    searchPeopleMock.mockResolvedValue([]);
+  });
+
+  it("rejects malformed explicit limit values before searching", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/trr-api/people?q=al&limit=abc"),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("limit must be an integer");
+    expect(searchPeopleMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed explicit offset values before searching", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/trr-api/people?q=al&offset=abc"),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("offset must be an integer");
+    expect(searchPeopleMock).not.toHaveBeenCalled();
+  });
+
+  it("clamps valid out-of-range pagination values", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/trr-api/people?q=al&limit=999&offset=-4"),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(searchPeopleMock).toHaveBeenCalledWith("al", { limit: 20, offset: 0 });
+    expect(payload.pagination).toMatchObject({ limit: 20, offset: 0 });
+  });
+});

--- a/apps/web/tests/admin-route-cache-key-normalization.test.ts
+++ b/apps/web/tests/admin-route-cache-key-normalization.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const { fetchAdminBackendJsonMock, requireAdminMock, resolveAdminShowIdMock } = vi.hoisted(() => {
+  process.env.TRR_ADMIN_ROUTE_CACHE_DISABLED = "0";
+  return {
+    fetchAdminBackendJsonMock: vi.fn(),
+    requireAdminMock: vi.fn(),
+    resolveAdminShowIdMock: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/server/auth", () => ({ requireAdmin: requireAdminMock }));
+vi.mock("@/lib/server/admin/resolve-show-id", () => ({
+  resolveAdminShowId: resolveAdminShowIdMock,
+}));
+vi.mock("@/lib/server/trr-api/admin-read-proxy", () => ({
+  AdminReadProxyError: class AdminReadProxyError extends Error {},
+  ADMIN_READ_PROXY_GALLERY_TIMEOUT_MS: 8_000,
+  ADMIN_READ_PROXY_PRIMARY_TIMEOUT_MS: 20_000,
+  ADMIN_READ_PROXY_SHORT_TIMEOUT_MS: 5_000,
+  buildAdminProxyErrorResponse: (error: unknown) =>
+    NextResponse.json({ error: error instanceof Error ? error.message : "failed" }, { status: 500 }),
+  fetchAdminBackendJson: fetchAdminBackendJsonMock,
+}));
+vi.mock("@/lib/server/trr-api/trr-shows-repository", () => ({
+  getSeasonsByShowId: vi.fn(),
+}));
+
+import { GET as getPeopleHome } from "@/app/api/admin/trr-api/people/home/route";
+import { GET as getPersonPhotos } from "@/app/api/admin/trr-api/people/[personId]/photos/route";
+import { GET as getSearch } from "@/app/api/admin/trr-api/search/route";
+import { GET as getSeasonEpisodes } from "@/app/api/admin/trr-api/seasons/[seasonId]/episodes/route";
+import { GET as getShowCast } from "@/app/api/admin/trr-api/shows/[showId]/cast/route";
+import { GET as getSeasonCast } from "@/app/api/admin/trr-api/shows/[showId]/seasons/[seasonNumber]/cast/route";
+import { GET as getShowSeasons } from "@/app/api/admin/trr-api/shows/[showId]/seasons/route";
+import { GET as getShows } from "@/app/api/admin/trr-api/shows/route";
+import { invalidateRouteResponseCache } from "@/lib/server/admin/route-response-cache";
+import {
+  TRR_PEOPLE_HOME_CACHE_NAMESPACE,
+  TRR_SEARCH_CACHE_NAMESPACE,
+  TRR_SEASON_CAST_CACHE_NAMESPACE,
+  TRR_SEASON_EPISODES_CACHE_NAMESPACE,
+  TRR_SHOW_CAST_CACHE_NAMESPACE,
+  TRR_SHOW_SEASONS_CACHE_NAMESPACE,
+  TRR_SHOWS_CACHE_NAMESPACE,
+} from "@/lib/server/trr-api/trr-show-read-route-cache";
+
+const PERSON_PHOTOS_CACHE_NAMESPACE = "admin-person-photos";
+
+describe("admin route cache key normalization", () => {
+  beforeEach(() => {
+    requireAdminMock.mockReset();
+    resolveAdminShowIdMock.mockReset();
+    fetchAdminBackendJsonMock.mockReset();
+    requireAdminMock.mockResolvedValue({ uid: "admin-user" });
+    resolveAdminShowIdMock.mockResolvedValue("show-1");
+    fetchAdminBackendJsonMock.mockResolvedValue({
+      status: 200,
+      data: { photos: [], pagination: {}, result: "ok" },
+      durationMs: 1,
+    });
+    for (const namespace of [
+      TRR_PEOPLE_HOME_CACHE_NAMESPACE,
+      TRR_SEARCH_CACHE_NAMESPACE,
+      TRR_SEASON_CAST_CACHE_NAMESPACE,
+      TRR_SEASON_EPISODES_CACHE_NAMESPACE,
+      TRR_SHOW_CAST_CACHE_NAMESPACE,
+      TRR_SHOW_SEASONS_CACHE_NAMESPACE,
+      TRR_SHOWS_CACHE_NAMESPACE,
+      PERSON_PHOTOS_CACHE_NAMESPACE,
+    ]) {
+      invalidateRouteResponseCache(namespace);
+    }
+  });
+
+  it("deduplicates equivalent top-level list requests", async () => {
+    const secondShows = await getShows(
+      new NextRequest("http://localhost/api/admin/trr-api/shows?q=bravo&limit=999&offset=-4"),
+    ).then(async () =>
+      getShows(new NextRequest("http://localhost/api/admin/trr-api/shows?q=bravo&limit=100&offset=0")),
+    );
+    const secondSearch = await getSearch(
+      new NextRequest("http://localhost/api/admin/trr-api/search?q=%20bravo%20&limit=999"),
+    ).then(async () =>
+      getSearch(new NextRequest("http://localhost/api/admin/trr-api/search?q=bravo&limit=20")),
+    );
+    const secondPeople = await getPeopleHome(
+      new NextRequest("http://localhost/api/admin/trr-api/people/home?limit=999"),
+    ).then(async () =>
+      getPeopleHome(new NextRequest("http://localhost/api/admin/trr-api/people/home?limit=24")),
+    );
+
+    expect(secondShows.headers.get("x-trr-cache")).toBe("hit");
+    expect(secondSearch.headers.get("x-trr-cache")).toBe("hit");
+    expect(secondPeople.headers.get("x-trr-cache")).toBe("hit");
+    expect(fetchAdminBackendJsonMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("deduplicates equivalent show, season, and episode requests", async () => {
+    const showParams = { params: Promise.resolve({ showId: "show-1" }) };
+    const secondSeasons = await getShowSeasons(
+      new NextRequest(
+        "http://localhost/api/admin/trr-api/shows/show-1/seasons?limit=999&offset=-1&include_episode_signal=1",
+      ),
+      showParams,
+    ).then(async () =>
+      getShowSeasons(
+        new NextRequest(
+          "http://localhost/api/admin/trr-api/shows/show-1/seasons?limit=500&offset=0&include_episode_signal=true",
+        ),
+        showParams,
+      ),
+    );
+    const secondShowCast = await getShowCast(
+      new NextRequest("http://localhost/api/admin/trr-api/shows/show-1/cast?limit=999&offset=-1"),
+      showParams,
+    ).then(async () =>
+      getShowCast(
+        new NextRequest("http://localhost/api/admin/trr-api/shows/show-1/cast?limit=500&offset=0"),
+        showParams,
+      ),
+    );
+    const seasonCastParams = {
+      params: Promise.resolve({ showId: "show-1", seasonNumber: "1" }),
+    };
+    const secondSeasonCast = await getSeasonCast(
+      new NextRequest(
+        "http://localhost/api/admin/trr-api/shows/show-1/seasons/1/cast?limit=999&offset=-1&include_archive_only=TRUE",
+      ),
+      seasonCastParams,
+    ).then(async () =>
+      getSeasonCast(
+        new NextRequest(
+          "http://localhost/api/admin/trr-api/shows/show-1/seasons/1/cast?limit=500&offset=0&include_archive_only=true&photo_fallback=none",
+        ),
+        seasonCastParams,
+      ),
+    );
+    const episodeParams = { params: Promise.resolve({ seasonId: "season-1" }) };
+    const secondEpisodes = await getSeasonEpisodes(
+      new NextRequest("http://localhost/api/admin/trr-api/seasons/season-1/episodes?limit=999&offset=-1"),
+      episodeParams,
+    ).then(async () =>
+      getSeasonEpisodes(
+        new NextRequest("http://localhost/api/admin/trr-api/seasons/season-1/episodes?limit=500&offset=0"),
+        episodeParams,
+      ),
+    );
+
+    expect(secondSeasons.headers.get("x-trr-cache")).toBe("hit");
+    expect(secondShowCast.headers.get("x-trr-cache")).toBe("hit");
+    expect(secondSeasonCast.headers.get("x-trr-cache")).toBe("hit");
+    expect(secondEpisodes.headers.get("x-trr-cache")).toBe("hit");
+    expect(fetchAdminBackendJsonMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("deduplicates canonical person-photo requests while excluding request role", async () => {
+    const params = { params: Promise.resolve({ personId: "person-1" }) };
+    await getPersonPhotos(
+      new NextRequest(
+        "http://localhost/api/admin/trr-api/people/person-1/photos?limit=999&offset=-1&include_broken=1&include_total_count=0&sources=getty,%20bravo&request_role=primary",
+      ),
+      params,
+    );
+    const second = await getPersonPhotos(
+      new NextRequest(
+        "http://localhost/api/admin/trr-api/people/person-1/photos?limit=500&offset=0&include_broken=true&include_total_count=false&sources=getty,bravo&request_role=polling",
+      ),
+      params,
+    );
+
+    expect(second.headers.get("x-trr-cache")).toBe("hit");
+    expect(fetchAdminBackendJsonMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/tests/admin-shows-route.test.ts
+++ b/apps/web/tests/admin-shows-route.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+process.env.TRR_ADMIN_ROUTE_CACHE_DISABLED = "1";
+
+const { requireAdminMock, fetchAdminBackendJsonMock } = vi.hoisted(() => ({
+  requireAdminMock: vi.fn(),
+  fetchAdminBackendJsonMock: vi.fn(),
+}));
+
+vi.mock("@/lib/server/auth", () => ({
+  requireAdmin: requireAdminMock,
+}));
+
+vi.mock("@/lib/server/trr-api/admin-read-proxy", () => ({
+  fetchAdminBackendJson: fetchAdminBackendJsonMock,
+  ADMIN_READ_PROXY_SHORT_TIMEOUT_MS: 5_000,
+  buildAdminProxyErrorResponse: (error: unknown) =>
+    NextResponse.json({ error: error instanceof Error ? error.message : "failed" }, { status: 500 }),
+}));
+
+import { GET } from "@/app/api/admin/trr-api/shows/route";
+
+describe("/api/admin/trr-api/shows", () => {
+  beforeEach(() => {
+    requireAdminMock.mockReset();
+    fetchAdminBackendJsonMock.mockReset();
+    requireAdminMock.mockResolvedValue({ uid: "admin-user" });
+    fetchAdminBackendJsonMock.mockResolvedValue({
+      status: 200,
+      data: { shows: [], pagination: { limit: 100, offset: 0, count: 0 } },
+      durationMs: 4,
+    });
+  });
+
+  it("rejects malformed explicit pagination values before proxying", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/trr-api/shows?q=bravo&limit=abc"),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("limit must be an integer");
+    expect(fetchAdminBackendJsonMock).not.toHaveBeenCalled();
+  });
+
+  it("clamps valid out-of-range pagination values before proxying", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/trr-api/shows?q=bravo&limit=999&offset=-4"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchAdminBackendJsonMock).toHaveBeenCalledWith(
+      "/admin/trr-api/shows?q=bravo&limit=100&offset=0",
+      expect.objectContaining({ routeName: "admin-shows" }),
+    );
+  });
+});

--- a/apps/web/tests/admin-shows-route.test.ts
+++ b/apps/web/tests/admin-shows-route.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest, NextResponse } from "next/server";
 
-process.env.TRR_ADMIN_ROUTE_CACHE_DISABLED = "1";
-
-const { requireAdminMock, fetchAdminBackendJsonMock } = vi.hoisted(() => ({
-  requireAdminMock: vi.fn(),
-  fetchAdminBackendJsonMock: vi.fn(),
-}));
+const { requireAdminMock, fetchAdminBackendJsonMock } = vi.hoisted(() => {
+  process.env.TRR_ADMIN_ROUTE_CACHE_DISABLED = "1";
+  return {
+    requireAdminMock: vi.fn(),
+    fetchAdminBackendJsonMock: vi.fn(),
+  };
+});
 
 vi.mock("@/lib/server/auth", () => ({
   requireAdmin: requireAdminMock,

--- a/apps/web/tests/season-episodes-route-parity.test.ts
+++ b/apps/web/tests/season-episodes-route-parity.test.ts
@@ -49,4 +49,16 @@ describe("season episodes route parity", () => {
     );
     expect(payload.episodes[0]).toMatchObject({ episode_number: 1, title: "Pilot" });
   });
+
+  it("rejects malformed explicit offsets before proxying", async () => {
+    const request = new NextRequest(
+      "http://localhost/api/admin/trr-api/seasons/season-1/episodes?offset=abc",
+    );
+    const response = await GET(request, { params: Promise.resolve({ seasonId: "season-1" }) });
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("offset must be an integer");
+    expect(fetchAdminBackendJsonMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/tests/show-assets-route.test.ts
+++ b/apps/web/tests/show-assets-route.test.ts
@@ -187,6 +187,37 @@ describe("show assets route", () => {
     );
   });
 
+  it("rejects malformed explicit gallery offsets before proxying", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/trr-api/shows/show-1/assets?offset=abc"),
+      { params: Promise.resolve({ showId: "show-1" }) },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("offset must be an integer");
+    expect(fetchAdminBackendJsonMock).not.toHaveBeenCalled();
+  });
+
+  it("clamps oversized gallery limits before proxying", async () => {
+    fetchAdminBackendJsonMock.mockResolvedValue({
+      status: 200,
+      data: { assets: [], pagination: { limit: 5000, offset: 0, count: 0, has_more: false, next_cursor: null, cursor: null, truncated: false, full: false } },
+      durationMs: 3,
+    });
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/trr-api/shows/show-1/assets?limit=999999"),
+      { params: Promise.resolve({ showId: "show-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchAdminBackendJsonMock).toHaveBeenCalledWith(
+      "/admin/trr-api/shows/show-1/assets?limit=5000&offset=0",
+      expect.objectContaining({ routeName: "show-assets" }),
+    );
+  });
+
   it("supports full fetch mode with truthful truncation metadata", async () => {
     fetchAdminBackendJsonMock.mockResolvedValue({
       status: 200,

--- a/apps/web/tests/show-cast-route-default-min-episodes.test.ts
+++ b/apps/web/tests/show-cast-route-default-min-episodes.test.ts
@@ -143,6 +143,18 @@ describe("show cast route proxy parity", () => {
     );
   });
 
+  it("rejects malformed pagination values before proxying", async () => {
+    const request = new NextRequest(
+      "http://localhost/api/admin/trr-api/shows/show-1/cast?limit=abc",
+    );
+    const response = await GET(request, { params: Promise.resolve({ showId: "show-1" }) });
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("limit must be an integer");
+    expect(fetchAdminBackendJsonMock).not.toHaveBeenCalled();
+  });
+
   it("returns 404 when show slug or id cannot be resolved", async () => {
     resolveAdminShowIdMock.mockResolvedValue(null);
 

--- a/apps/web/tests/show-seasons-route-episode-signal.test.ts
+++ b/apps/web/tests/show-seasons-route-episode-signal.test.ts
@@ -95,6 +95,25 @@ describe("/api/admin/trr-api/shows/[showId]/seasons include episode signal", () 
     );
   });
 
+  it("preserves 500-season requests used by the image scrape drawer", async () => {
+    fetchAdminBackendJsonMock.mockResolvedValue({
+      status: 200,
+      data: { seasons: [], pagination: { limit: 500, offset: 0, count: 0 } },
+      durationMs: 2,
+    });
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/admin/trr-api/shows/show-1/seasons?limit=500"),
+      { params: Promise.resolve({ showId: "show-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchAdminBackendJsonMock).toHaveBeenCalledWith(
+      "/admin/trr-api/shows/show-1/seasons?limit=500&offset=0",
+      expect.objectContaining({ routeName: "show-seasons" }),
+    );
+  });
+
   it("falls back to the local seasons repository when the backend read times out", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     fetchAdminBackendJsonMock.mockRejectedValue(new Error("Admin read request timed out after 12s"));


### PR DESCRIPTION
## Summary
- share bounded integer parsing across admin proxy routes
- reject malformed pagination and clamp valid ranges
- provide a seeded public typography fallback without a database

## Validation
- 23 targeted Vitest tests passed

## Stack
Targets the admin-runtime-security branch.