### PR TITLE
feat(release): guard Vercel rollback evidence

### DIFF
--- a/apps/web/tests/vercel-rollback-guard.test.ts
+++ b/apps/web/tests/vercel-rollback-guard.test.ts
@@ -1,0 +1,231 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const appRoot = resolve(__dirname, "../../..");
+const wrapper = join(appRoot, "scripts", "vercel.sh");
+
+describe("guarded Vercel release operations", () => {
+  let tempDir: string;
+  let fakeGuard: string;
+  let fakeVercel: string;
+  let providerLog: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "trr-vercel-release-guard-"));
+    fakeGuard = join(tempDir, "guard.py");
+    await writeFile(fakeGuard, "raise SystemExit(0)\n", "utf-8");
+    await chmod(fakeGuard, 0o755);
+    providerLog = join(tempDir, "provider.jsonl");
+    fakeVercel = join(tempDir, "vercel");
+    await writeFile(
+      fakeVercel,
+      [
+        "#!/usr/bin/env python3",
+        "import json, os, sys",
+        `log = ${JSON.stringify(providerLog)}`,
+        "with open(log, 'a', encoding='utf-8') as target:",
+        "    target.write(json.dumps(sys.argv[1:]) + '\\n')",
+        "if sys.argv[1:2] == ['api']:",
+        "    print(os.environ.get('FAKE_VERCEL_METADATA', '{}'))",
+        "else:",
+        "    print('{}')",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    await chmod(fakeVercel, 0o755);
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  function runWrapper(args: string[], extraEnv: NodeJS.ProcessEnv = {}) {
+    return spawnSync("bash", [wrapper, ...args], {
+      cwd: appRoot,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        TRR_VERCEL_PROJECT_GUARD: fakeGuard,
+        TRR_VERCEL_GUARD_ONLY: "1",
+        TRR_VERCEL_BIN: fakeVercel,
+        ...extraEnv,
+      },
+    });
+  }
+
+  it("emits a pinned rollback plan without invoking Vercel", () => {
+    const result = runWrapper(["rollback-trr", "--deployment", "dpl_Abc123"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toEqual({
+      command: [
+        "rollback",
+        "dpl_Abc123",
+        "--cwd",
+        appRoot,
+        "--non-interactive",
+        "--timeout=0",
+      ],
+      deployment: "dpl_Abc123",
+      execute: false,
+      operation: "rollback",
+      projectId: "prj_MHpStkwr26rV5kjt0f80zqhwZpAs",
+      projectName: "trr-app",
+      teamId: "team_EUsG2kN9TAvVDGOu4yZVEoCX",
+      teamSlug: "the-reality-reports-projects",
+      targetBinding: {
+        status: "pending_provider_inspection",
+        requiredProjectId: "prj_MHpStkwr26rV5kjt0f80zqhwZpAs",
+        requiredProjectName: "trr-app",
+        requiredTeamId: "team_EUsG2kN9TAvVDGOu4yZVEoCX",
+        verificationCommand: [
+          "api",
+          "/v13/deployments/dpl_Abc123?teamId=team_EUsG2kN9TAvVDGOu4yZVEoCX",
+          "--cwd",
+          appRoot,
+          "--non-interactive",
+          "--scope",
+          "the-reality-reports-projects",
+        ],
+      },
+    });
+    expect(() => readFileSync(providerLog)).toThrow();
+  });
+
+  it("emits a read-only evidence plan without invoking Vercel", () => {
+    const result = runWrapper([
+      "release-evidence",
+      "--deployment",
+      "https://trr-app-good.vercel.app",
+    ]);
+
+    expect(result.status).toBe(0);
+    const payload = JSON.parse(result.stdout);
+    expect(payload).toMatchObject({
+      operation: "evidence",
+      deployment: "https://trr-app-good.vercel.app",
+      execute: false,
+      projectName: "trr-app",
+      teamId: "team_EUsG2kN9TAvVDGOu4yZVEoCX",
+      targetBinding: {
+        status: "pending_provider_inspection",
+      },
+    });
+    expect(payload.commands).toEqual([
+      ["list", "trr-app", "--prod", "--format", "json", "--cwd", appRoot],
+      ["inspect", "https://trr-app-good.vercel.app", "--cwd", appRoot, "--no-color"],
+      ["rollback", "status", "trr-app", "--cwd", appRoot, "--non-interactive"],
+    ]);
+  });
+
+  it("requires both production and rollback approval before execute", () => {
+    const result = runWrapper([
+      "rollback-trr",
+      "--deployment",
+      "dpl_Abc123",
+      "--execute",
+    ]);
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("TRR_VERCEL_ALLOW_PROD=1");
+    expect(result.stderr).toContain("TRR_VERCEL_ROLLBACK_APPROVED=1");
+  });
+
+  it("blocks ambient rollback commands in favor of the pinned operation", () => {
+    const result = runWrapper(["rollback", "dpl_Abc123"]);
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("rollback-trr");
+  });
+
+  it("rejects foreign deployment metadata before collecting release evidence", () => {
+    const result = runWrapper(
+      [
+        "release-evidence",
+        "--deployment",
+        "https://foreign-preview.vercel.app",
+        "--execute",
+      ],
+      {
+        TRR_VERCEL_GUARD_ONLY: "0",
+        FAKE_VERCEL_METADATA: JSON.stringify({
+          id: "dpl_Foreign",
+          url: "foreign-preview.vercel.app",
+          name: "foreign-app",
+          projectId: "prj_foreign",
+          ownerId: "team_foreign",
+        }),
+      },
+    );
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("deployment binding mismatch");
+    const calls = readFileSync(providerLog, "utf-8")
+      .trim()
+      .split("\n")
+      .map((line: string) => JSON.parse(line));
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.[0]).toBe("api");
+  });
+
+  it("rejects a foreign deployment before rollback mutation", () => {
+    const result = runWrapper(
+      ["rollback-trr", "--deployment", "dpl_Abc123", "--execute"],
+      {
+        TRR_VERCEL_GUARD_ONLY: "0",
+        TRR_VERCEL_ALLOW_PROD: "1",
+        TRR_VERCEL_ROLLBACK_APPROVED: "1",
+        FAKE_VERCEL_METADATA: JSON.stringify({
+          id: "dpl_Abc123",
+          url: "foreign-preview.vercel.app",
+          name: "foreign-app",
+          projectId: "prj_foreign",
+          ownerId: "team_foreign",
+        }),
+      },
+    );
+
+    expect(result.status).toBe(2);
+    const calls = readFileSync(providerLog, "utf-8")
+      .trim()
+      .split("\n")
+      .map((line: string) => JSON.parse(line));
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.[0]).toBe("api");
+  });
+
+  it("verifies authoritative project and team metadata before rollback", () => {
+    const result = runWrapper(
+      ["rollback-trr", "--deployment", "dpl_Abc123", "--execute"],
+      {
+        TRR_VERCEL_GUARD_ONLY: "0",
+        TRR_VERCEL_ALLOW_PROD: "1",
+        TRR_VERCEL_ROLLBACK_APPROVED: "1",
+        FAKE_VERCEL_METADATA: JSON.stringify({
+          id: "dpl_Abc123",
+          url: "trr-app-good.vercel.app",
+          name: "trr-app",
+          projectId: "prj_MHpStkwr26rV5kjt0f80zqhwZpAs",
+          ownerId: "team_EUsG2kN9TAvVDGOu4yZVEoCX",
+        }),
+      },
+    );
+
+    expect(result.status).toBe(0);
+    const calls = readFileSync(providerLog, "utf-8")
+      .trim()
+      .split("\n")
+      .map((line: string) => JSON.parse(line));
+    expect(calls.map((call: string[]) => call.slice(0, 2))).toEqual([
+      ["api", "/v13/deployments/dpl_Abc123?teamId=team_EUsG2kN9TAvVDGOu4yZVEoCX"],
+      ["rollback", "dpl_Abc123"],
+      ["rollback", "status"],
+    ]);
+  });
+});

--- a/apps/web/tests/vercel-rollback-guard.test.ts
+++ b/apps/web/tests/vercel-rollback-guard.test.ts
@@ -144,6 +144,14 @@ describe("guarded Vercel release operations", () => {
     expect(result.stderr).toContain("rollback-trr");
   });
 
+  it("blocks ambient promotion with production-deployment guidance", () => {
+    const result = runWrapper(["promote", "dpl_Abc123"]);
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("explicitly approved production deployment");
+    expect(result.stderr).not.toContain("rollback-trr");
+  });
+
   it("rejects foreign deployment metadata before collecting release evidence", () => {
     const result = runWrapper(
       [

--- a/apps/web/tests/vercel-rollback-guard.test.ts
+++ b/apps/web/tests/vercel-rollback-guard.test.ts
@@ -30,7 +30,12 @@ describe("guarded Vercel release operations", () => {
         "with open(log, 'a', encoding='utf-8') as target:",
         "    target.write(json.dumps(sys.argv[1:]) + '\\n')",
         "if sys.argv[1:2] == ['api']:",
-        "    print(os.environ.get('FAKE_VERCEL_METADATA', '{}'))",
+        "    metadata_file = os.environ.get('FAKE_VERCEL_METADATA_FILE', '')",
+        "    if metadata_file:",
+        "        with open(metadata_file, encoding='utf-8') as source:",
+        "            print(source.read())",
+        "    else:",
+        "        print(os.environ.get('FAKE_VERCEL_METADATA', '{}'))",
         "else:",
         "    print('{}')",
         "",
@@ -150,6 +155,59 @@ describe("guarded Vercel release operations", () => {
     expect(result.status).toBe(2);
     expect(result.stderr).toContain("explicitly approved production deployment");
     expect(result.stderr).not.toContain("rollback-trr");
+  });
+
+  it("does not treat option values named help or version as read-only bypasses", () => {
+    for (const optionValue of ["help", "version"]) {
+      const rollback = runWrapper(["--cwd", optionValue, "rollback", "dpl_Abc123"]);
+      expect(rollback.status).toBe(2);
+      expect(rollback.stderr).toContain("rollback-trr");
+
+      const promote = runWrapper(["--cwd", optionValue, "promote", "dpl_Abc123"]);
+      expect(promote.status).toBe(2);
+      expect(promote.stderr).toContain("explicitly approved production deployment");
+      expect(promote.stderr).not.toContain("rollback-trr");
+    }
+    expect(() => readFileSync(providerLog)).toThrow();
+  });
+
+  it("keeps actual help and version commands read-only", () => {
+    for (const args of [
+      ["--help"],
+      ["--version"],
+      ["--cwd", "help", "help"],
+      ["--cwd", "version", "version"],
+    ]) {
+      const result = runWrapper(args);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("guard-only: command accepted");
+    }
+    expect(() => readFileSync(providerLog)).toThrow();
+  });
+
+  it("validates provider metadata above the environment-string limit", async () => {
+    const metadataPath = join(tempDir, "oversized-provider-metadata.json");
+    const metadata = JSON.stringify({
+      id: "dpl_Abc123",
+      url: "trr-app-good.vercel.app",
+      name: "trr-app",
+      projectId: "prj_MHpStkwr26rV5kjt0f80zqhwZpAs",
+      ownerId: "team_EUsG2kN9TAvVDGOu4yZVEoCX",
+      deploymentPayload: "x".repeat(129 * 1024),
+    });
+    expect(Buffer.byteLength(metadata)).toBeGreaterThan(128 * 1024);
+    await writeFile(metadataPath, metadata, "utf-8");
+
+    const result = runWrapper(
+      ["release-evidence", "--deployment", "dpl_Abc123", "--execute"],
+      {
+        TRR_VERCEL_GUARD_ONLY: "0",
+        FAKE_VERCEL_METADATA_FILE: metadataPath,
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("Verified deployment binding");
   });
 
   it("rejects foreign deployment metadata before collecting release evidence", () => {

--- a/scripts/vercel.sh
+++ b/scripts/vercel.sh
@@ -94,14 +94,34 @@ find_active_vercel_project_dir() {
 
 guard_is_bypassed_read_only_command() {
   local arg
+  local skip_next=0
 
   for arg in "$@"; do
+    if [[ "$skip_next" -eq 1 ]]; then
+      skip_next=0
+      continue
+    fi
+
     case "$arg" in
-      --help | -h | help | --version | -v | version)
+      --help | -h | --version | -v)
         return 0
+        ;;
+      --*=*)
+        continue
+        ;;
+      -*)
+        if option_takes_value "$arg"; then
+          skip_next=1
+        fi
         ;;
     esac
   done
+
+  case "$(first_vercel_command "$@" || true)" in
+    help | version)
+      return 0
+      ;;
+  esac
 
   return 1
 }
@@ -241,9 +261,9 @@ verify_release_deployment_binding() {
     echo "[vercel.sh] Authoritative deployment inspection failed; release operation blocked." >&2
     return 2
   fi
-  if ! VERCEL_DEPLOYMENT_METADATA="$metadata" python3 - \
+  if ! python3 - \
     "$deployment" "$deployment_key" "$TRR_VERCEL_PROJECT_NAME" \
-    "$TRR_VERCEL_PROJECT_ID" "$TRR_VERCEL_TEAM_ID" <<'PY'
+    "$TRR_VERCEL_PROJECT_ID" "$TRR_VERCEL_TEAM_ID" 3<<<"$metadata" <<'PY'
 from __future__ import annotations
 
 import json
@@ -251,7 +271,8 @@ import os
 import sys
 
 deployment, lookup_key, expected_name, expected_project_id, expected_team_id = sys.argv[1:]
-raw = os.environ.get("VERCEL_DEPLOYMENT_METADATA", "")
+with os.fdopen(3, "r", encoding="utf-8") as metadata_stream:
+    raw = metadata_stream.read()
 start = raw.find("{")
 end = raw.rfind("}")
 try:

--- a/scripts/vercel.sh
+++ b/scripts/vercel.sh
@@ -6,9 +6,10 @@ VERCEL_VERSION="${TRR_VERCEL_CLI_VERSION:-54.15.1}"
 APP_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORKSPACE_ROOT="$(cd "$APP_ROOT/.." && pwd)"
 VERCEL_PROJECT_GUARD="${TRR_VERCEL_PROJECT_GUARD:-$WORKSPACE_ROOT/scripts/vercel-project-guard.py}"
-TRR_VERCEL_PROJECT_NAME="${TRR_VERCEL_PROJECT_NAME:-trr-app}"
-TRR_VERCEL_TEAM_SLUG="${TRR_VERCEL_TEAM_SLUG:-the-reality-reports-projects}"
-TRR_VERCEL_TEAM_ID="${TRR_VERCEL_TEAM_ID:-team_EUsG2kN9TAvVDGOu4yZVEoCX}"
+TRR_VERCEL_PROJECT_NAME="trr-app"
+TRR_VERCEL_PROJECT_ID="prj_MHpStkwr26rV5kjt0f80zqhwZpAs"
+TRR_VERCEL_TEAM_SLUG="the-reality-reports-projects"
+TRR_VERCEL_TEAM_ID="team_EUsG2kN9TAvVDGOu4yZVEoCX"
 PNPM_SPEC="$(
   python3 - "$APP_ROOT/package.json" <<'PY'
 from __future__ import annotations
@@ -185,6 +186,9 @@ vercel_project_guard_required() {
     "" | deploy)
       return 0
       ;;
+    rollback | promote)
+      return 0
+      ;;
     env)
       env_subcommand="$(vercel_env_subcommand "$@" || true)"
       case "$env_subcommand" in
@@ -196,6 +200,289 @@ vercel_project_guard_required() {
   esac
 
   return 1
+}
+
+valid_vercel_deployment_target() {
+  local target="$1"
+
+  [[ "$target" =~ ^dpl_[A-Za-z0-9]+$ ]] && return 0
+  [[ "$target" =~ ^https://[A-Za-z0-9][A-Za-z0-9.-]*\.vercel\.app/?$ ]] && return 0
+  return 1
+}
+
+guard_release_project() {
+  if ! python3 "$VERCEL_PROJECT_GUARD" --project-dir "$APP_ROOT" >/dev/null; then
+    echo "[vercel.sh] Release operation blocked: TRR-APP is not linked to the pinned trr-app project/team." >&2
+    return 1
+  fi
+}
+
+vercel_deployment_lookup_key() {
+  local deployment="$1"
+  deployment="${deployment#https://}"
+  deployment="${deployment%/}"
+  printf '%s\n' "$deployment"
+}
+
+vercel_deployment_metadata_endpoint() {
+  local deployment_key
+  deployment_key="$(vercel_deployment_lookup_key "$1")"
+  printf '/v13/deployments/%s?teamId=%s\n' "$deployment_key" "$TRR_VERCEL_TEAM_ID"
+}
+
+verify_release_deployment_binding() {
+  local deployment="$1"
+  local deployment_key
+  local endpoint
+  local metadata
+  deployment_key="$(vercel_deployment_lookup_key "$deployment")"
+  endpoint="$(vercel_deployment_metadata_endpoint "$deployment")"
+  if ! metadata="$(run_vercel_cli_with_scope_fallback api "$endpoint" --cwd "$APP_ROOT" --non-interactive)"; then
+    echo "[vercel.sh] Authoritative deployment inspection failed; release operation blocked." >&2
+    return 2
+  fi
+  if ! VERCEL_DEPLOYMENT_METADATA="$metadata" python3 - \
+    "$deployment" "$deployment_key" "$TRR_VERCEL_PROJECT_NAME" \
+    "$TRR_VERCEL_PROJECT_ID" "$TRR_VERCEL_TEAM_ID" <<'PY'
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+deployment, lookup_key, expected_name, expected_project_id, expected_team_id = sys.argv[1:]
+raw = os.environ.get("VERCEL_DEPLOYMENT_METADATA", "")
+start = raw.find("{")
+end = raw.rfind("}")
+try:
+    payload = json.loads(raw[start : end + 1]) if start >= 0 and end >= start else None
+except json.JSONDecodeError:
+    payload = None
+if not isinstance(payload, dict):
+    print("[vercel.sh] deployment binding mismatch: provider metadata was not a JSON object.", file=sys.stderr)
+    raise SystemExit(2)
+
+observed = {
+    "id": str(payload.get("id") or ""),
+    "url": str(payload.get("url") or "").removeprefix("https://").rstrip("/"),
+    "name": str(payload.get("name") or ""),
+    "projectId": str(payload.get("projectId") or ""),
+    "ownerId": str(payload.get("ownerId") or ""),
+}
+target_matches = (
+    observed["id"] == lookup_key
+    if deployment.startswith("dpl_")
+    else observed["url"] == lookup_key
+)
+binding_matches = (
+    target_matches
+    and observed["name"] == expected_name
+    and observed["projectId"] == expected_project_id
+    and observed["ownerId"] == expected_team_id
+)
+if not binding_matches:
+    print(
+        "[vercel.sh] deployment binding mismatch: "
+        f"target={deployment} observed_id={observed['id'] or '<missing>'} "
+        f"observed_url={observed['url'] or '<missing>'} "
+        f"project={observed['name'] or '<missing>'}/{observed['projectId'] or '<missing>'} "
+        f"owner={observed['ownerId'] or '<missing>'}; expected "
+        f"{expected_name}/{expected_project_id} owner={expected_team_id}.",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
+
+print(
+    "[vercel.sh] Verified deployment binding: "
+    f"id={observed['id']} url={observed['url']} "
+    f"project={observed['name']}/{observed['projectId']} owner={observed['ownerId']}.",
+    file=sys.stderr,
+)
+PY
+  then
+    return 2
+  fi
+}
+
+emit_release_operation_plan() {
+  local operation="$1"
+  local execute="$2"
+  local deployment="$3"
+  shift 3
+  python3 - "$operation" "$execute" "$deployment" "$TRR_VERCEL_PROJECT_NAME" \
+    "$TRR_VERCEL_PROJECT_ID" "$TRR_VERCEL_TEAM_SLUG" "$TRR_VERCEL_TEAM_ID" \
+    "$APP_ROOT" "$@" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+
+(
+    operation,
+    execute,
+    deployment,
+    project_name,
+    project_id,
+    team_slug,
+    team_id,
+    app_root,
+    *command_parts,
+) = sys.argv[1:]
+
+payload: dict[str, object] = {
+    "operation": operation,
+    "execute": execute == "1",
+    "deployment": deployment,
+    "projectName": project_name,
+    "projectId": project_id,
+    "teamSlug": team_slug,
+    "teamId": team_id,
+    "targetBinding": {
+        "status": "verified_by_provider_metadata" if execute == "1" else "pending_provider_inspection",
+        "requiredProjectName": project_name,
+        "requiredProjectId": project_id,
+        "requiredTeamId": team_id,
+        "verificationCommand": [
+            "api",
+            f"/v13/deployments/{deployment.removeprefix('https://').rstrip('/')}?teamId={team_id}",
+            "--cwd",
+            app_root,
+            "--non-interactive",
+            "--scope",
+            team_slug,
+        ],
+    },
+}
+if operation == "rollback":
+    payload["command"] = command_parts
+else:
+    separator = "--next-command--"
+    commands: list[list[str]] = [[]]
+    for part in command_parts:
+        if part == separator:
+            commands.append([])
+        else:
+            commands[-1].append(part)
+    payload["commands"] = commands
+print(json.dumps(payload, indent=2, sort_keys=True))
+PY
+}
+
+run_release_evidence() {
+  local deployment=""
+  local execute=0
+  local mode_seen=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --deployment)
+        if [[ -z "${2:-}" ]]; then
+          echo "[vercel.sh] release-evidence --deployment requires a deployment ID or *.vercel.app URL." >&2
+          return 2
+        fi
+        deployment="$2"
+        shift 2
+        ;;
+      --deployment=*)
+        deployment="${1#--deployment=}"
+        shift
+        ;;
+      --execute | --dry-run)
+        if [[ -n "$mode_seen" && "$mode_seen" != "$1" ]]; then
+          echo "[vercel.sh] release-evidence accepts only one of --dry-run or --execute." >&2
+          return 2
+        fi
+        mode_seen="$1"
+        [[ "$1" == "--execute" ]] && execute=1 || execute=0
+        shift
+        ;;
+      *)
+        echo "[vercel.sh] release-evidence received an unsupported argument: $1" >&2
+        return 2
+        ;;
+    esac
+  done
+  if ! valid_vercel_deployment_target "$deployment"; then
+    echo "[vercel.sh] release-evidence requires an exact dpl_* ID or https://*.vercel.app deployment; got ${deployment:-<missing>}." >&2
+    return 2
+  fi
+  guard_release_project || return $?
+
+  local list_command=(list "$TRR_VERCEL_PROJECT_NAME" --prod --format json --cwd "$APP_ROOT")
+  local inspect_command=(inspect "$deployment" --cwd "$APP_ROOT" --no-color)
+  local status_command=(rollback status "$TRR_VERCEL_PROJECT_NAME" --cwd "$APP_ROOT" --non-interactive)
+  if [[ "$execute" == "0" ]]; then
+    emit_release_operation_plan evidence "$execute" "$deployment" \
+      "${list_command[@]}" --next-command-- "${inspect_command[@]}" --next-command-- "${status_command[@]}"
+    return 0
+  fi
+  if [[ "${TRR_VERCEL_GUARD_ONLY:-}" == "1" ]]; then
+    echo "[vercel.sh] release-evidence --execute is incompatible with TRR_VERCEL_GUARD_ONLY=1; provider verification is required." >&2
+    return 2
+  fi
+
+  verify_release_deployment_binding "$deployment" || return $?
+  run_vercel_cli_with_scope_fallback "${list_command[@]}"
+  run_vercel_cli_with_scope_fallback "${inspect_command[@]}"
+  run_vercel_cli_with_scope_fallback "${status_command[@]}"
+}
+
+run_rollback_trr() {
+  local deployment=""
+  local execute=0
+  local mode_seen=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --deployment)
+        if [[ -z "${2:-}" ]]; then
+          echo "[vercel.sh] rollback-trr --deployment requires a deployment ID or *.vercel.app URL." >&2
+          return 2
+        fi
+        deployment="$2"
+        shift 2
+        ;;
+      --deployment=*)
+        deployment="${1#--deployment=}"
+        shift
+        ;;
+      --execute | --dry-run)
+        if [[ -n "$mode_seen" && "$mode_seen" != "$1" ]]; then
+          echo "[vercel.sh] rollback-trr accepts only one of --dry-run or --execute." >&2
+          return 2
+        fi
+        mode_seen="$1"
+        [[ "$1" == "--execute" ]] && execute=1 || execute=0
+        shift
+        ;;
+      *)
+        echo "[vercel.sh] rollback-trr received an unsupported argument: $1" >&2
+        return 2
+        ;;
+    esac
+  done
+  if ! valid_vercel_deployment_target "$deployment"; then
+    echo "[vercel.sh] rollback-trr requires an exact dpl_* ID or https://*.vercel.app deployment; got ${deployment:-<missing>}." >&2
+    return 2
+  fi
+
+  local rollback_command=(rollback "$deployment" --cwd "$APP_ROOT" --non-interactive --timeout=0)
+  if [[ "$execute" == "1" && ( "${TRR_VERCEL_ALLOW_PROD:-}" != "1" || "${TRR_VERCEL_ROLLBACK_APPROVED:-}" != "1" ) ]]; then
+    echo "[vercel.sh] rollback execution requires both TRR_VERCEL_ALLOW_PROD=1 and TRR_VERCEL_ROLLBACK_APPROVED=1 in the current approved invocation." >&2
+    return 2
+  fi
+  guard_release_project || return $?
+  if [[ "$execute" == "0" ]]; then
+    emit_release_operation_plan rollback "$execute" "$deployment" "${rollback_command[@]}"
+    return 0
+  fi
+  if [[ "${TRR_VERCEL_GUARD_ONLY:-}" == "1" ]]; then
+    echo "[vercel.sh] rollback-trr --execute is incompatible with TRR_VERCEL_GUARD_ONLY=1; provider verification is required." >&2
+    return 2
+  fi
+
+  verify_release_deployment_binding "$deployment" || return $?
+  emit_release_operation_plan rollback 1 "$deployment" "${rollback_command[@]}" >&2
+  run_vercel_cli_with_scope_fallback "${rollback_command[@]}"
+  run_vercel_cli_with_scope_fallback rollback status "$TRR_VERCEL_PROJECT_NAME" --cwd "$APP_ROOT" --non-interactive
 }
 
 vercel_deploy_targets_production() {
@@ -256,6 +543,14 @@ vercel_deploy_targets_production() {
 }
 
 run_vercel_cli() {
+  if [[ -n "${TRR_VERCEL_BIN:-}" ]]; then
+    if [[ ! -x "$TRR_VERCEL_BIN" ]]; then
+      echo "[vercel.sh] TRR_VERCEL_BIN is not executable: $TRR_VERCEL_BIN" >&2
+      return 1
+    fi
+    "$TRR_VERCEL_BIN" "$@"
+    return
+  fi
   # Use a repo-controlled CLI version so local builds do not depend on a stale
   # globally-installed `vercel` that may reject the workspace's Node 24 baseline.
   if [[ "$PNPM_SPEC" == pnpm@* ]] && command -v corepack >/dev/null 2>&1; then
@@ -585,7 +880,27 @@ case "${1:-}" in
     run_preview_ready "$@"
     exit 0
     ;;
+  release-evidence)
+    shift
+    run_release_evidence "$@"
+    exit $?
+    ;;
+  rollback-trr)
+    shift
+    run_rollback_trr "$@"
+    exit $?
+    ;;
 esac
+
+if ! guard_is_bypassed_read_only_command "$@"; then
+  ambient_command="$(first_vercel_command "$@" || true)"
+  case "$ambient_command" in
+    rollback | promote)
+      echo "[vercel.sh] Ambient ${ambient_command} is blocked. Use rollback-trr with an exact deployment and the pinned release guard." >&2
+      exit 2
+      ;;
+  esac
+fi
 
 if vercel_project_guard_required "$@"; then
   active_project_dir="$(find_active_vercel_project_dir "$(vercel_invocation_cwd "$@")")"

--- a/scripts/vercel.sh
+++ b/scripts/vercel.sh
@@ -895,8 +895,12 @@ esac
 if ! guard_is_bypassed_read_only_command "$@"; then
   ambient_command="$(first_vercel_command "$@" || true)"
   case "$ambient_command" in
-    rollback | promote)
-      echo "[vercel.sh] Ambient ${ambient_command} is blocked. Use rollback-trr with an exact deployment and the pinned release guard." >&2
+    rollback)
+      echo "[vercel.sh] Ambient rollback is blocked. Use rollback-trr with an exact deployment and the pinned release guard." >&2
+      exit 2
+      ;;
+    promote)
+      echo "[vercel.sh] Ambient promote is blocked. Use a fresh, explicitly approved production deployment through this guarded wrapper." >&2
       exit 2
       ;;
   esac


### PR DESCRIPTION
## Summary

- fail closed around Vercel rollback and promotion operations
- require dual approval and verify provider metadata before mutation
- add focused fake-provider coverage without accessing live Vercel state

## Validation

- `bash -n scripts/vercel.sh`
- focused Vitest guard suite: 7/7 passed
- focused ESLint passed
- TypeScript `--noEmit` passed
- `git diff --check`
- staged gitleaks scan

No Vercel command, deployment, rollback, or provider credential was used.