### PR TITLE
refactor(admin): extract show workspace components

### DIFF
--- a/apps/web/src/app/admin/trr-shows/[showId]/page.tsx
+++ b/apps/web/src/app/admin/trr-shows/[showId]/page.tsx
@@ -1,63 +1,43 @@
 "use client";
 
-import { useDeferredValue, useEffect, useLayoutEffect, useState, useCallback, useRef, useMemo, type ReactNode } from "react";
+import { useDeferredValue, useEffect, useLayoutEffect, useState, useCallback, useRef, useMemo } from "react";
 import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import Image from "next/image";
 import dynamic from "next/dynamic";
 import type { Route } from "next";
 import ClientOnly from "@/components/ClientOnly";
 import AdminBreadcrumbs from "@/components/admin/AdminBreadcrumbs";
 import AdminGlobalHeader from "@/components/admin/AdminGlobalHeader";
-import AdminModal from "@/components/admin/AdminModal";
+import ShowBatchRoleModals from "@/components/admin/ShowBatchRoleModals";
+import ShowBravoSyncModal from "@/components/admin/ShowBravoSyncModal";
+import ShowHealthCenterModal from "@/components/admin/ShowHealthCenterModal";
+import ShowLinksDiscoveryModal from "@/components/admin/ShowLinksDiscoveryModal";
+import { SocialHandlePill, SourceBadge } from "@/components/admin/ShowLinkBadges";
 import { useAdminGuard } from "@/lib/admin/useAdminGuard";
 import { useAdminOperationUnloadGuard } from "@/lib/admin/use-operation-unload-guard";
 import {
   GettyLocalPrefetchError,
   prefetchGettyLocallyForPerson,
 } from "@/lib/admin/getty-local-prefetch";
-import {
-  Editable,
-  EditableArea,
-  EditableCancel,
-  EditableInput,
-  EditablePreview,
-  EditableSubmit,
-  EditableToolbar,
-  EditableTrigger,
-} from "@/components/ui/editable";
 import SocialPostsSection from "@/components/admin/social-posts-section";
 import SeasonSocialAnalyticsSection, {
   type PlatformTab,
   type SocialAnalyticsView,
   type SocialTarget,
 } from "@/components/admin/season-social-analytics-section";
-import ShowBrandEditor from "@/components/admin/ShowBrandEditor";
 import ShowSurveysTab from "@/components/admin/show-tabs/ShowSurveysTab";
 import ShowOverviewTab from "@/components/admin/show-tabs/ShowOverviewTab";
 import {
-  ShowCreditsCastMembers,
-  ShowCreditsCastViewControls,
-  ShowCreditsCrewSections,
   type ShowCreditsCrewSectionData,
 } from "@/components/admin/show-tabs/ShowCreditsViews";
-import {
-  CastMatrixSyncPanel,
-  type CastMatrixSyncResult,
-} from "@/components/admin/CastMatrixSyncPanel";
-import { ExternalLinks, TmdbLinkIcon, ImdbLinkIcon } from "@/components/admin/ExternalLinks";
+import { type CastMatrixSyncResult } from "@/components/admin/CastMatrixSyncPanel";
+import { TmdbLinkIcon, ImdbLinkIcon } from "@/components/admin/ExternalLinks";
 import { ImageLightbox } from "@/components/admin/ImageLightbox";
 import { GalleryAssetEditTools } from "@/components/admin/GalleryAssetEditTools";
 import { ImageScrapeDrawer, type EntityContext } from "@/components/admin/ImageScrapeDrawer";
 import { AdvancedFilterDrawer } from "@/components/admin/AdvancedFilterDrawer";
-import { BravotvImageRunPanel } from "@/components/admin/BravotvImageRunPanel";
 import { ShowTabsNav } from "@/components/admin/show-tabs/ShowTabsNav";
-import { ShowAssetsImageSections } from "@/components/admin/show-tabs/ShowAssetsImageSections";
-import {
-  ShowBrandLogosSection,
-  type ShowLogoVariant,
-} from "@/components/admin/show-tabs/ShowBrandLogosSection";
-import { ShowFeaturedMediaSelectors } from "@/components/admin/show-tabs/ShowFeaturedMediaSelectors";
+import type { ShowLogoVariant } from "@/components/admin/show-tabs/show-logo-types";
 import { resolveGalleryAssetCapabilities } from "@/lib/admin/gallery-asset-capabilities";
 import { shouldIncludeCastMemberForSeasonFilter } from "@/lib/admin/cast-role-filtering";
 import {
@@ -108,7 +88,6 @@ import {
 import { buildSeasonSocialBreadcrumb, buildShowBreadcrumb } from "@/lib/admin/admin-breadcrumbs";
 import {
   buildPipelineRows,
-  isRefreshLogTerminalSuccess,
   normalizeRefreshLogTopic,
   resolveRefreshLogTopicKey,
   shouldDedupeRefreshLogEntry,
@@ -129,10 +108,6 @@ import {
   contentTypeToContextType,
   normalizeContentTypeToken,
 } from "@/lib/media/content-type";
-import {
-  THUMBNAIL_DEFAULTS,
-  parseThumbnailCrop,
-} from "@/lib/thumbnail-crop";
 import {
   ASSET_SECTION_LABELS,
   ASSET_SECTION_TO_BATCH_CONTENT_TYPE,
@@ -189,22 +164,117 @@ import { SHOW_SOCIAL_PLATFORM_TABS } from "@/lib/admin/show-page/constants";
 import { useShowCoverage } from "@/lib/admin/show-page/use-show-coverage";
 import { useShowDetailsController } from "@/lib/admin/show-page/use-show-details-controller";
 import { useShowIdentityLoad } from "@/lib/admin/show-page/use-show-identity-load";
-import SocialPlatformTabIcon, { type SocialPlatformTabIconKey } from "@/components/admin/SocialPlatformTabIcon";
+import {
+  GalleryAssetSourceError,
+  buildSeasonEpisodeSummary,
+  buildSeasonEpisodeSummaryMap,
+  getMeaningfulShowCreditsRoles,
+  groupShowCrewRows,
+  normalizeErrorMessage,
+  normalizeShowCreditsCastRoster as normalizeShowCreditsCastRosterValue,
+  type BravoCandidateSummary,
+  type BravoImportImageKind,
+  type BravoNewsItem,
+  type BravoPersonCandidateResult,
+  type BravoPreviewPerson,
+  type BravoVideoItem,
+  type CastBatchRunSummary,
+  type CastPhotoFallbackMode,
+  type CastRoleEditDraft,
+  type CastRoleMember,
+  type CastRunFailedMember,
+  type EntityLink,
+  type GalleryAssetSourceFailure,
+  type GalleryAssetSourceRequest,
+  type HealthStatus,
+  type PersonApprovedLinkPill,
+  type PersonLinkCoverageCard,
+  type PersonLinkSourceKey,
+  type PersonLinkSourceSummary,
+  type PersonRefreshMode,
+  type RefreshLogEntry,
+  type RefreshProgressState,
+  type RoleRenameDraft,
+  type SeasonCoverageLinkPill,
+  type SeasonEpisodeSummary,
+  type SeasonUrlCoverageRow,
+  type ShowCastEligibilityMode,
+  type ShowCastRosterMode,
+  type ShowCastSource,
+  type ShowCreditsPayload,
+  type ShowCrewSection,
+  type ShowGalleryVisibleBySection,
+  type ShowRedditCommunity,
+  type ShowRefreshRunOptions as WorkspaceShowRefreshRunOptions,
+  type ShowRefreshTarget,
+  type ShowRole,
+  type ShowSocialLinkPill,
+  type ShowTab,
+  type SyncBravoRunMode,
+  type TabId,
+  type TrrCastMember,
+  type TrrSeason,
+  type TrrShow,
+  type UnifiedNewsFacets,
+  type UnifiedNewsItem,
+} from "@/lib/admin/show-page/workspace-model";
+import SocialPlatformTabIcon from "@/components/admin/SocialPlatformTabIcon";
 import {
   buildHostFaviconUrl,
-  getHostnameFromUrl,
-  isFandomSeedUrl,
-  isLikelyPageUrl,
   isSocialLinkKind,
-  normalizeLinkKind,
-  parsePersonNameFromLink,
   resolveLinkPageTitle,
-  resolveLinkSiteTitle,
-  resolveShowPageDisplayTitle,
 } from "@/lib/admin/show-page/link-display";
 import {
-  deriveShowDetailsSlugPreview,
-} from "@/lib/admin/show-page/details-form";
+  classifyPersonLinkSource,
+  getApprovedLinkText,
+  getCastMemberLinkText,
+  getLinkSourceBadgeKind,
+  getLinkSourceLabel,
+  getShowPageLinkTitle,
+  getSourceBadgeOrder,
+  isRenderableSeasonPageLink,
+  isRenderableShowPageLink,
+  normalizeEntityLinkStatus,
+  pickPreferredPersonSourceLink,
+  resolveCastMemberNameFromLinks,
+  usesBrandIconOnly,
+} from "@/lib/admin/show-page/show-link-display-model";
+import {
+  CAST_REFRESH_PHASE_ORDER,
+  SEASON_PAGE_TABS,
+  areNumberArraysEqual,
+  areStringArraysEqual,
+  buildAssetAutoCropPayloadWithFallback,
+  buildProgressMessage,
+  extractBravoSocialHandle,
+  formatBravoSocialLabel,
+  formatFixed1,
+  formatGallerySourceFailure,
+  formatIsoAgeLabel,
+  getAssetDisplayUrl,
+  getFeaturedShowImageKind,
+  getShowRefreshTargetLabel,
+  inferBravoImportImageKind,
+  inferBravoPersonUrl,
+  inferBravoShowUrl,
+  isAbortError,
+  isBravoNetworkName,
+  isCastRefreshPhaseId,
+  isHttpUrlValue,
+  isRefreshTopicDone,
+  isRefreshTopicFailed,
+  looksLikeUuid,
+  normalizeBravoSocialKey,
+  normalizeGallerySourceFailure,
+  normalizeRefreshLogMessage,
+  parseGalleryAssetErrorPayload,
+  parseProgressNumber,
+  readTrimmedToken,
+  resolveStageLabel,
+  toIsoNow,
+  updateCastRefreshPhaseStates,
+  withSnapshotAgeSuffix,
+} from "@/lib/admin/show-page/show-detail-utilities";
 import {
   buildOverviewAlternativeNamesText,
   buildOverviewRedditGroups,
@@ -236,697 +306,13 @@ import {
 const EPISODE_ID_GAP_WARNING_CODE = "episodes_tmdb_missing_imdb_ids";
 const EPISODE_ID_IGNORED_SEASON_ZERO_WARNING_CODE = "episodes_tmdb_season_zero_ignored_specials";
 
-// Types
-type ShowSyncWarningSample = {
-  season_number?: number | null;
-  episode_number?: number | null;
-  title?: string | null;
-  air_date?: string | null;
-  tmdb_episode_id?: number | null;
-};
+// Keep the route-local name as a stable source-inspection seam while the implementation lives in the model.
+const normalizeShowCreditsCastRoster = (value: unknown): TrrCastMember[] =>
+  normalizeShowCreditsCastRosterValue(value);
 
-type ShowSyncWarning = {
-  code: string;
-  severity?: "info" | "warning" | "error" | string;
-  message: string;
-  count?: number | null;
-  ignored_season_zero_count?: number | null;
-  samples?: ShowSyncWarningSample[] | null;
-};
-
-interface TrrShow {
-  id: string;
-  name: string;
-  slug: string;
-  canonical_slug: string;
-  alternative_names: string[];
-  overview_alternative_names?: string[] | null;
-  imdb_id: string | null;
-  tmdb_id: number | null;
-  external_ids?: Record<string, unknown> | null;
-  derived_external_links?: {
-    justwatch_url?: string | null;
-  } | null;
-  overview_watch_availability?: Array<{
-    region: "US" | "GB" | "CA" | "AU";
-    stream: string[];
-    buy: string[];
-  }> | null;
-  watch_provider_regions?: Array<{
-    region: string;
-    stream: string[];
-    free: string[];
-    buy_rent: string[];
-  }> | null;
-  show_total_seasons: number | null;
-  show_total_episodes: number | null;
-  description: string | null;
-  premiere_date: string | null;
-  networks: string[];
-  overview_networks?: string[] | null;
-  genres: string[];
-  tags: string[];
-  tmdb_status: string | null;
-  tmdb_vote_average: number | null;
-  imdb_rating_value: number | null;
-  primary_poster_image_id?: string | null;
-  primary_backdrop_image_id?: string | null;
-  primary_logo_image_id?: string | null;
-  logo_url?: string | null;
-  streaming_providers?: string[] | null;
-  overview_streaming_providers?: string[] | null;
-  watch_providers?: string[] | null;
-  sync_warnings?: ShowSyncWarning[] | null;
-}
-
-interface ShowRedditCommunity {
-  id: string;
-  subreddit: string;
-  display_name: string | null;
-  post_flairs: string[];
-  analysis_flairs: string[];
-  analysis_all_flairs: string[];
-  is_show_focused: boolean;
-  network_focus_targets: string[];
-  franchise_focus_targets: string[];
-}
-
-interface TrrSeason {
-  id: string;
-  show_id: string;
-  season_number: number;
-  name: string | null;
-  title: string | null;
-  overview: string | null;
-  air_date: string | null;
-  premiere_date?: string | null;
-  url_original_poster: string | null;
-  tmdb_season_id: number | null;
-  episode_count?: number | null;
-  episode_airdate_count?: number | null;
-  first_episode_air_date?: string | null;
-  last_episode_air_date?: string | null;
-  fandom_source_url?: string | null;
-  fandom_page_title?: string | null;
-}
-
-type SeasonEpisodeSummary = {
-  count: number;
-  premiereDate: string | null;
-  finaleDate: string | null;
-};
-
-const buildSeasonEpisodeSummary = (season: TrrSeason): SeasonEpisodeSummary | null => {
-  const count =
-    typeof season.episode_count === "number"
-      ? season.episode_count
-      : typeof season.episode_airdate_count === "number"
-        ? season.episode_airdate_count
-        : null;
-  const premiereDate = season.first_episode_air_date ?? season.premiere_date ?? season.air_date ?? null;
-  const finaleDate = season.last_episode_air_date ?? season.air_date ?? season.premiere_date ?? premiereDate;
-
-  if (count === null && !premiereDate && !finaleDate) return null;
-
-  return {
-    count: count ?? 0,
-    premiereDate,
-    finaleDate,
-  };
-};
-
-const buildSeasonEpisodeSummaryMap = (seasonList: TrrSeason[]): Record<string, SeasonEpisodeSummary> => {
-  const summaries: Record<string, SeasonEpisodeSummary> = {};
-  for (const season of seasonList) {
-    const summary = buildSeasonEpisodeSummary(season);
-    if (!summary) continue;
-    summaries[season.id] = summary;
-  }
-  return summaries;
-};
-
-const normalizeErrorMessage = (value: unknown): string | null => {
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    return trimmed.length > 0 ? trimmed : null;
-  }
-
-  if (Array.isArray(value)) {
-    const messages = value
-      .map((entry) => normalizeErrorMessage(entry))
-      .filter((entry): entry is string => Boolean(entry));
-    return messages.length > 0 ? messages.join("; ") : null;
-  }
-
-  if (value && typeof value === "object") {
-    const candidate = value as {
-      detail?: unknown;
-      error?: unknown;
-      msg?: unknown;
-      message?: unknown;
-    };
-    return (
-      normalizeErrorMessage(candidate.error) ??
-      normalizeErrorMessage(candidate.detail) ??
-      normalizeErrorMessage(candidate.msg) ??
-      normalizeErrorMessage(candidate.message) ??
-      JSON.stringify(value)
-    );
-  }
-
-  return null;
-};
-
-const parsePositiveIntegerInputValue = (value: string): number | null => {
-  const trimmed = value.trim();
-  if (!trimmed) return null;
-  const parsed = Number.parseInt(trimmed, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
-};
-
-
-interface TrrCastMember {
-  id: string;
-  person_id: string;
-  full_name: string | null;
-  cast_member_name: string | null;
-  role: string | null;
-  roles?: string[] | null;
-  billing_order: number | null;
-  credit_category: string;
-  photo_url: string | null;
-  cover_photo_url: string | null;
-  thumbnail_focus_x?: number | null;
-  thumbnail_focus_y?: number | null;
-  thumbnail_zoom?: number | null;
-  thumbnail_crop_mode?: "manual" | "auto" | null;
-  total_episodes?: number | null;
-  archive_episode_count?: number | null;
-  latest_season?: number | null;
-  seasons_appeared?: number[] | null;
-}
-
-type ShowCastEligibilityMode = "default" | "links";
-
-type EntityLinkType = "show" | "season" | "person";
-type EntityLinkGroup = "official" | "social" | "knowledge" | "cast_announcements" | "other";
-type EntityLinkStatus = "pending" | "approved" | "rejected";
-
-interface EntityLink {
-  id: string;
-  show_id: string;
-  entity_type: EntityLinkType;
-  entity_id: string;
-  season_number: number;
-  link_group: EntityLinkGroup;
-  link_kind: string;
-  label: string | null;
-  url: string;
-  status: EntityLinkStatus;
-  confidence: number | null;
-  source: string | null;
-  metadata: Record<string, unknown> | null;
-  created_at: string | null;
-  updated_at: string | null;
-}
-
-interface ShowRole {
-  id: string;
-  show_id: string;
-  name: string;
-  normalized_name: string;
-  sort_order: number;
-  is_active: boolean;
-}
-
-interface CastRoleMember {
-  person_id: string;
-  person_name: string | null;
-  total_episodes: number | null;
-  seasons_appeared: number | null;
-  latest_season: number | null;
-  roles: string[];
-  photo_url: string | null;
-}
-
-interface ShowCrewCreditRow {
-  credit_id: string;
-  person_id: string;
-  person_name: string | null;
-  role: string | null;
-  billing_order: number | null;
-  source_type: string | null;
-  episode_count: number | null;
-  episodes_label: string | null;
-  years_label: string | null;
-  imdb_name_id: string | null;
-  display_order: number | null;
-}
-
-interface ShowCrewGroupedRow {
-  person_id: string;
-  person_name: string | null;
-  role_lines: ShowCrewCreditRow[];
-}
-
-interface ShowCrewSection {
-  title: string;
-  rows: ShowCrewCreditRow[];
-  grouped_rows?: ShowCrewGroupedRow[];
-}
-
-interface ShowCreditsPayload {
-  cast_roster: Array<Record<string, unknown>>;
-  crew_sections: ShowCrewSection[];
-  source_metadata?: {
-    source_page_url?: string | null;
-    show_imdb_id?: string | null;
-    last_synced_at?: string | null;
-  } | null;
-}
-
-const normalizeShowCreditsCastRoster = (value: unknown): TrrCastMember[] => {
-  if (!Array.isArray(value)) return [];
-  return value
-    .map((row) => {
-      if (!row || typeof row !== "object") return null;
-      const candidate = row as Record<string, unknown>;
-      const personId =
-        typeof candidate.person_id === "string" ? candidate.person_id.trim() : "";
-      if (!personId) return null;
-      const roles = Array.isArray(candidate.roles)
-        ? candidate.roles.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
-        : [];
-      const seasonNumbers = Array.isArray(candidate.season_numbers)
-        ? candidate.season_numbers.filter(
-            (item): item is number => typeof item === "number" && Number.isFinite(item)
-          )
-        : [];
-      return {
-        id:
-          typeof candidate.person_id === "string" && candidate.person_id.trim()
-            ? candidate.person_id.trim()
-            : typeof candidate.show_id === "string"
-              ? `${candidate.show_id}:${personId}`
-              : personId,
-        person_id: personId,
-        full_name:
-          typeof candidate.person_name === "string" && candidate.person_name.trim()
-            ? candidate.person_name
-            : null,
-        cast_member_name:
-          typeof candidate.person_name === "string" && candidate.person_name.trim()
-            ? candidate.person_name
-            : null,
-        role: roles[0] ?? null,
-        roles,
-        billing_order: null,
-        credit_category: "Self",
-        photo_url:
-          typeof candidate.photo_url === "string" && candidate.photo_url.trim()
-            ? candidate.photo_url
-            : null,
-        cover_photo_url: null,
-        total_episodes:
-          typeof candidate.total_episodes === "number" ? candidate.total_episodes : null,
-        archive_episode_count:
-          typeof candidate.archive_episodes === "number" ? candidate.archive_episodes : null,
-        latest_season:
-          typeof candidate.latest_season === "number" ? candidate.latest_season : null,
-        seasons_appeared: seasonNumbers,
-      } as TrrCastMember;
-    })
-    .filter((row): row is TrrCastMember => row !== null);
-};
-
-const shouldHideShowCreditsRoleChip = (role: string): boolean => {
-  const normalized = role.trim().toLowerCase();
-  return (
-    normalized === "cast" ||
-    normalized === "self" ||
-    normalized.startsWith("self ") ||
-    normalized.startsWith("self-") ||
-    normalized.startsWith("self/")
-  );
-};
-
-const getMeaningfulShowCreditsRoles = (roles: string[] | null | undefined): string[] => {
-  if (!Array.isArray(roles)) return [];
-  return roles
-    .map((role) => role.trim())
-    .filter((role) => role.length > 0 && !shouldHideShowCreditsRoleChip(role));
-};
-
-const groupShowCrewRows = (rows: ShowCrewCreditRow[]): ShowCrewGroupedRow[] => {
-  const grouped = new Map<string, ShowCrewGroupedRow>();
-  const orderedKeys: string[] = [];
-
-  for (const row of rows) {
-    const personId = typeof row.person_id === "string" && row.person_id.trim() ? row.person_id.trim() : row.credit_id;
-    const existing = grouped.get(personId);
-    if (existing) {
-      existing.role_lines.push(row);
-      continue;
-    }
-    grouped.set(personId, {
-      person_id: personId,
-      person_name: row.person_name,
-      role_lines: [row],
-    });
-    orderedKeys.push(personId);
-  }
-
-  return orderedKeys
-    .map((key) => grouped.get(key))
-    .filter((row): row is ShowCrewGroupedRow => Boolean(row));
-};
-
-interface BravoPersonTag {
-  person_id?: string | null;
-  person_name?: string | null;
-  person_url?: string | null;
-}
-
-interface BravoVideoItem {
-  title?: string | null;
-  runtime?: string | null;
-  kicker?: string | null;
-  image_url?: string | null;
-  hosted_image_url?: string | null;
-  original_image_url?: string | null;
-  media_asset_id?: string | null;
-  thumbnail_sync_status?: string | null;
-  thumbnail_sync_error?: string | null;
-  clip_url: string;
-  season_number?: number | null;
-  published_at?: string | null;
-  person_tags?: BravoPersonTag[];
-}
-
-interface BravoNewsItem {
-  headline?: string | null;
-  image_url?: string | null;
-  article_url: string;
-  published_at?: string | null;
-  person_tags?: BravoPersonTag[];
-}
-
-interface UnifiedNewsSeasonMatch {
-  season_number?: number | null;
-  match_types?: string[] | null;
-}
-
-interface UnifiedNewsItem {
-  source_id?: string | null;
-  headline?: string | null;
-  article_url: string;
-  canonical_article_url?: string | null;
-  image_url?: string | null;
-  hosted_image_url?: string | null;
-  original_image_url?: string | null;
-  mirror_status?: string | null;
-  mirror_attempt_count?: number | null;
-  last_mirror_attempt_at?: string | null;
-  last_mirror_success_at?: string | null;
-  last_mirror_error?: string | null;
-  mirror_retry_after?: string | null;
-  published_at?: string | null;
-  publisher_name?: string | null;
-  publisher_domain?: string | null;
-  person_tags?: BravoPersonTag[];
-  topic_tags?: string[] | null;
-  season_matches?: UnifiedNewsSeasonMatch[] | null;
-  feed_rank?: number | null;
-  trending_rank?: number | null;
-  quality_score?: number | null;
-}
-
-interface UnifiedNewsFacetSource {
-  token: string;
-  label: string;
-  count: number;
-}
-
-interface UnifiedNewsFacetPerson {
-  person_id: string;
-  person_name: string;
-  count: number;
-}
-
-interface UnifiedNewsFacetTopic {
-  topic: string;
-  count: number;
-}
-
-interface UnifiedNewsFacetSeason {
-  season_number: number;
-  count: number;
-}
-
-interface UnifiedNewsFacets {
-  sources: UnifiedNewsFacetSource[];
-  people: UnifiedNewsFacetPerson[];
-  topics: UnifiedNewsFacetTopic[];
-  seasons: UnifiedNewsFacetSeason[];
-}
-
-interface BravoPreviewPerson {
-  name?: string | null;
-  canonical_url?: string | null;
-  bio?: string | null;
-  hero_image_url?: string | null;
-  social_links?: Record<string, string> | null;
-}
-
-interface BravoPersonCandidateResult {
-  url: string;
-  source?: "bravo" | "fandom";
-  name?: string | null;
-  status?: "pending" | "in_progress" | "ok" | "missing" | "error" | string;
-  error?: string | null;
-  person?: BravoPreviewPerson | null;
-}
-
-type BravoCandidateSummary = {
-  tested: number;
-  valid: number;
-  missing: number;
-  errors: number;
-};
-
-type BravoImportImageKind =
-  | "poster"
-  | "backdrop"
-  | "logo"
-  | "episode_still"
-  | "cast"
-  | "promo"
-  | "intro"
-  | "reunion"
-  | "other";
-type SyncBravoRunMode = "full" | "cast-only";
-
-type TabId = "seasons" | "assets" | "news" | "cast" | "surveys" | "social" | "details" | "settings";
-type ShowCastSource = "episode_evidence" | "show_fallback" | "imdb_show_membership";
-type ShowCastRosterMode = "episode_evidence" | "imdb_show_membership";
-type CastPhotoFallbackMode = "none" | "bravo";
-type ShowRefreshTarget =
-  | "details"
-  | "seasons_episodes"
-  | "photos"
-  | "cast_credits"
-  | "videos"
-  | "news"
-  | "social_setup"
-  | "show_core"
-  | "links"
-  | "bravo"
-  | "cast_profiles"
-  | "cast_media"
-  | "get_images";
-type ShowTab = { id: TabId; label: string; icon?: "home" };
-type RefreshProgressState = {
-  stage?: string | null;
-  message?: string | null;
-  current: number | null;
-  total: number | null;
-};
-
-type RefreshLogEntry = {
-  id: string;
-  at: string;
-  category: string;
-  message: string;
-  current: number | null;
-  total: number | null;
-  stageKey?: string | null;
-  topic?: RefreshLogTopicKey | null;
-  provider?: string | null;
-  subOperationId?: string | null;
-  executionOwner?: string | null;
-  parentOperationId?: string | null;
-};
-
-type RoleRenameDraft = {
-  roleId: string;
-  originalName: string;
-  nextName: string;
-};
-
-type CastRoleEditDraft = {
-  personId: string;
-  personName: string;
-  roleCsv: string;
-};
-
-type CastRunFailedMember = {
-  personId: string;
-  name: string;
-  reason: string;
-};
-
-type CastBatchRunSummary = {
-  attempted: number;
-  succeeded: number;
-  skipped: number;
-  failed: number;
-  failedMembers: CastRunFailedMember[];
-};
-
-type ShowRefreshRunOptions = {
-  photoMode?: "fast" | "full";
-  skipCastPhotos?: boolean;
-  includeCastProfiles?: boolean;
+type ShowRefreshRunOptions = WorkspaceShowRefreshRunOptions & {
   suppressSuccessNotice?: boolean;
-  onProgress?: (progress: Partial<CastRefreshPhaseProgress>) => void;
 };
-type PersonRefreshMode = "full" | "ingest_only" | "profile_only";
-
-type HealthStatus = "ready" | "missing" | "stale";
-type PersonLinkSourceKey = "bravo" | "imdb" | "tmdb" | "wikipedia" | "wikidata" | "fandom";
-type PersonLinkSourceState = "missing" | "unvalidated";
-type LinkSourceBadgeKind =
-  | PersonLinkSourceKey
-  | "official"
-  | "google_news"
-  | "instagram"
-  | "tiktok"
-  | "x"
-  | "youtube"
-  | "threads"
-  | "facebook"
-  | "reddit"
-  | "tvdb"
-  | "tvmaze"
-  | "trakt"
-  | "freebase"
-  | "google_kg"
-  | "ratinggraph"
-  | "x_topic"
-  | "other";
-
-type PersonLinkSourceSummary = {
-  key: PersonLinkSourceKey;
-  label: string;
-  state: PersonLinkSourceState;
-  url: string | null;
-  link: EntityLink | null;
-};
-
-type ShowSocialLinkPill = {
-  id: string;
-  sourceKind: LinkSourceBadgeKind;
-  sourceLabel: string;
-  text: string;
-  url: string;
-  link: EntityLink;
-};
-
-type PersonApprovedLinkPill = {
-  id: string;
-  sourceKind: LinkSourceBadgeKind;
-  sourceLabel: string;
-  text: string;
-  label: string;
-  url: string;
-  iconUrl: string | null;
-  link: EntityLink;
-};
-
-type PersonLinkCoverageCard = {
-  personId: string;
-  personName: string;
-  avatarUrl: string | null;
-  seasons: number[];
-  approvedLinkCount: number;
-  approvedLinks: PersonApprovedLinkPill[];
-  missingSources: PersonLinkSourceSummary[];
-};
-
-type SeasonCoverageLinkPill = {
-  id: string;
-  seasonNumber: number;
-  url: string;
-  sourceKind: LinkSourceBadgeKind;
-  sourceLabel: string;
-  iconUrl: string | null;
-  linkTitle: string | null;
-  link?: EntityLink;
-};
-
-type SeasonUrlCoverageRow = {
-  seasonNumber: number;
-  links: SeasonCoverageLinkPill[];
-};
-
-type ShowGalleryVisibleBySection = Partial<Record<AssetSectionKey, number>>;
-type GalleryAssetSourceRequest = {
-  id: string;
-  label: string;
-  baseUrl: string;
-};
-type GalleryAssetSourceFailure = {
-  sourceId: string;
-  label: string;
-  message: string;
-  status: number;
-  retryable: boolean;
-  code?: string;
-  reason?: string;
-  detail?: Record<string, unknown>;
-};
-
-class GalleryAssetSourceError extends Error {
-  status: number;
-  retryable: boolean;
-  code?: string;
-  reason?: string;
-  detail?: Record<string, unknown>;
-
-  constructor({
-    message,
-    status,
-    retryable,
-    code,
-    reason,
-    detail,
-  }: {
-    message: string;
-    status: number;
-    retryable: boolean;
-    code?: string;
-    reason?: string;
-    detail?: Record<string, unknown>;
-  }) {
-    super(message);
-    this.name = "GalleryAssetSourceError";
-    this.status = status;
-    this.retryable = retryable;
-    this.code = code;
-    this.reason = reason;
-    this.detail = detail;
-  }
-}
 
 const TabLoadingFallback = ({ label }: { label: string }) => (
   <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm">
@@ -946,13 +332,13 @@ const ShowNewsTab = dynamic(() => import("@/components/admin/show-tabs/ShowNewsT
 });
 const ShowCastTab = dynamic(() => import("@/components/admin/show-tabs/ShowCastTab"), {
   loading: () => <TabLoadingFallback label="Credits" />,
-});
+}) as typeof import("@/components/admin/show-tabs/ShowCastTab").default;
 const ShowSocialTab = dynamic(() => import("@/components/admin/show-tabs/ShowSocialTab"), {
   loading: () => <TabLoadingFallback label="Social" />,
 });
 const ShowSettingsTab = dynamic(() => import("@/components/admin/show-tabs/ShowSettingsTab"), {
   loading: () => <TabLoadingFallback label="Settings" />,
-});
+}) as typeof import("@/components/admin/show-tabs/ShowSettingsTab").default;
 
 const REFRESH_LOG_TOPIC_DEFINITIONS: RefreshLogTopicDefinition[] = [
   { key: "show_core", label: "SHOW CORE", description: "Details, seasons, episodes, cast, and setup" },
@@ -1126,22 +512,6 @@ const PERSON_LINK_SOURCE_DEFINITIONS: Array<{ key: PersonLinkSourceKey; label: s
   { key: "fandom", label: "Fandom/Wikia" },
 ];
 
-const SHOW_REFRESH_TARGET_LABELS: Record<ShowRefreshTarget, string> = {
-  details: "Show Info",
-  seasons_episodes: "Seasons & Episodes",
-  photos: "Gallery Media",
-  cast_credits: "Credits",
-  videos: "Bravo Videos",
-  news: "Google News",
-  social_setup: "Social Setup",
-  show_core: "Show Core",
-  links: "Links",
-  bravo: "Bravo",
-  cast_profiles: "Cast Profiles",
-  cast_media: "Cast Media",
-  get_images: "Getty/NBCUMV Images",
-};
-
 const SHOW_REFRESH_STAGE_LABELS: Record<string, string> = {
   starting: "Initializing",
   show_core: "Show Core",
@@ -1276,14 +646,6 @@ const CAST_REFRESH_PHASE_STAGES: Record<CastRefreshPhaseId, string> = {
   media_ingest: "Media",
 };
 
-const CAST_REFRESH_PHASE_ORDER: CastRefreshPhaseId[] = [
-  "credits_sync",
-  "profile_links_sync",
-  "bio_sync",
-  "network_augmentation",
-  "media_ingest",
-];
-
 const CREDITS_PIPELINE_BACKEND_TARGET = "credits_pipeline";
 
 const createCastRefreshPhaseStates = (): CastRefreshPhaseState[] =>
@@ -1332,12 +694,6 @@ const shouldPreferLocalAdminExecution = (): boolean => {
   if (typeof window === "undefined") return false;
   const hostname = window.location.hostname.trim().toLowerCase();
   return hostname === "localhost" || hostname === "127.0.0.1" || hostname.endsWith(".localhost");
-};
-
-const readTrimmedToken = (value: unknown): string | null => {
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
 };
 
 const shortenAdminToken = (value: string | null | undefined): string | null => {
@@ -1456,911 +812,6 @@ const readLinkDiscoverySourceCounts = (value: unknown): LinkDiscoverySourceCount
       if (b.count !== a.count) return b.count - a.count;
       return a.label.localeCompare(b.label);
     });
-};
-
-const formatIsoAgeLabel = (value: string | null | undefined): string | null => {
-  const trimmed = readTrimmedToken(value);
-  if (!trimmed) return null;
-  const timestamp = Date.parse(trimmed);
-  if (!Number.isFinite(timestamp)) return null;
-  const diffSeconds = Math.max(0, Math.round((Date.now() - timestamp) / 1000));
-  return `${diffSeconds}s ago`;
-};
-
-const isCastRefreshPhaseId = (value: unknown): value is CastRefreshPhaseId =>
-  typeof value === "string" && CAST_REFRESH_PHASE_ORDER.includes(value as CastRefreshPhaseId);
-
-const toIsoNow = (): string => new Date().toISOString();
-
-const updateCastRefreshPhaseStates = (
-  states: CastRefreshPhaseState[],
-  phaseId: CastRefreshPhaseId,
-  updater: (state: CastRefreshPhaseState) => CastRefreshPhaseState
-): CastRefreshPhaseState[] => states.map((state) => (state.id === phaseId ? updater(state) : state));
-
-const SEASON_PAGE_TABS = [
-  { tab: "overview", label: "Home" },
-  { tab: "episodes", label: "Episodes" },
-  { tab: "assets", label: "Assets" },
-  { tab: "news", label: "News" },
-  { tab: "fandom", label: "Fandom" },
-  { tab: "cast", label: "Credits" },
-  { tab: "surveys", label: "Surveys" },
-  { tab: "social", label: "Social Media" },
-] as const;
-
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const looksLikeUuid = (value: string) => UUID_RE.test(value);
-
-const normalizeEntityLinkStatus = (value: unknown): EntityLinkStatus => {
-  const normalized = String(value ?? "").trim().toLowerCase();
-  if (normalized === "approved") return "approved";
-  if (normalized === "rejected") return "rejected";
-  return "pending";
-};
-
-const classifyPersonLinkSource = (linkKind: string): PersonLinkSourceKey | null => {
-  const kind = linkKind.trim().toLowerCase();
-  if (!kind) return null;
-  if (kind === "bravo_profile" || kind.includes("bravo")) return "bravo";
-  if (kind.includes("imdb")) return "imdb";
-  if (kind.includes("tmdb")) return "tmdb";
-  if (kind === "wikipedia") return "wikipedia";
-  if (kind === "wikidata") return "wikidata";
-  if (kind === "fandom" || kind === "wikia") return "fandom";
-  return null;
-};
-
-const getPersonSourceKindPriority = (sourceKey: PersonLinkSourceKey, linkKind: string): number => {
-  const kind = linkKind.trim().toLowerCase();
-  if (sourceKey === "wikidata") return kind === "wikidata" ? 0 : 99;
-  if (sourceKey === "wikipedia") return kind === "wikipedia" ? 0 : 99;
-  return 99;
-};
-
-const pickPreferredPersonSourceLink = (
-  sourceKey: PersonLinkSourceKey,
-  links: EntityLink[]
-): EntityLink | null => {
-  if (links.length === 0) return null;
-  const rankByStatus = (status: EntityLinkStatus): number => {
-    if (status === "approved") return 0;
-    if (status === "pending") return 1;
-    return 2;
-  };
-  const sorted = [...links].sort((a, b) => {
-    const statusDiff = rankByStatus(normalizeEntityLinkStatus(a.status)) - rankByStatus(normalizeEntityLinkStatus(b.status));
-    if (statusDiff !== 0) return statusDiff;
-    const kindDiff =
-      getPersonSourceKindPriority(sourceKey, a.link_kind) -
-      getPersonSourceKindPriority(sourceKey, b.link_kind);
-    if (kindDiff !== 0) return kindDiff;
-    return (a.label || a.url).localeCompare(b.label || b.url);
-  });
-  return sorted[0] ?? null;
-};
-
-function PersonSourceLogo({ sourceKey }: { sourceKey: PersonLinkSourceKey }) {
-  const baseClass =
-    "inline-flex h-5 min-w-[2.1rem] items-center justify-center rounded border px-1 text-[10px] font-bold uppercase tracking-[0.08em]";
-  if (sourceKey === "imdb") {
-    return <span className={`${baseClass} border-zinc-300 bg-[#f5c518] text-zinc-900`}>IMDb</span>;
-  }
-  if (sourceKey === "tmdb") {
-    return <span className={`${baseClass} border-zinc-300 bg-[#01d277] text-zinc-900`}>TMDb</span>;
-  }
-  if (sourceKey === "bravo") {
-    return <span className={`${baseClass} border-zinc-300 bg-zinc-900 text-white`}>Bravo</span>;
-  }
-  if (sourceKey === "wikipedia") {
-    return <span className={`${baseClass} border-zinc-300 bg-sky-600 text-white`}>Wiki</span>;
-  }
-  if (sourceKey === "wikidata") {
-    return <span className={`${baseClass} border-zinc-300 bg-cyan-700 text-white`}>WD</span>;
-  }
-  return <span className={`${baseClass} border-zinc-300 bg-[#f3f4f6] text-zinc-800`}>Fandom</span>;
-}
-
-const PAGE_LINK_SOURCE_ORDER: LinkSourceBadgeKind[] = [
-  "official",
-  "bravo",
-  "fandom",
-  "wikipedia",
-  "wikidata",
-  "imdb",
-  "tmdb",
-  "tvdb",
-  "tvmaze",
-  "trakt",
-  "ratinggraph",
-  "freebase",
-  "google_kg",
-  "x_topic",
-  "google_news",
-  "instagram",
-  "tiktok",
-  "x",
-  "youtube",
-  "threads",
-  "facebook",
-  "reddit",
-  "other",
-];
-
-const PAGE_LINK_SOURCE_LABELS: Record<LinkSourceBadgeKind, string> = {
-  official: "Official",
-  google_news: "Google News",
-  bravo: "Bravo TV",
-  fandom: "Fandom",
-  wikipedia: "Wikipedia",
-  wikidata: "Wikidata",
-  imdb: "IMDb",
-  tmdb: "TMDb",
-  instagram: "Instagram",
-  tiktok: "TikTok",
-  x: "X",
-  youtube: "YouTube",
-  threads: "Threads",
-  facebook: "Facebook",
-  reddit: "Reddit",
-  tvdb: "TVDB",
-  tvmaze: "TVmaze",
-  trakt: "Trakt",
-  freebase: "Freebase",
-  google_kg: "Google KG",
-  ratinggraph: "RatingGraph",
-  x_topic: "X Topic",
-  other: "Link",
-};
-
-const getLinkSourceBadgeKind = (link: EntityLink): LinkSourceBadgeKind => {
-  const normalizedKind = normalizeLinkKind(link.link_kind);
-  const sourceKey = classifyPersonLinkSource(normalizedKind);
-  if (sourceKey) return sourceKey;
-  if (isSocialLinkKind(normalizedKind)) {
-    if (normalizedKind === "x") return "x";
-    return normalizedKind as LinkSourceBadgeKind;
-  }
-  if (normalizedKind === "official_page" || normalizedKind === "network_blog" || normalizedKind === "cast_announcement") {
-    const host = getHostnameFromUrl(link.url)?.toLowerCase() ?? "";
-    if (host.includes("bravotv.com")) return "bravo";
-    return "official";
-  }
-  if (normalizedKind === "tvdb") return "tvdb";
-  if (normalizedKind === "tvmaze") return "tvmaze";
-  if (normalizedKind === "trakt") return "trakt";
-  if (normalizedKind === "freebase") return "freebase";
-  if (normalizedKind === "google_kg") return "google_kg";
-  if (normalizedKind === "ratinggraph") return "ratinggraph";
-  if (normalizedKind === "x_topic") return "x_topic";
-  if (normalizedKind === "google_news_url") return "google_news";
-  return "other";
-};
-
-const getSourceBadgeOrder = (kind: LinkSourceBadgeKind): number => {
-  const index = PAGE_LINK_SOURCE_ORDER.indexOf(kind);
-  return index === -1 ? PAGE_LINK_SOURCE_ORDER.length : index;
-};
-
-const getLinkSourceLabel = (link: EntityLink): string => {
-  const badgeKind = getLinkSourceBadgeKind(link);
-  if (badgeKind === "fandom") {
-    return resolveLinkSiteTitle(link) || PAGE_LINK_SOURCE_LABELS.fandom;
-  }
-  if (badgeKind === "official" || badgeKind === "bravo") {
-    const host = getHostnameFromUrl(link.url)?.toLowerCase() ?? "";
-    if (host.includes("bravotv.com")) return "Bravo TV";
-  }
-  return PAGE_LINK_SOURCE_LABELS[badgeKind] || String(link.label || link.link_kind || "Link").trim() || "Link";
-};
-
-const getShowPageLinkTitle = (link: EntityLink, showName: string): string => {
-  return resolveShowPageDisplayTitle(link, showName);
-};
-
-const decodeHandleToken = (value: string): string => {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
-  }
-};
-
-const normalizeSocialHandleValue = (value: string): string | null => {
-  const decoded = decodeHandleToken(value).trim();
-  if (!decoded) return null;
-  const handleMatch = decoded.match(/@[\w.]+/);
-  if (handleMatch) {
-    return `@${handleMatch[0].replace(/^@+/, "")}`;
-  }
-  const normalized = decoded.replace(/^@+/, "").trim();
-  if (!normalized) return null;
-  return `@${normalized}`;
-};
-
-const extractSocialHandleFromUrl = (url: string): string | null => {
-  try {
-    const parsed = new URL(url);
-    const segments = parsed.pathname.split("/").filter(Boolean);
-    const handle = segments.at(-1) ?? "";
-    return normalizeSocialHandleValue(handle);
-  } catch {
-    return null;
-  }
-};
-
-const getApprovedLinkText = (link: EntityLink, fallbackTitle: string): string => {
-  const badgeKind = getLinkSourceBadgeKind(link);
-  if (isSocialLinkKind(badgeKind)) {
-    const normalizedUrlHandle = extractSocialHandleFromUrl(link.url);
-    if (normalizedUrlHandle) return normalizedUrlHandle;
-    const rawLabel = String(link.label || "").trim();
-    const normalizedLabelHandle = normalizeSocialHandleValue(rawLabel);
-    if (normalizedLabelHandle) return normalizedLabelHandle;
-    return rawLabel.startsWith("@") ? rawLabel : link.url;
-  }
-  return (
-    resolveLinkPageTitle(link) ||
-    String(link.label || "").trim() ||
-    fallbackTitle
-  );
-};
-
-const getCastMemberLinkText = (link: EntityLink, personName: string): string => {
-  const badgeKind = getLinkSourceBadgeKind(link);
-  if (isSocialLinkKind(badgeKind)) {
-    return getApprovedLinkText(link, personName);
-  }
-  if (badgeKind === "fandom") {
-    return resolveLinkPageTitle(link) || personName;
-  }
-  return personName;
-};
-
-const getCastMemberNameSourcePriority = (link: EntityLink): number => {
-  const normalizedKind = normalizeLinkKind(link.link_kind);
-  if (normalizedKind === "bravo_profile") return 0;
-  if (normalizedKind === "wikipedia") return 1;
-  if (normalizedKind === "fandom") return 2;
-  if (normalizedKind === "wikidata") return 3;
-  if (normalizedKind === "imdb") return 4;
-  if (normalizedKind === "tmdb") return 5;
-  if (isSocialLinkKind(normalizedKind)) return 99;
-  if (normalizedKind === "freebase" || normalizedKind === "google_kg") return 98;
-  return 50;
-};
-
-const resolveCastMemberNameFromLinks = (
-  links: EntityLink[],
-  rosterName: string | null | undefined
-): string => {
-  const normalizedRosterName = String(rosterName || "").trim();
-  if (normalizedRosterName) return normalizedRosterName;
-
-  const rankedCandidates = links
-    .map((link) => ({
-      link,
-      name: parsePersonNameFromLink(link),
-      statusPriority: normalizeEntityLinkStatus(link.status) === "approved" ? 0 : 1,
-      sourcePriority: getCastMemberNameSourcePriority(link),
-    }))
-    .filter((candidate): candidate is typeof candidate & { name: string } => Boolean(candidate.name))
-    .sort((a, b) => {
-      const statusDiff = a.statusPriority - b.statusPriority;
-      if (statusDiff !== 0) return statusDiff;
-      const sourceDiff = a.sourcePriority - b.sourcePriority;
-      if (sourceDiff !== 0) return sourceDiff;
-      const shorterDiff = a.name.length - b.name.length;
-      if (shorterDiff !== 0) return shorterDiff;
-      return a.name.localeCompare(b.name);
-    });
-
-  return rankedCandidates[0]?.name || "Unknown Person";
-};
-
-const isRenderableSeasonPageLink = (link: EntityLink): boolean => {
-  if (normalizeEntityLinkStatus(link.status) !== "approved") return false;
-  if (link.entity_type !== "season" && !(typeof link.season_number === "number" && link.season_number > 0)) return false;
-  const normalizedKind = normalizeLinkKind(link.link_kind);
-  if (isSocialLinkKind(normalizedKind)) return false;
-  if (normalizedKind === "cast_announcement" || normalizedKind === "network_blog") return false;
-  if (isFandomSeedUrl(link.url)) return false;
-  return isLikelyPageUrl(link.url);
-};
-
-const isRenderableShowPageLink = (link: EntityLink): boolean => {
-  if (normalizeEntityLinkStatus(link.status) !== "approved") return false;
-  if (link.entity_type !== "show" || Number(link.season_number || 0) > 0) return false;
-  const normalizedKind = normalizeLinkKind(link.link_kind);
-  if (link.link_group === "social" || isSocialLinkKind(normalizedKind)) return false;
-  if (normalizedKind === "cast_announcement") return false;
-  if (isFandomSeedUrl(link.url)) return false;
-  return isLikelyPageUrl(link.url);
-};
-
-const toSocialPlatformIconKey = (kind: LinkSourceBadgeKind): SocialPlatformTabIconKey | null => {
-  if (kind === "instagram" || kind === "tiktok" || kind === "youtube" || kind === "threads" || kind === "facebook" || kind === "reddit") {
-    return kind;
-  }
-  if (kind === "x") return "twitter";
-  return null;
-};
-
-const usesBrandIconOnly = (kind: LinkSourceBadgeKind): boolean =>
-  Boolean(
-    toSocialPlatformIconKey(kind) ||
-      kind === "imdb" ||
-      kind === "tmdb" ||
-      kind === "bravo" ||
-      kind === "wikipedia" ||
-      kind === "wikidata"
-  );
-
-function SourceBadge({
-  kind,
-  label,
-  iconUrl,
-  iconOnly = false,
-}: {
-  kind: LinkSourceBadgeKind;
-  label: string;
-  iconUrl?: string | null;
-  iconOnly?: boolean;
-}) {
-  const socialIconKey = toSocialPlatformIconKey(kind);
-  if (socialIconKey) {
-    return (
-      <span className="inline-flex items-center justify-center">
-        <SocialPlatformTabIcon tab={socialIconKey} />
-        {!iconOnly ? <span className="sr-only">{label}</span> : null}
-      </span>
-    );
-  }
-
-  if (kind === "imdb") return <PersonSourceLogo sourceKey="imdb" />;
-  if (kind === "tmdb") return <PersonSourceLogo sourceKey="tmdb" />;
-  if (kind === "bravo") return <PersonSourceLogo sourceKey="bravo" />;
-  if (kind === "wikipedia") return <PersonSourceLogo sourceKey="wikipedia" />;
-  if (kind === "wikidata") return <PersonSourceLogo sourceKey="wikidata" />;
-  if (kind === "fandom") {
-    if (iconUrl) {
-      return (
-        <span className="inline-flex items-center gap-1">
-          <Image
-            src={iconUrl}
-            alt=""
-            width={14}
-            height={14}
-            className="h-3.5 w-3.5 shrink-0 rounded-sm"
-            unoptimized
-          />
-          {!iconOnly ? <span className="text-xs font-semibold text-zinc-700">{label}</span> : null}
-        </span>
-      );
-    }
-    return iconOnly ? <PersonSourceLogo sourceKey="fandom" /> : <span className="text-xs font-semibold text-zinc-700">{label}</span>;
-  }
-
-  const baseClass =
-    "inline-flex h-5 min-w-[2.1rem] items-center justify-center rounded border px-1 text-[10px] font-bold uppercase tracking-[0.08em]";
-  const tokenText = (() => {
-    if (kind === "official") return "Site";
-    if (kind === "tvdb") return "TVDB";
-    if (kind === "tvmaze") return "TVM";
-    if (kind === "trakt") return "Trakt";
-    if (kind === "freebase") return "FB";
-    if (kind === "google_kg") return "GKG";
-    if (kind === "ratinggraph") return "RG";
-    if (kind === "x_topic") return "X";
-    if (kind === "google_news") return "News";
-    return label.slice(0, 6) || "Link";
-  })();
-  return <span className={`${baseClass} border-zinc-300 bg-zinc-100 text-zinc-700`}>{tokenText}</span>;
-}
-
-function SocialHandlePill({ pill }: { pill: ShowSocialLinkPill }) {
-  return (
-    <a
-      href={pill.url}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="inline-flex max-w-full items-center gap-2 rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs font-semibold text-zinc-700 hover:bg-zinc-100"
-      title={pill.url}
-    >
-      <SourceBadge
-        kind={pill.sourceKind}
-        label={pill.sourceLabel}
-        iconOnly={true}
-      />
-      <span className="truncate">{pill.text}</span>
-    </a>
-  );
-}
-
-function InlineEditableLinkUrl({
-  linkId,
-  url,
-  openUrl,
-  label,
-  saving,
-  onSubmit,
-  children,
-  actions,
-  containerClassName,
-  canEdit = true,
-}: {
-  linkId: string;
-  url: string;
-  openUrl?: string | null;
-  label?: string;
-  saving: boolean;
-  onSubmit: (linkId: string, nextUrl: string) => Promise<void>;
-  children?: ReactNode;
-  actions?: ReactNode;
-  containerClassName?: string;
-  canEdit?: boolean;
-}) {
-  const editButton = canEdit ? (
-    <EditableTrigger asChild>
-      <button
-        type="button"
-        disabled={saving}
-        className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-zinc-200 bg-white text-zinc-700 transition hover:bg-zinc-50 disabled:opacity-50"
-        aria-label={label ? `Edit URL for ${label}` : "Edit link URL"}
-        title={label ? `Edit URL for ${label}` : "Edit link URL"}
-      >
-        <EditActionIcon />
-      </button>
-    </EditableTrigger>
-  ) : null;
-  const openButton = openUrl ? (
-    <a
-      href={openUrl}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-zinc-200 bg-white text-zinc-700 transition hover:bg-zinc-50"
-      aria-label={label ? `Open ${label}` : "Open link"}
-      title={label ? `Open ${label}` : "Open link"}
-    >
-      <OpenLinkActionIcon />
-    </a>
-  ) : null;
-
-  return (
-    <Editable value={url} placeholder="https://example.com" onSubmit={(nextUrl) => onSubmit(linkId, nextUrl)}>
-      <div className={containerClassName ? `${containerClassName} space-y-2` : "space-y-2"}>
-        {(children || actions || editButton || openButton) && (
-          <div className="flex flex-wrap items-start justify-between gap-2">
-            <div className="min-w-0 flex-1">{children}</div>
-            <div className="flex shrink-0 items-center gap-2">
-              {editButton}
-              {openButton}
-              {actions}
-            </div>
-          </div>
-        )}
-        {!children && !actions && (editButton || openButton) && (
-          <div className="flex justify-end">
-            <div className="flex items-center gap-2">
-              {editButton}
-              {openButton}
-            </div>
-          </div>
-        )}
-        <EditableArea className="space-y-1">
-          <EditablePreview className="hidden" />
-          <EditableInput
-            type="url"
-            autoCapitalize="off"
-            autoCorrect="off"
-            spellCheck={false}
-            className="min-h-9 rounded-lg text-xs"
-          />
-        </EditableArea>
-        <EditableToolbar className="pt-1">
-          <EditableSubmit asChild>
-            <button
-              type="button"
-              disabled={saving}
-              className="rounded border border-zinc-300 bg-zinc-900 px-2 py-1 text-[11px] font-semibold text-white hover:bg-zinc-800 disabled:opacity-50"
-            >
-              {saving ? "Saving..." : "Save URL"}
-            </button>
-          </EditableSubmit>
-          <EditableCancel asChild>
-            <button
-              type="button"
-              disabled={saving}
-              className="rounded border border-zinc-200 bg-white px-2 py-1 text-[11px] font-semibold text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
-            >
-              Cancel
-            </button>
-          </EditableCancel>
-        </EditableToolbar>
-      </div>
-    </Editable>
-  );
-}
-
-function EditActionIcon() {
-  return (
-    <svg className="h-4 w-4" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M11.8 2.2a1.7 1.7 0 0 1 2.4 2.4l-7.5 7.5-3 .6.6-3z" />
-      <path d="M10.7 3.3l2 2" />
-    </svg>
-  );
-}
-
-function OpenLinkActionIcon() {
-  return (
-    <svg
-      className="h-4 w-4"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M7 3H3v10h10V9" />
-      <path d="M10 3h3v3" />
-      <path d="M6.5 9.5L13 3" />
-    </svg>
-  );
-}
-
-const toFiniteNumber = (value: unknown): number | null => {
-  if (typeof value === "number") {
-    return Number.isFinite(value) ? value : null;
-  }
-  if (typeof value === "string" && value.trim().length > 0) {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : null;
-  }
-  return null;
-};
-
-const formatFixed1 = (value: unknown): string | null => {
-  const parsed = toFiniteNumber(value);
-  return parsed === null ? null : parsed.toFixed(1);
-};
-
-const parseProgressNumber = (value: unknown): number | null => {
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "string" && value.trim().length > 0) {
-    const parsed = Number.parseInt(value, 10);
-    return Number.isFinite(parsed) ? parsed : null;
-  }
-  return null;
-};
-
-const isAbortError = (error: unknown): boolean =>
-  error instanceof Error && error.name === "AbortError";
-
-const isRetryableGalleryStatus = (status: number): boolean =>
-  status === 408 || status === 409 || status === 425 || status === 429 || status >= 500;
-
-const readGalleryErrorString = (value: unknown): string | undefined =>
-  typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
-
-const readGalleryErrorBoolean = (value: unknown): boolean | undefined =>
-  typeof value === "boolean" ? value : undefined;
-
-const parseGalleryAssetErrorPayload = async (
-  response: Response,
-): Promise<{
-  message: string;
-  code?: string;
-  reason?: string;
-  retryable: boolean;
-  detail?: Record<string, unknown>;
-}> => {
-  let payload: Record<string, unknown> | null = null;
-  try {
-    const parsed = (await response.clone().json()) as unknown;
-    payload = parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : null;
-  } catch {
-    payload = null;
-  }
-
-  const detail =
-    payload?.detail && typeof payload.detail === "object" && !Array.isArray(payload.detail)
-      ? (payload.detail as Record<string, unknown>)
-      : null;
-  const code = readGalleryErrorString(payload?.code) ?? readGalleryErrorString(detail?.code);
-  const reason = readGalleryErrorString(payload?.reason) ?? readGalleryErrorString(detail?.reason);
-  return {
-    message:
-      readGalleryErrorString(payload?.error) ??
-      readGalleryErrorString(payload?.detail) ??
-      readGalleryErrorString(detail?.message) ??
-      `${response.status} ${response.statusText || "Failed to load gallery assets"}`,
-    ...(code ? { code } : {}),
-    ...(reason ? { reason } : {}),
-    retryable:
-      readGalleryErrorBoolean(payload?.retryable) ??
-      readGalleryErrorBoolean(detail?.retryable) ??
-      isRetryableGalleryStatus(response.status),
-    ...(detail ? { detail } : {}),
-  };
-};
-
-const normalizeGallerySourceFailure = (
-  source: GalleryAssetSourceRequest,
-  reason: unknown,
-): GalleryAssetSourceFailure => {
-  if (reason instanceof GalleryAssetSourceError) {
-    return {
-      sourceId: source.id,
-      label: source.label,
-      message: reason.message,
-      status: reason.status,
-      retryable: reason.retryable,
-      ...(reason.code ? { code: reason.code } : {}),
-      ...(reason.reason ? { reason: reason.reason } : {}),
-      ...(reason.detail ? { detail: reason.detail } : {}),
-    };
-  }
-  return {
-    sourceId: source.id,
-    label: source.label,
-    message: reason instanceof Error ? reason.message : "Failed to load gallery assets",
-    status: 500,
-    retryable: false,
-  };
-};
-
-const formatGallerySourceFailure = (failure: GalleryAssetSourceFailure): string => {
-  const retryLabel = failure.retryable ? "retryable" : "not retryable";
-  const codeLabel = failure.code ? ` (${failure.code})` : "";
-  return `${failure.label}: ${failure.message}${codeLabel}, ${retryLabel}`;
-};
-
-const formatSnapshotAgeLabel = (timestampMs: number): string => {
-  const diffMs = Math.max(0, Date.now() - timestampMs);
-  const diffMinutes = Math.floor(diffMs / 60_000);
-  if (diffMinutes < 1) return "just now";
-  if (diffMinutes < 60) return `${diffMinutes}m ago`;
-  const diffHours = Math.floor(diffMinutes / 60);
-  if (diffHours < 24) return `${diffHours}h ago`;
-  const diffDays = Math.floor(diffHours / 24);
-  return `${diffDays}d ago`;
-};
-
-const isHttpUrlValue = (value: string): boolean => {
-  try {
-    const parsed = new URL(value);
-    return parsed.protocol === "http:" || parsed.protocol === "https:";
-  } catch {
-    return false;
-  }
-};
-
-const withSnapshotAgeSuffix = (warning: string | null, timestampMs: number | null): string | null => {
-  if (!warning) return null;
-  if (!timestampMs) return warning;
-  return `${warning} Last successful snapshot: ${formatSnapshotAgeLabel(timestampMs)}.`;
-};
-
-const inferBravoShowUrl = (showName: string | null | undefined): string | null => {
-  if (typeof showName !== "string") return null;
-  const slug = showName
-    .trim()
-    .toLowerCase()
-    .replace(/&/g, " and ")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/(^-|-$)/g, "");
-  if (!slug) return null;
-  return `https://www.bravotv.com/${slug}`;
-};
-
-const inferBravoPersonUrl = (personName: string | null | undefined): string | null => {
-  if (typeof personName !== "string") return null;
-  const slug = personName
-    .trim()
-    .toLowerCase()
-    .replace(/&/g, " and ")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/(^-|-$)/g, "");
-  if (!slug) return null;
-  return `https://www.bravotv.com/people/${slug}`;
-};
-
-const isBravoNetworkName = (value: unknown): boolean => {
-  const normalized = String(value ?? "")
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "");
-  if (!normalized) return false;
-  return normalized === "bravo" || normalized === "bravotv" || normalized.includes("bravo");
-};
-
-const normalizeBravoSocialKey = (value: string): string => {
-  const normalized = value.trim().toLowerCase();
-  if (!normalized) return "link";
-  if (normalized.includes("instagram")) return "instagram";
-  if (normalized === "x" || normalized.includes("twitter")) return "x";
-  if (normalized.includes("facebook")) return "facebook";
-  if (normalized.includes("tiktok")) return "tiktok";
-  if (normalized.includes("youtube")) return "youtube";
-  return normalized;
-};
-
-const formatBravoSocialLabel = (key: string): string => {
-  if (key === "x") return "X";
-  if (key === "instagram") return "Instagram";
-  if (key === "facebook") return "Facebook";
-  if (key === "tiktok") return "TikTok";
-  if (key === "youtube") return "YouTube";
-  return key.replace(/[_-]+/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
-};
-
-const extractBravoSocialHandle = (url: string): string | null => {
-  return extractSocialHandleFromUrl(url);
-};
-
-const BRAVO_IMPORT_IMAGE_KIND_OPTIONS: Array<{ value: BravoImportImageKind; label: string }> = [
-  { value: "poster", label: "Poster" },
-  { value: "backdrop", label: "Backdrop" },
-  { value: "logo", label: "Logo" },
-  { value: "episode_still", label: "Episode Still" },
-  { value: "cast", label: "Cast" },
-  { value: "promo", label: "Promo" },
-  { value: "intro", label: "Intro" },
-  { value: "reunion", label: "Reunion" },
-  { value: "other", label: "Other" },
-];
-
-const inferBravoImportImageKind = (
-  image: { url: string; alt?: string | null }
-): BravoImportImageKind => {
-  const haystack = `${image.alt ?? ""} ${image.url}`.toLowerCase();
-  if (haystack.includes("logo")) return "logo";
-  if (haystack.includes("key art") || haystack.includes("poster")) return "poster";
-  if (haystack.includes("backdrop") || haystack.includes("background")) return "backdrop";
-  if (haystack.includes("cast")) return "cast";
-  if (haystack.includes("still")) return "episode_still";
-  if (haystack.includes("intro")) return "intro";
-  if (haystack.includes("reunion")) return "reunion";
-  return "promo";
-};
-
-const humanizeStage = (value: string): string => {
-  const normalized = value.replace(/[_-]+/g, " ").trim();
-  if (!normalized) return "Working";
-  return normalized
-    .split(" ")
-    .map((token) =>
-      token.length > 0 ? token.charAt(0).toUpperCase() + token.slice(1) : token
-    )
-    .join(" ");
-};
-
-const resolveStageLabel = (
-  stageValue: unknown,
-  stageLabels: Record<string, string>
-): string | null => {
-  if (typeof stageValue !== "string") return null;
-  const normalized = stageValue.trim().toLowerCase();
-  if (!normalized) return null;
-  return stageLabels[normalized] ?? humanizeStage(normalized);
-};
-
-const getShowRefreshTargetLabel = (target: ShowRefreshTarget): string => {
-  return SHOW_REFRESH_TARGET_LABELS[target] ?? target;
-};
-
-const buildProgressMessage = (
-  stageLabel: string | null,
-  rawMessage: unknown,
-  fallback: string
-): string => {
-  const message = typeof rawMessage === "string" ? rawMessage.trim() : "";
-  if (!message) return stageLabel ? `Working on ${stageLabel}...` : fallback;
-  if (stageLabel) return `${stageLabel}: ${message}`;
-  return message;
-};
-
-const UUID_LIKE_RE =
-  /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
-
-const normalizeRefreshLogMessage = (value: string): string => {
-  return value
-    .replace(UUID_LIKE_RE, "person")
-    .replace(/\s+/g, " ")
-    .trim();
-};
-
-const extractRefreshLogSubJob = (entry: RefreshLogEntry): { subJob: string; details: string } => {
-  const normalizedMessage = normalizeRefreshLogMessage(entry.message);
-  const prefixMatch = normalizedMessage.match(/^([^:]{2,50}):\s+(.+)$/);
-  if (prefixMatch) {
-    return {
-      subJob: prefixMatch[1].trim(),
-      details: prefixMatch[2].trim(),
-    };
-  }
-  const fallbackSubJob = entry.category.trim() || "Update";
-  return {
-    subJob: fallbackSubJob,
-    details: normalizedMessage,
-  };
-};
-
-const isRefreshTopicDone = (entry: RefreshLogEntry | null): boolean => {
-  return isRefreshLogTerminalSuccess(entry);
-};
-
-const isRefreshTopicFailed = (entry: RefreshLogEntry | null): boolean => {
-  if (!entry) return false;
-  const message = entry.message.toLowerCase();
-  return message.includes("failed") || message.includes("error");
-};
-
-const getAssetDisplayUrl = (asset: SeasonAsset): string =>
-  firstImageUrlCandidate(getSeasonAssetCardUrlCandidates(asset)) ?? asset.hosted_url;
-
-const getFeaturedShowImageKind = (asset: SeasonAsset): "poster" | "backdrop" | null => {
-  const normalizedKind = String(asset.kind ?? "").trim().toLowerCase();
-  if (normalizedKind === "poster") return "poster";
-  if (normalizedKind === "backdrop") return "backdrop";
-  return null;
-};
-
-const buildAssetAutoCropPayload = (asset: SeasonAsset): Record<string, unknown> | null => {
-  const directCrop = parseThumbnailCrop(
-    {
-      x: asset.thumbnail_focus_x,
-      y: asset.thumbnail_focus_y,
-      zoom: asset.thumbnail_zoom,
-      mode: asset.thumbnail_crop_mode,
-    },
-    { clamp: true }
-  );
-  const metadataCrop = parseThumbnailCrop(
-    (asset.metadata as Record<string, unknown> | null)?.thumbnail_crop,
-    { clamp: true }
-  );
-  const crop = directCrop ?? metadataCrop;
-  if (!crop) return null;
-  return {
-    x: crop.x,
-    y: crop.y,
-    zoom: crop.zoom,
-    mode: crop.mode,
-  };
-};
-
-const buildAssetAutoCropPayloadWithFallback = (
-  asset: SeasonAsset
-): Record<string, unknown> =>
-  buildAssetAutoCropPayload(asset) ?? {
-    x: THUMBNAIL_DEFAULTS.x,
-    y: THUMBNAIL_DEFAULTS.y,
-    zoom: THUMBNAIL_DEFAULTS.zoom,
-    mode: "auto",
-    strategy: "resize_center_fallback_v1",
-  };
-
-const areStringArraysEqual = (a: string[], b: string[]): boolean => {
-  if (a === b) return true;
-  if (a.length !== b.length) return false;
-  for (let index = 0; index < a.length; index += 1) {
-    if (a[index] !== b[index]) return false;
-  }
-  return true;
-};
-
-const areNumberArraysEqual = (a: number[], b: number[]): boolean => {
-  if (a === b) return true;
-  if (a.length !== b.length) return false;
-  for (let index = 0; index < a.length; index += 1) {
-    if (a[index] !== b[index]) return false;
-  }
-  return true;
 };
 
 export default function TrrShowDetailPage() {
@@ -8259,42 +6710,6 @@ export default function TrrShowDetailPage() {
     [newsFacets.seasons]
   );
 
-  const settingsLinkSections = useMemo(
-    () =>
-      [
-        {
-          key: "social-links",
-          title: "Social Links",
-          description:
-            "Show-level handles routed from submitted Instagram, TikTok, X, YouTube, Threads, Facebook, and Reddit links.",
-        },
-        {
-          key: "show-pages",
-          title: "Show Pages",
-          description:
-            "Validated show-level pages. Fandom community roots stay internal and only page URLs render here.",
-        },
-        {
-          key: "season-pages",
-          title: "Season Pages",
-          description:
-            "Validated season pages only. Cast-announcement, social, and non-page links are excluded.",
-        },
-        {
-          key: "cast-member-pages",
-          title: "Cast Member Pages",
-          description: showIsBravo
-            ? "Cast-member profile links (BravoTV, Fandom, Wikipedia, IMDb, TMDb, and related pages)."
-            : "Cast-member profile links (Fandom, Wikipedia, IMDb, TMDb, and related pages). Bravo appears only when a Bravo profile link exists.",
-        },
-      ] as const,
-    [showIsBravo]
-  );
-  const socialLinksSection = settingsLinkSections[0];
-  const showPagesSection = settingsLinkSections[1];
-  const seasonPagesSection = settingsLinkSections[2];
-  const castMemberPagesSection = settingsLinkSections[3];
-
   const showSocialLinks = useMemo<ShowSocialLinkPill[]>(() => {
     const socialLinks = showLinks
       .filter((link) => {
@@ -11927,6 +10342,12 @@ export default function TrrShowDetailPage() {
           : null;
     return formatIsoAgeLabel(stageTransition);
   }, [linksRefreshLatestPayload, linksRefreshResult]);
+  const linksRefreshTimeoutMessage = useMemo(() => {
+    const timeout = linksRefreshLatestPayload?.timeout;
+    if (!timeout || typeof timeout !== "object") return null;
+    const detail = (timeout as Record<string, unknown>).detail;
+    return typeof detail === "string" ? detail : "Discovery reported a timeout condition.";
+  }, [linksRefreshLatestPayload]);
 
   if (checking) {
     return (
@@ -12224,12 +10645,6 @@ export default function TrrShowDetailPage() {
         </Link>
       </div>
     );
-  };
-
-  const healthBadgeClassName = (status: HealthStatus): string => {
-    if (status === "ready") return "border-emerald-200 bg-emerald-50 text-emerald-700";
-    if (status === "stale") return "border-amber-200 bg-amber-50 text-amber-700";
-    return "border-rose-200 bg-rose-50 text-rose-700";
   };
 
   const showHealthStatus: HealthStatus = refreshingTargets.details
@@ -12729,452 +11144,154 @@ export default function TrrShowDetailPage() {
 
           {/* ASSETS Tab */}
           {activeTab === "assets" && (
-            <ShowAssetsTab>
-            {assetsView === "images" && (
-              <div className="mb-6">
-                <BravotvImageRunPanel
-                  mode="show"
-                  targetId={showId}
-                  title={`BRAVOTV Get Images for ${show.name}`}
-                  season={selectedGallerySeason === "all" ? null : selectedGallerySeason}
-                  onCompleted={async () => {
-                    await loadGalleryAssets(selectedGallerySeason);
-                  }}
+            <ShowAssetsTab
+              assetsView={assetsView}
+              showId={showId}
+              showName={show.name}
+              featuredPosterImageId={show.primary_poster_image_id}
+              featuredBackdropImageId={show.primary_backdrop_image_id}
+              images={{
+                selectedSeason: selectedGallerySeason,
+                seasonOptions: visibleSeasons,
+                refreshCenterButtonLabel,
+                autoAdvanceMode: galleryAutoAdvanceMode,
+                hasActiveAdvancedFilters,
+                activeAdvancedFilterCount,
+                refreshingGetImages: refreshingTargets.get_images,
+                photosNotice: refreshTargetNotice.photos,
+                photosError: refreshTargetError.photos,
+                getImagesNotice: refreshTargetNotice.get_images,
+                getImagesError: refreshTargetError.get_images,
+                getImagesProgress: refreshTargetProgress.get_images,
+                batchJobsNotice,
+                batchJobsError,
+                batchJobsRunning,
+                batchJobsProgress,
+                truncatedWarning: galleryTruncatedWarning,
+                fallbackTelemetry: galleryFallbackTelemetry,
+                mirrorTelemetry: galleryMirrorTelemetry,
+                sourceFailures: gallerySourceFailures,
+                loading: galleryLoading,
+                filteredAssetCount: filteredGalleryAssets.length,
+                sections: gallerySectionAssets,
+                castPromoAssets: castPromoSectionAssets,
+                onRunCompleted: async () => {
+                  await loadGalleryAssets(selectedGallerySeason);
+                },
+                onSelectSeason: (value) =>
+                  setSelectedGallerySeason(value === "all" ? "all" : parseInt(value)),
+                onOpenRefreshCenter: () => setRefreshLogOpen(true),
+                onOpenFilters: () => setAdvancedFiltersOpen(true),
+                onToggleAutoAdvance: () =>
+                  setGalleryAutoAdvanceMode((previous) =>
+                    previous === "manual" ? "auto" : "manual",
+                  ),
+                onClearFilters: clearGalleryFilters,
+                onOpenBatchJobs: () => {
+                  setBatchJobsError(null);
+                  setBatchJobsNotice(null);
+                  setBatchJobsOpen(true);
+                },
+                onGetImages: () => {
+                  void refreshShow("get_images");
+                },
+                onOpenImport: () => {
+                  if (selectedGallerySeason !== "all") {
+                    const selectedSeason = visibleSeasons.find(
+                      (season) => season.season_number === selectedGallerySeason,
+                    );
+                    setScrapeDrawerContext({
+                      type: "season",
+                      showId,
+                      showName: show.name,
+                      seasonNumber: selectedGallerySeason,
+                      seasonId: selectedSeason?.id,
+                    });
+                  } else {
+                    setScrapeDrawerContext({
+                      type: "show",
+                      showId,
+                      showName: show.name,
+                      seasons: visibleSeasons.map((season) => ({
+                        seasonNumber: season.season_number,
+                        seasonId: season.id,
+                      })),
+                      defaultSeasonNumber: null,
+                    });
+                  }
+                  setScrapeDrawerOpen(true);
+                },
+                onLoadMoreBackdrops: () => increaseGallerySectionVisible("backdrops"),
+                onLoadMoreBanners: () => increaseGallerySectionVisible("banners"),
+                onLoadMorePosters: () => increaseGallerySectionVisible("posters"),
+                onLoadMoreProfilePictures: () =>
+                  increaseGallerySectionVisible("profile_pictures"),
+                onLoadMoreCastPromos: () => increaseGallerySectionVisible("cast_photos"),
+                onOpenAssetLightbox: openAssetLightbox,
+                formatSourceFailure: formatGallerySourceFailure,
+              }}
+              videos={{
+                error: bravoError,
+                loading: bravoLoading,
+                thumbnailSyncing: bravoVideoSyncing,
+                thumbnailSyncWarning: bravoVideoSyncWarning,
+                rows: bravoVideos,
+                getThumbnailUrl: resolveBravoVideoThumbnailUrl,
+                formatPublishedDate: formatBravoPublishedDate,
+              }}
+              branding={{
+                posterAssets: featuredPosterCandidates,
+                backdropAssets: featuredBackdropCandidates,
+                featuredPosterImageId: show.primary_poster_image_id,
+                featuredBackdropImageId: show.primary_backdrop_image_id,
+                logoAssets: brandLogoAssets,
+                featuredLogoAssetId: featuredShowLogoAssetId,
+                featuredLogoSavingAssetId,
+                featuredLogoVariant,
+                seasons,
+                cast,
+                getAssetDisplayUrl,
+                onSetFeaturedPoster: (showImageId) => {
+                  void setFeaturedShowImage("poster", showImageId);
+                },
+                onSetFeaturedBackdrop: (showImageId) => {
+                  void setFeaturedShowImage("backdrop", showImageId);
+                },
+                onSelectFeaturedLogoVariant: selectFeaturedLogoVariant,
+                onSetFeaturedLogo: (asset) => {
+                  void setFeaturedShowLogo(asset);
+                },
+              }}
+              renderProgress={(progress) => <RefreshProgressBar {...progress} />}
+              renderAssetImage={({ asset, alt, sizes, className, useResolvedUrl }) => (
+                <GalleryImage
+                  src={
+                    useResolvedUrl
+                      ? getResolvedGalleryAssetDisplayUrl(asset)
+                      : getAssetDisplayUrl(asset)
+                  }
+                  srcCandidates={
+                    useResolvedUrl
+                      ? getResolvedGalleryAssetCardUrlCandidates(asset)
+                      : getSeasonAssetCardUrlCandidates(asset)
+                  }
+                  diagnosticKey={`${asset.origin_table || "unknown"}:${asset.id}`}
+                  onFallbackEvent={trackGalleryFallbackEvent}
+                  alt={alt}
+                  sizes={sizes}
+                  className={className}
                 />
-              </div>
-            )}
-            <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm">
-              {assetsView === "images" ? (
-                <>
-                  {/* Season filter and Import button */}
-                  <div className="mb-6 flex items-center justify-between">
-                    <div className="flex items-center gap-4">
-                      <label className="text-sm font-medium text-zinc-700">
-                        Filter by season:
-                      </label>
-                      <select
-                        value={selectedGallerySeason}
-                        onChange={(e) =>
-                          setSelectedGallerySeason(
-                            e.target.value === "all" ? "all" : parseInt(e.target.value)
-                          )
-                        }
-                        className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm"
-                      >
-                        <option value="all">All Seasons</option>
-                        {visibleSeasons.map((s) => (
-                          <option key={s.id} value={s.season_number}>
-                            Season {s.season_number}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <button
-                        type="button"
-                        onClick={() => setRefreshLogOpen(true)}
-                        className="flex items-center gap-2 rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-50 disabled:opacity-50"
-                      >
-                        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M4 4v6h6M20 20v-6h-6M20 8a8 8 0 00-14-4M4 16a8 8 0 0014 4"
-                          />
-                        </svg>
-                        {refreshCenterButtonLabel}
-                      </button>
-
-                      <button type="button"
-                        onClick={() => setAdvancedFiltersOpen(true)}
-                        className="flex items-center gap-2 rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-50"
-                      >
-                        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 6h18M7 12h10M10 18h4" />
-                        </svg>
-                        Filters
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() =>
-                          setGalleryAutoAdvanceMode((prev) =>
-                            prev === "manual" ? "auto" : "manual"
-                          )
-                        }
-                        className="rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-50"
-                      >
-                        Auto-Load: {galleryAutoAdvanceMode === "auto" ? "On" : "Off"}
-                      </button>
-                      {hasActiveAdvancedFilters && (
-                        <button
-                          type="button"
-                          onClick={clearGalleryFilters}
-                          className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm font-semibold text-red-700 transition hover:bg-red-100"
-                        >
-                          Clear Filters ({activeAdvancedFilterCount})
-                        </button>
-                      )}
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setBatchJobsError(null);
-                          setBatchJobsNotice(null);
-                          setBatchJobsOpen(true);
-                        }}
-                        className="flex items-center gap-2 rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-50"
-                      >
-                        Batch Jobs
-                      </button>
-
-                      <button
-                        type="button"
-                        disabled={refreshingTargets.get_images}
-                        onClick={() => refreshShow("get_images")}
-                        className="flex items-center gap-2 rounded-lg border border-indigo-200 bg-indigo-50 px-4 py-2 text-sm font-semibold text-indigo-700 transition hover:bg-indigo-100 disabled:opacity-50"
-                      >
-                        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                        </svg>
-                        {refreshingTargets.get_images ? "Getting Images..." : "Get Images"}
-                      </button>
-
-                      <button type="button"
-                        onClick={() => {
-                          if (selectedGallerySeason !== "all") {
-                            const selectedSeason = visibleSeasons.find(
-                              (season) => season.season_number === selectedGallerySeason
-                            );
-                            setScrapeDrawerContext({
-                              type: "season",
-                              showId: showId,
-                              showName: show.name,
-                              seasonNumber: selectedGallerySeason,
-                              seasonId: selectedSeason?.id,
-                            });
-                          } else {
-                            setScrapeDrawerContext({
-                              type: "show",
-                              showId: showId,
-                              showName: show.name,
-                              seasons: visibleSeasons.map((season) => ({
-                                seasonNumber: season.season_number,
-                                seasonId: season.id,
-                              })),
-                              defaultSeasonNumber: null,
-                            });
-                          }
-                          setScrapeDrawerOpen(true);
-                        }}
-                        className="flex items-center gap-2 rounded-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-zinc-800"
-                      >
-                        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                        </svg>
-                        Import Images
-                      </button>
-                    </div>
-                  </div>
-
-                  {(refreshTargetNotice.photos || refreshTargetError.photos) && (
-                    <p
-                      className={`mb-4 text-sm ${
-                        refreshTargetError.photos ? "text-red-600" : "text-zinc-500"
-                      }`}
-                    >
-                      {refreshTargetError.photos || refreshTargetNotice.photos}
-                    </p>
-                  )}
-                  {(refreshTargetNotice.get_images || refreshTargetError.get_images || refreshingTargets.get_images) && (
-                    <div className="mb-4">
-                      {refreshTargetProgress.get_images && refreshingTargets.get_images && (
-                        <RefreshProgressBar
-                          show={true}
-                          stage={refreshTargetProgress.get_images.stage}
-                          message={refreshTargetProgress.get_images.message}
-                          current={refreshTargetProgress.get_images.current}
-                          total={refreshTargetProgress.get_images.total}
-                        />
-                      )}
-                      {(refreshTargetNotice.get_images || refreshTargetError.get_images) && (
-                        <p className={`text-sm ${refreshTargetError.get_images ? "text-red-600" : "text-indigo-600"}`}>
-                          {refreshTargetError.get_images || refreshTargetNotice.get_images}
-                        </p>
-                      )}
-                    </div>
-                  )}
-                  {(batchJobsNotice || batchJobsError) && (
-                    <p className={`mb-4 text-sm ${batchJobsError ? "text-red-600" : "text-zinc-500"}`}>
-                      {batchJobsError || batchJobsNotice}
-                    </p>
-                  )}
-                  <RefreshProgressBar
-                    show={batchJobsRunning}
-                    stage={batchJobsProgress?.stage}
-                    message={batchJobsProgress?.message}
-                    current={batchJobsProgress?.current}
-                    total={batchJobsProgress?.total}
-                  />
-                  {galleryTruncatedWarning && (
-                    <p className="mb-4 text-xs font-medium text-amber-700">{galleryTruncatedWarning}</p>
-                  )}
-                  <p className="mb-4 text-xs text-zinc-500">
-                    Fallback diagnostics: {galleryFallbackTelemetry.fallbackRecoveredCount} recovered,{" "}
-                    {galleryFallbackTelemetry.allCandidatesFailedCount} failed,{" "}
-                    {galleryFallbackTelemetry.totalImageAttempts} attempted. Mirrored URL usage:{" "}
-                    {galleryMirrorTelemetry.mirroredCount}/{galleryMirrorTelemetry.totalCount} (
-                    {Math.round(galleryMirrorTelemetry.mirroredRatio * 100)}%).
-                  </p>
-                  {process.env.NODE_ENV === "development" && gallerySourceFailures.length > 0 && (
-                    <details className="mb-4 rounded border border-zinc-200 bg-zinc-50 px-3 py-2 text-xs text-zinc-700">
-                      <summary className="cursor-pointer font-medium text-zinc-900">
-                        Gallery source debug
-                      </summary>
-                      <ul className="mt-2 space-y-1">
-                        {gallerySourceFailures.map((failure) => (
-                          <li key={failure.sourceId}>{formatGallerySourceFailure(failure)}</li>
-                        ))}
-                      </ul>
-                    </details>
-                  )}
-
-                  {galleryLoading ? (
-                    <div className="flex items-center justify-center py-12">
-                      <div className="h-8 w-8 animate-spin rounded-full border-4 border-zinc-300 border-t-blue-500" />
-                    </div>
-                  ) : filteredGalleryAssets.length === 0 ? (
-                    <p className="py-8 text-center text-zinc-500">
-                      No images found for this selection.
-                    </p>
-                  ) : (
-                    <div className="space-y-8">
-                      <ShowAssetsImageSections
-                        backdrops={gallerySectionAssets.backdrops}
-                        banners={gallerySectionAssets.banners}
-                        posters={gallerySectionAssets.posters}
-                        featuredBackdropImageId={show.primary_backdrop_image_id}
-                        featuredPosterImageId={show.primary_poster_image_id}
-                        autoAdvanceMode={galleryAutoAdvanceMode}
-                        hasMoreBackdrops={Boolean(gallerySectionAssets.hasMoreBySection.backdrops)}
-                        hasMoreBanners={Boolean(gallerySectionAssets.hasMoreBySection.banners)}
-                        hasMorePosters={Boolean(gallerySectionAssets.hasMoreBySection.posters)}
-                        onLoadMoreBackdrops={() => increaseGallerySectionVisible("backdrops")}
-                        onLoadMoreBanners={() => increaseGallerySectionVisible("banners")}
-                        onLoadMorePosters={() => increaseGallerySectionVisible("posters")}
-                        onOpenAssetLightbox={openAssetLightbox}
-                        renderGalleryImage={({ asset, alt, sizes, className }) => (
-                          <GalleryImage
-                            src={getAssetDisplayUrl(asset)}
-                            srcCandidates={getSeasonAssetCardUrlCandidates(asset)}
-                            diagnosticKey={`${asset.origin_table || "unknown"}:${asset.id}`}
-                            onFallbackEvent={trackGalleryFallbackEvent}
-                            alt={alt}
-                            sizes={sizes}
-                            className={className}
-                          />
-                        )}
-                      />
-
-                      {/* Profile Pictures */}
-                      {gallerySectionAssets.profile_pictures.length > 0 && (
-                        <section>
-                          <h4 className="mb-3 text-sm font-semibold text-zinc-900">
-                            Profile Pictures
-                          </h4>
-                          <div className="grid grid-cols-5 gap-4">
-                            {gallerySectionAssets.profile_pictures.map((asset, i, arr) => (
-                                <button type="button"
-                                  key={asset.id}
-                                  onClick={(e) =>
-                                    openAssetLightbox(asset, i, arr, e.currentTarget)
-                                  }
-                                  className="relative aspect-[2/3] overflow-hidden rounded-lg bg-zinc-200 cursor-zoom-in focus:outline-none focus:ring-2 focus:ring-blue-500"
-                                >
-                                  <GalleryImage
-                                    src={getAssetDisplayUrl(asset)}
-                                    srcCandidates={getSeasonAssetCardUrlCandidates(asset)}
-                                    diagnosticKey={`${asset.origin_table || "unknown"}:${asset.id}`}
-                                    onFallbackEvent={trackGalleryFallbackEvent}
-                                    alt={asset.caption || "Profile picture"}
-                                    sizes="180px"
-                                  />
-                                  {asset.person_name && (
-                                    <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent p-2">
-                                      <p className="truncate text-xs text-white">
-                                        {asset.person_name}
-                                      </p>
-                                    </div>
-                                  )}
-                                </button>
-                              ))}
-                          </div>
-                          {gallerySectionAssets.hasMoreBySection.profile_pictures && (
-                            <div className="mt-3 flex justify-center">
-                              <button
-                                type="button"
-                                onClick={() => increaseGallerySectionVisible("profile_pictures")}
-                                className="rounded-lg border border-zinc-300 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-50"
-                              >
-                                Load More Profile Pictures
-                              </button>
-                            </div>
-                          )}
-                        </section>
-                      )}
-
-                      {/* Cast Photos (official season announcement only) */}
-                      {castPromoSectionAssets.length > 0 && (
-                        <section>
-                          <h4 className="mb-3 text-sm font-semibold text-zinc-900">
-                            Cast Promos
-                          </h4>
-                          <div className="grid grid-cols-5 gap-4">
-                            {castPromoSectionAssets.map((asset, i, arr) => (
-                                <button type="button"
-                                  key={asset.id}
-                                  onClick={(e) =>
-                                    openAssetLightbox(asset, i, arr, e.currentTarget)
-                                  }
-                                  className="relative aspect-[2/3] overflow-hidden rounded-lg bg-zinc-200 cursor-zoom-in focus:outline-none focus:ring-2 focus:ring-blue-500"
-                                >
-                                  <GalleryImage
-                                    src={getResolvedGalleryAssetDisplayUrl(asset)}
-                                    srcCandidates={getResolvedGalleryAssetCardUrlCandidates(asset)}
-                                    diagnosticKey={`${asset.origin_table || "unknown"}:${asset.id}`}
-                                    onFallbackEvent={trackGalleryFallbackEvent}
-                                    alt={asset.caption || "Cast photo"}
-                                    sizes="180px"
-                                  />
-                                  {asset.person_name && (
-                                    <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent p-2">
-                                      <p className="truncate text-xs text-white">
-                                        {asset.person_name}
-                                      </p>
-                                    </div>
-                                  )}
-                                </button>
-                              ))}
-                          </div>
-                          {gallerySectionAssets.hasMoreBySection.cast_photos && (
-                            <div className="mt-3 flex justify-center">
-                              <button
-                                type="button"
-                                onClick={() => increaseGallerySectionVisible("cast_photos")}
-                                className="rounded-lg border border-zinc-300 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-50"
-                              >
-                                Load More Cast Promos
-                              </button>
-                            </div>
-                          )}
-                        </section>
-                      )}
-
-                    </div>
-                  )}
-                </>
-              ) : assetsView === "videos" ? (
-                <div className="space-y-4">
-                  {(bravoError || bravoLoading) && (
-                    <p className={`text-sm ${bravoError ? "text-red-600" : "text-zinc-500"}`}>
-                      {bravoError || "Loading Bravo videos..."}
-                    </p>
-                  )}
-                  {bravoVideoSyncing && (
-                    <p className="text-sm text-zinc-500">Syncing high-quality video thumbnails...</p>
-                  )}
-                  {bravoVideoSyncWarning && !bravoError && (
-                    <p className="text-sm text-amber-700">{bravoVideoSyncWarning}</p>
-                  )}
-                  {!bravoLoading && bravoVideos.length === 0 && !bravoError && (
-                    <p className="text-sm text-zinc-500">No persisted Bravo videos found for this show.</p>
-                  )}
-                  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                    {bravoVideos.map((video) => {
-                      const thumbnailUrl = resolveBravoVideoThumbnailUrl(video);
-                      return (
-                      <article key={`${video.clip_url}-${video.published_at ?? "unknown"}`} className="rounded-xl border border-zinc-200 bg-zinc-50 p-3">
-                        <a
-                          href={video.clip_url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="group block"
-                        >
-                          <div className="relative mb-3 aspect-video overflow-hidden rounded-lg bg-zinc-200">
-                            {thumbnailUrl ? (
-                              <GalleryImage
-                                src={thumbnailUrl}
-                                alt={video.title || "Bravo video"}
-                                sizes="400px"
-                                className="object-cover transition group-hover:scale-105"
-                              />
-                            ) : (
-                              <div className="flex h-full items-center justify-center text-zinc-400">No image</div>
-                            )}
-                          </div>
-                          <h4 className="text-sm font-semibold text-zinc-900 group-hover:text-blue-700">
-                            {video.title || "Untitled video"}
-                          </h4>
-                        </a>
-                        <div className="mt-1 flex flex-wrap gap-2 text-xs text-zinc-500">
-                          {video.runtime && <span>{video.runtime}</span>}
-                          {typeof video.season_number === "number" && <span>Season {video.season_number}</span>}
-                          {video.kicker && <span>{video.kicker}</span>}
-                          {formatBravoPublishedDate(video.published_at) && (
-                            <span>Posted {formatBravoPublishedDate(video.published_at)}</span>
-                          )}
-                        </div>
-                      </article>
-                      );
-                    })}
-                  </div>
-                </div>
-              ) : (
-                <div className="space-y-6">
-                  <section>
-                    <h4 className="mb-3 text-sm font-semibold text-zinc-900">Featured Images</h4>
-                    <ShowFeaturedMediaSelectors
-                      posterAssets={featuredPosterCandidates}
-                      backdropAssets={featuredBackdropCandidates}
-                      featuredPosterImageId={show.primary_poster_image_id}
-                      featuredBackdropImageId={show.primary_backdrop_image_id}
-                      getAssetDisplayUrl={getAssetDisplayUrl}
-                      onSetFeaturedPoster={(showImageId) => {
-                        void setFeaturedShowImage("poster", showImageId);
-                      }}
-                      onSetFeaturedBackdrop={(showImageId) => {
-                        void setFeaturedShowImage("backdrop", showImageId);
-                      }}
-                    />
-                  </section>
-
-                  <section>
-                    <h4 className="mb-3 text-sm font-semibold text-zinc-900">Logos</h4>
-                    <ShowBrandLogosSection
-                      logoAssets={brandLogoAssets}
-                      featuredLogoAssetId={featuredShowLogoAssetId}
-                      featuredLogoSavingAssetId={featuredLogoSavingAssetId}
-                      selectedFeaturedLogoVariant={featuredLogoVariant}
-                      getAssetDisplayUrl={getAssetDisplayUrl}
-                      onSelectFeaturedLogoVariant={selectFeaturedLogoVariant}
-                      onSetFeaturedLogo={(asset) => {
-                        void setFeaturedShowLogo(asset);
-                      }}
-                    />
-                  </section>
-
-                  <ShowBrandEditor
-                    trrShowId={showId}
-                    trrShowName={show.name}
-                    trrSeasons={seasons}
-                    trrCast={cast}
-                    showDefaultMediaSection={false}
-                  />
-                </div>
               )}
-            </div>
-            </ShowAssetsTab>
+              renderVideoThumbnail={({ src, alt, sizes, className }) => (
+                <GalleryImage
+                  src={src}
+                  alt={alt}
+                  sizes={sizes}
+                  className={className}
+                />
+              )}
+            />
           )}
-
           {/* NEWS Tab */}
           {activeTab === "news" && (
             <ShowNewsTab
@@ -13224,618 +11341,147 @@ export default function TrrShowDetailPage() {
 
           {/* Cast Tab */}
           {activeTab === "cast" && (
-            <ShowCastTab>
-            <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm">
-              <div className="mb-6 flex items-center justify-between">
-                <div>
-                  <h3 className="text-xl font-bold text-zinc-900">Credits</h3>
-                </div>
-                <div className="flex items-center gap-3">
-                  <span className="rounded-full bg-zinc-100 px-3 py-1 text-xs font-semibold text-zinc-700">
-                    {renderedCastCount}/{matchedCastCount}/{totalCastCount} cast ·{" "}
-                    {renderedCrewCount}/{matchedCrewCount}/{totalCrewCount} crew ·{" "}
-                    {renderedVisibleCount}/{matchedVisibleCount}/{totalVisibleCount} visible
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => void enrichCastMedia()}
-                    disabled={isCastRefreshBusy}
-                    title={isCastRefreshBusy ? "Cast sync in progress" : undefined}
-                    className="rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs font-semibold text-zinc-700 transition hover:bg-zinc-50 disabled:opacity-50"
-                  >
-                    {castMediaEnriching ? "Enriching..." : "Enrich Media"}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => void enrichMissingCastPhotos()}
-                    disabled={isCastRefreshBusy || castPhotoEnriching || castLoading || missingCastPhotoCount <= 0}
-                    title={isCastRefreshBusy ? "Cast sync in progress" : undefined}
-                    className="rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs font-semibold text-zinc-700 transition hover:bg-zinc-50 disabled:opacity-50"
-                  >
-                    {castPhotoEnriching
-                      ? "Enriching..."
-                      : `Enrich Missing Cast Photos${missingCastPhotoCount > 0 ? ` (${missingCastPhotoCount})` : ""}`}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => refreshShowCast()}
-                    disabled={isCastRefreshBusy}
-                    title={isCastRefreshBusy ? "Cast sync in progress" : undefined}
-                    className="rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs font-semibold text-zinc-700 transition hover:bg-zinc-50 disabled:opacity-50"
-                  >
-                    {castRefreshButtonLabel}
-                  </button>
-                  {(castRefreshPipelineRunning ||
-                    castMediaEnriching ||
-                    hasPersonRefreshInFlight ||
-                    hasReconnectableCreditsRun) && (
-                    <button
-                      type="button"
-                      onClick={() => void cancelShowCastWorkflow()}
-                      disabled={castRefreshCanceling}
-                      className="rounded-full border border-rose-200 bg-white px-3 py-1 text-xs font-semibold text-rose-700 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
-                    >
-                      {castRefreshCancelButtonLabel}
-                    </button>
-                  )}
-                </div>
-              </div>
-                  {(refreshTargetNotice.cast_credits ||
-                refreshTargetError.cast_credits) && (
-                <p
-                  className={`mb-4 text-sm ${
-                    refreshTargetError.cast_credits ? "text-red-600" : "text-zinc-500"
-                  }`}
-                >
-                  {refreshTargetError.cast_credits ||
-                    refreshTargetNotice.cast_credits}
-                </p>
-              )}
-              {(castRefreshPipelineRunning || castRefreshPhaseStates.length > 0) && (
-                <div className="mb-4 rounded-xl border border-zinc-200 bg-zinc-50 p-4">
-                  <div className="mb-3 flex items-center justify-between gap-3">
-                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                      Credits Refresh Pipeline
-                    </p>
-                    {castRefreshPipelineRunning && (
-                      <p className="text-[11px] text-zinc-500">Fail-fast timeout policy enabled</p>
-                    )}
-                  </div>
-                  <div className="space-y-2">
-                    {castRefreshPhasePanelStates.map((phase, index) => (
-                      <div
-                        key={`cast-refresh-phase-${phase.id}`}
-                        className="flex items-center justify-between gap-3 rounded-lg border border-zinc-200 bg-white px-3 py-2"
-                      >
-                        <div className="min-w-0">
-                          <p className="text-sm font-semibold text-zinc-800">
-                            {index + 1}. {CAST_REFRESH_PHASE_STAGES[phase.id] ?? phase.label}
-                          </p>
-                          {phase.status !== "pending" && phase.progress.message && (
-                              <p className="truncate text-xs text-zinc-500">{phase.progress.message}</p>
-                            )}
-                        </div>
-                        <span
-                          className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${castRefreshPhaseStatusChipClassName(
-                            phase.status
-                          )}`}
-                        >
-                          {castRefreshPhaseStatusLabel(phase.status)}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-              {(refreshNotice || refreshError) && (
-                <p className={`mb-4 text-sm ${refreshError ? "text-red-600" : "text-zinc-500"}`}>
-                  {refreshError || refreshNotice}
-                </p>
-              )}
-              {(castPhotoEnrichNotice || castPhotoEnrichError) && (
-                <p className={`mb-4 text-sm ${castPhotoEnrichError ? "text-red-600" : "text-zinc-500"}`}>
-                  {castPhotoEnrichError || castPhotoEnrichNotice}
-                </p>
-              )}
-              {(castMediaEnrichNotice || castMediaEnrichError) && (
-                <p className={`mb-4 text-sm ${castMediaEnrichError ? "text-red-600" : "text-zinc-500"}`}>
-                  {castMediaEnrichError || castMediaEnrichNotice}
-                </p>
-              )}
-              {castLoadWarning && (
-                <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
-                  <span>{castLoadWarning}</span>
-                  <button
-                    type="button"
-                    onClick={() => void fetchCast({ throwOnError: false })}
-                    className="rounded-full border border-amber-400 bg-white px-3 py-1 text-xs font-semibold text-amber-900 transition hover:bg-amber-100"
-                  >
-                    Retry Cast
-                  </button>
-                </div>
-              )}
-              {castLoadError && (
-                <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
-                  <span>{castLoadError}</span>
-                  <button
-                    type="button"
-                    onClick={() => void fetchCast({ throwOnError: false })}
-                    className="rounded-full border border-rose-300 bg-white px-3 py-1 text-xs font-semibold text-rose-700 transition hover:bg-rose-100"
-                  >
-                    Retry Cast
-                  </button>
-                </div>
-              )}
-              {showCreditsError && (
-                <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
-                  <span>{showCreditsError}</span>
-                  <button
-                    type="button"
-                    onClick={() => void fetchShowCredits()}
-                    className="rounded-full border border-rose-300 bg-white px-3 py-1 text-xs font-semibold text-rose-700 transition hover:bg-rose-100"
-                  >
-                    Retry Crew
-                  </button>
-                </div>
-              )}
-              {showCreditsLoading && !showCreditsLoadedOnce && (
-                <p className="mb-4 text-sm text-zinc-500">Loading crew credits...</p>
-              )}
-              {showCreditsSourceUrl && (
-                <p className="mb-4 text-xs text-zinc-500">
-                  Crew source:{" "}
-                  <a
-                    href={showCreditsSourceUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="font-semibold text-zinc-700 underline decoration-zinc-300 underline-offset-2"
-                  >
-                    IMDb Full Credits
-                  </a>
-                </p>
-              )}
-              {castRoleMembersWarningWithSnapshotAge && (
-                <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
-                  <span>{castRoleMembersWarningWithSnapshotAge}</span>
-                  <button
-                    type="button"
-                    onClick={() => void fetchCastRoleMembers({ force: true })}
-                    className="rounded-full border border-amber-400 bg-white px-3 py-1 text-xs font-semibold text-amber-900 transition hover:bg-amber-100"
-                  >
-                    Retry
-                  </button>
-                </div>
-              )}
-              {rolesWarningWithSnapshotAge && (
-                <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
-                  <span>{rolesWarningWithSnapshotAge}</span>
-                  <button
-                    type="button"
-                    onClick={() => void fetchShowRoles({ force: true })}
-                    className="rounded-full border border-amber-400 bg-white px-3 py-1 text-xs font-semibold text-amber-900 transition hover:bg-amber-100"
-                  >
-                    Retry Roles
-                  </button>
-                </div>
-              )}
-              {showCastIntelligenceUnavailable && (
-                <div className="mb-4 rounded-lg border border-amber-300 bg-amber-50 px-3 py-3 text-sm text-amber-900">
-                  <p className="font-semibold">
-                    Cast intelligence unavailable; showing base cast snapshot.
-                  </p>
-                  {(castRoleMembersError || rolesError) && (
-                    <p className="mt-1 text-xs">
-                      {[castRoleMembersError, rolesError].filter(Boolean).join(" · ")}
-                    </p>
-                  )}
-                  <div className="mt-2 flex flex-wrap items-center gap-2">
-                    <button
-                      type="button"
-                      onClick={() => void fetchCastRoleMembers({ force: true })}
-                      className="rounded-full border border-amber-400 bg-white px-3 py-1 text-xs font-semibold text-amber-900 transition hover:bg-amber-100"
-                    >
-                      Retry Cast Intelligence
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => void fetchShowRoles({ force: true })}
-                      className="rounded-full border border-amber-400 bg-white px-3 py-1 text-xs font-semibold text-amber-900 transition hover:bg-amber-100"
-                    >
-                      Retry Roles
-                    </button>
-                  </div>
-                </div>
-              )}
-              {castRoleEditorDeepLinkWarning && (
-                <div className="mb-4 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
-                  {castRoleEditorDeepLinkWarning}
-                </div>
-              )}
-              {castSource === "show_fallback" && castEligibilityWarning && (
-                <div className="mb-4 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
-                  {castEligibilityWarning}
-                </div>
-              )}
-              {castRunFailedMembers.length > 0 && (
-                <div className="mb-4 rounded-xl border border-amber-200 bg-amber-50 p-3">
-                  <div className="flex flex-wrap items-center justify-between gap-3">
-                    <p className="text-sm font-semibold text-amber-900">
-                      Failed Members ({castRunFailedMembers.length})
-                    </p>
-                    <div className="flex items-center gap-2">
-                      <button
-                        type="button"
-                        onClick={() => setCastFailedMembersOpen((prev) => !prev)}
-                        className="rounded-full border border-amber-300 bg-white px-3 py-1 text-xs font-semibold text-amber-900 hover:bg-amber-100"
-                      >
-                        {castFailedMembersOpen ? "Hide" : "Show"}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => void retryFailedCastMediaEnrich()}
-                        disabled={isCastRefreshBusy}
-                        className="rounded-full border border-amber-300 bg-white px-3 py-1 text-xs font-semibold text-amber-900 hover:bg-amber-100 disabled:opacity-50"
-                      >
-                        Retry failed only
-                      </button>
-                    </div>
-                  </div>
-                  {castFailedMembersOpen && (
-                    <ul className="mt-3 space-y-2 text-xs text-amber-900">
-                      {castRunFailedMembers.map((member) => (
-                        <li
-                          key={`${member.personId}-${member.name}-${member.reason}`}
-                          className="rounded-md border border-amber-200 bg-white px-2 py-1"
-                        >
-                          <span className="font-semibold">{member.name}</span>: {member.reason}
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </div>
-              )}
-
-              <CastMatrixSyncPanel
-                loading={castMatrixSyncLoading}
-                error={castMatrixSyncError}
-                result={castMatrixSyncResult}
-                scopeLabel={castMatrixSyncScopeLabel}
-                onSync={() => void syncCastMatrixRoles()}
-              />
-
-              <div className="mb-4 rounded-xl border border-zinc-200 bg-zinc-50 p-4">
-                <div className="grid gap-3 md:grid-cols-5">
-                  <label className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500 md:col-span-2">
-                    Search Name
-                    <input
-                      value={castSearchQuery}
-                      onChange={(event) => setCastSearchQuery(event.target.value)}
-                      placeholder="Search cast or crew..."
-                      className="mt-1 block w-full rounded-lg border border-zinc-300 bg-white px-2 py-2 text-sm font-medium normal-case tracking-normal text-zinc-700"
-                    />
-                  </label>
-                  <label className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                    Sort By
-                    <select
-                      value={castSortBy}
-                      onChange={(event) =>
-                        setCastSortBy(event.target.value as "episodes" | "season" | "name")
-                      }
-                      className="mt-1 block w-full rounded-lg border border-zinc-300 bg-white px-2 py-2 text-sm font-medium normal-case tracking-normal text-zinc-700"
-                    >
-                      <option value="episodes">Episodes</option>
-                      <option value="season">Season Recency</option>
-                      <option value="name">Name</option>
-                    </select>
-                  </label>
-                  <label className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                    Order
-                    <select
-                      value={castSortOrder}
-                      onChange={(event) => setCastSortOrder(event.target.value as "desc" | "asc")}
-                      className="mt-1 block w-full rounded-lg border border-zinc-300 bg-white px-2 py-2 text-sm font-medium normal-case tracking-normal text-zinc-700"
-                    >
-                      <option value="desc">Desc</option>
-                      <option value="asc">Asc</option>
-                    </select>
-                  </label>
-                  <label className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                    Has Image
-                    <select
-                      value={castHasImageFilter}
-                      onChange={(event) =>
-                        setCastHasImageFilter(event.target.value as "all" | "yes" | "no")
-                      }
-                      className="mt-1 block w-full rounded-lg border border-zinc-300 bg-white px-2 py-2 text-sm font-medium normal-case tracking-normal text-zinc-700"
-                    >
-                      <option value="all">All</option>
-                      <option value="yes">With Image</option>
-                      <option value="no">Without Image</option>
-                    </select>
-                  </label>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setCastSeasonFilters([]);
-                      setCastRoleAndCreditFilters([]);
-                      setCastHasImageFilter("all");
-                      setCastExactEpisodeCount(null);
-                      setCastMinEpisodeCount(null);
-                      setCastMaxEpisodeCount(null);
-                      setCastSortBy("episodes");
-                      setCastSortOrder("desc");
-                      setCastSearchQuery("");
-                    }}
-                    className="self-end rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm font-semibold text-zinc-700 hover:bg-zinc-100"
-                  >
-                    Clear Filters
-                  </button>
-                </div>
-                <div className="mt-3 grid gap-3 md:grid-cols-3">
-                  <label className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                    Episode Exact
-                    <input
-                      type="number"
-                      min={1}
-                      inputMode="numeric"
-                      value={castExactEpisodeCount ?? ""}
-                      onChange={(event) =>
-                        setCastExactEpisodeCount(parsePositiveIntegerInputValue(event.target.value))
-                      }
-                      placeholder="Any"
-                      className="mt-1 block w-full rounded-lg border border-zinc-300 bg-white px-2 py-2 text-sm font-medium normal-case tracking-normal text-zinc-700"
-                    />
-                  </label>
-                  <label className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                    Episode Min
-                    <input
-                      type="number"
-                      min={1}
-                      inputMode="numeric"
-                      value={castMinEpisodeCount ?? ""}
-                      onChange={(event) =>
-                        setCastMinEpisodeCount(parsePositiveIntegerInputValue(event.target.value))
-                      }
-                      placeholder="Any"
-                      className="mt-1 block w-full rounded-lg border border-zinc-300 bg-white px-2 py-2 text-sm font-medium normal-case tracking-normal text-zinc-700"
-                    />
-                  </label>
-                  <label className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                    Episode Max
-                    <input
-                      type="number"
-                      min={1}
-                      inputMode="numeric"
-                      value={castMaxEpisodeCount ?? ""}
-                      onChange={(event) =>
-                        setCastMaxEpisodeCount(parsePositiveIntegerInputValue(event.target.value))
-                      }
-                      placeholder="Any"
-                      className="mt-1 block w-full rounded-lg border border-zinc-300 bg-white px-2 py-2 text-sm font-medium normal-case tracking-normal text-zinc-700"
-                    />
-                  </label>
-                </div>
-                <div className="mt-3 space-y-2">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                      Seasons
-                    </span>
-                    {availableCastSeasons.length === 0 ? (
-                      <span className="text-xs text-zinc-500">No season recency data yet.</span>
-                    ) : (
-                      availableCastSeasons.map((seasonNumber) => {
-                        const active = castSeasonFilters.includes(seasonNumber);
-                        return (
-                          <button
-                            key={`season-filter-${seasonNumber}`}
-                            type="button"
-                            aria-pressed={active}
-                            onClick={() =>
-                              setCastSeasonFilters((prev) =>
-                                prev.includes(seasonNumber)
-                                  ? prev.filter((value) => value !== seasonNumber)
-                                  : [...prev, seasonNumber]
-                              )
-                            }
-                            className={`rounded-full border px-2 py-1 text-xs font-semibold ${
-                              active
-                                ? "border-zinc-900 bg-zinc-900 text-white"
-                                : "border-zinc-200 bg-white text-zinc-600"
-                            }`}
-                          >
-                            S{seasonNumber}
-                          </button>
-                        );
-                      })
-                    )}
-                  </div>
-                  <p className="text-[11px] text-zinc-500">
-                    Season filters use season-scoped role assignments plus global season-0 roles.{" "}
-                    {castEpisodeScopeLabel}
-                  </p>
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                      Roles & Credit
-                    </span>
-                    {shouldShowRoleCreditEmptyState ? (
-                      <span className="text-xs text-zinc-500">No role or credit filters available.</span>
-                    ) : !castUiTerminalReady ? (
-                      <span className="text-xs text-zinc-500">Loading role and credit filters...</span>
-                    ) : (
-                      availableCastRoleAndCreditFilters.map((option) => {
-                        const active = castRoleAndCreditFilters.includes(option.key);
-                        return (
-                          <button
-                            key={`role-credit-filter-${option.key}`}
-                            type="button"
-                            aria-pressed={active}
-                            onClick={() =>
-                              setCastRoleAndCreditFilters((prev) =>
-                                active ? prev.filter((value) => value !== option.key) : [...prev, option.key]
-                              )
-                            }
-                            className={`rounded-full border px-2 py-1 text-xs font-semibold ${
-                              active
-                                ? "border-zinc-900 bg-zinc-900 text-white"
-                                : "border-zinc-200 bg-white text-zinc-600"
-                            }`}
-                          >
-                            {option.label}
-                          </button>
-                        );
-                      })
-                    )}
-                  </div>
-                </div>
-              </div>
-              {castRoleMembersLoading && (
-                <p className="mb-4 text-sm text-zinc-500" aria-live="polite">
-                  Refreshing cast intelligence...
-                </p>
-              )}
-              {castLoading && !castLoadedOnce && (
-                <p className="mb-4 text-sm text-zinc-500" aria-live="polite">
-                  Loading cast members...
-                </p>
-              )}
-              {castLoading && castLoadedOnce && cast.length === 0 && (
-                <p className="mb-4 text-sm text-zinc-500" aria-live="polite">
-                  Cast list unavailable; retrying cast roster...
-                </p>
-              )}
-              {castRenderProgressLabel && (
-                <p className="mb-3 text-xs text-zinc-500" role="status" aria-live="polite">
-                  {castRenderProgressLabel}
-                </p>
-              )}
-              <div className="space-y-8">
-                <section>
-                  <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
-                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-zinc-500">
-                      Cast
-                    </p>
-                    <ShowCreditsCastViewControls
-                      viewMode={castViewMode}
-                      galleryColumns={castGalleryColumns}
-                      onViewModeChange={setCastViewMode}
-                      onGalleryColumnsChange={setCastGalleryColumns}
-                    />
-                  </div>
-                  {castGalleryMembers.length === 0 ? (
-                    !castRosterReady ? (
-                      <p className="text-sm text-zinc-500">Loading cast roster...</p>
-                    ) : cast.length === 0 && archiveFootageCast.length === 0 ? (
-                      <p className="text-sm text-zinc-500">No cast members found for this show.</p>
-                    ) : (
-                      <p className="text-sm text-zinc-500">No cast members match the selected filters.</p>
-                    )
-                  ) : (
-                    <ShowCreditsCastMembers
-                      members={visibleCastMembers}
-                      viewMode={castViewMode}
-                      galleryColumns={castGalleryColumns}
-                      renderMember={renderShowCreditsCastMember}
-                    />
-                  )}
-                </section>
-
-                {crewDisplaySections.length > 0 && (
-                  <section>
-                    <p className="mb-3 text-xs font-semibold uppercase tracking-[0.3em] text-zinc-500">
-                      Crew
-                    </p>
-                    <ShowCreditsCrewSections
-                      sections={visibleCrewSections}
-                      renderPersonName={(row) => (
-                        <Link
-                          href={buildPersonAdminUrl({
-                            showSlug: showSlugForRouting,
-                            personSlug: buildPersonRouteSlug({
-                              personName: row.personName,
-                              personId: row.personId,
-                            }),
-                            tab: "overview",
-                          }) as Route}
-                          className="hover:underline"
-                        >
-                          {row.personName || "Unknown"}
-                        </Link>
-                      )}
-                    />
-                  </section>
-                )}
-
-                {archiveFootageCast.length > 0 && (
-                  <section>
-                    <p className="mb-3 text-xs font-semibold uppercase tracking-[0.3em] text-zinc-500">
-                      Archive Footage
-                    </p>
-                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-                      {archiveFootageCast.map((member) => {
-                        const thumbnailUrl = member.cover_photo_url || member.photo_url;
-                        const archiveLabel =
-                          typeof member.archive_episode_count === "number"
-                            ? `${member.archive_episode_count} archive footage episodes`
-                            : "Archive footage appearance";
-
-                        return (
-                          <Link
-                            key={`archive-${member.id}`}
-                            href={buildPersonAdminUrl({
-                              showSlug: showSlugForRouting,
-                              personSlug: buildPersonRouteSlug({
-                                personName: member.full_name || member.cast_member_name || null,
-                                personId: member.person_id,
-                              }),
-                              tab: "overview",
-                            }) as Route}
-                            className="rounded-xl border border-amber-200 bg-amber-50/40 p-4 transition hover:border-amber-300 hover:bg-amber-100/40"
-                          >
-                            <div className="relative mb-3 aspect-[4/5] overflow-hidden rounded-lg bg-zinc-200">
-                              {thumbnailUrl ? (
-                                <CastPhoto
-                                  src={thumbnailUrl}
-                                  alt={member.full_name || member.cast_member_name || "Cast member"}
-                                  thumbnail_focus_x={member.thumbnail_focus_x}
-                                  thumbnail_focus_y={member.thumbnail_focus_y}
-                                  thumbnail_zoom={member.thumbnail_zoom}
-                                  thumbnail_crop_mode={member.thumbnail_crop_mode}
-                                />
-                              ) : (
-                                <div className="flex h-full items-center justify-center text-zinc-400">
-                                  <svg width="48" height="48" viewBox="0 0 24 24" fill="none">
-                                    <circle cx="12" cy="8" r="4" stroke="currentColor" strokeWidth="2" />
-                                    <path d="M4 20c0-4 4-6 8-6s8 2 8 6" stroke="currentColor" strokeWidth="2" />
-                                  </svg>
-                                </div>
-                              )}
-                            </div>
-                            <p className="font-semibold text-zinc-900">
-                              {member.full_name || member.cast_member_name || "Unknown"}
-                            </p>
-                            <p className="text-sm text-amber-700">{archiveLabel}</p>
-                          </Link>
-                        );
-                      })}
-                    </div>
-                  </section>
-                )}
-
-                {castUiTerminalReady &&
-                  castGalleryMembers.length === 0 &&
-                  crewDisplaySections.length === 0 &&
-                  cast.length > 0 && (
-                  <p className="text-sm text-zinc-500">No cast members match the selected filters.</p>
-                )}
-
-                {castUiTerminalReady && cast.length === 0 && archiveFootageCast.length === 0 && (
-                  <p className="text-sm text-zinc-500">
-                    No cast members found for this show.
-                  </p>
-                )}
-              </div>
-            </div>
-            </ShowCastTab>
+            <ShowCastTab<TrrCastMember & { merged_photo_url?: string | null }>
+              renderedCastCount={renderedCastCount}
+              matchedCastCount={matchedCastCount}
+              totalCastCount={totalCastCount}
+              renderedCrewCount={renderedCrewCount}
+              matchedCrewCount={matchedCrewCount}
+              totalCrewCount={totalCrewCount}
+              renderedVisibleCount={renderedVisibleCount}
+              matchedVisibleCount={matchedVisibleCount}
+              totalVisibleCount={totalVisibleCount}
+              castMediaEnriching={castMediaEnriching}
+              isCastRefreshBusy={isCastRefreshBusy}
+              castPhotoEnriching={castPhotoEnriching}
+              castLoading={castLoading}
+              missingCastPhotoCount={missingCastPhotoCount}
+              castRefreshButtonLabel={castRefreshButtonLabel}
+              showCancelRunButton={
+                castRefreshPipelineRunning ||
+                castMediaEnriching ||
+                hasPersonRefreshInFlight ||
+                hasReconnectableCreditsRun
+              }
+              castRefreshCanceling={castRefreshCanceling}
+              castRefreshCancelButtonLabel={castRefreshCancelButtonLabel}
+              onEnrichCastMedia={() => void enrichCastMedia()}
+              onEnrichMissingCastPhotos={() => void enrichMissingCastPhotos()}
+              onRefreshShowCast={() => refreshShowCast()}
+              onCancelShowCastWorkflow={() => void cancelShowCastWorkflow()}
+              castCreditsRefreshNotice={refreshTargetNotice.cast_credits ?? null}
+              castCreditsRefreshError={refreshTargetError.cast_credits ?? null}
+              castRefreshPhaseRows={castRefreshPhasePanelStates.map((phase) => ({
+                id: phase.id,
+                label: CAST_REFRESH_PHASE_STAGES[phase.id] ?? phase.label,
+                message: phase.status !== "pending" ? phase.progress.message ?? null : null,
+                statusClassName: castRefreshPhaseStatusChipClassName(phase.status),
+                statusLabel: castRefreshPhaseStatusLabel(phase.status),
+              }))}
+              castRefreshPipelineRunning={castRefreshPipelineRunning}
+              refreshNotice={refreshNotice}
+              refreshError={refreshError}
+              castPhotoEnrichNotice={castPhotoEnrichNotice}
+              castPhotoEnrichError={castPhotoEnrichError}
+              castMediaEnrichNotice={castMediaEnrichNotice}
+              castMediaEnrichError={castMediaEnrichError}
+              castLoadWarning={castLoadWarning}
+              castLoadError={castLoadError}
+              onRetryCast={() => void fetchCast({ throwOnError: false })}
+              showCreditsError={showCreditsError}
+              onRetryCrew={() => void fetchShowCredits()}
+              showCreditsLoading={showCreditsLoading}
+              showCreditsLoadedOnce={showCreditsLoadedOnce}
+              showCreditsSourceUrl={showCreditsSourceUrl}
+              castRoleMembersWarningWithSnapshotAge={castRoleMembersWarningWithSnapshotAge}
+              onRetryCastRoleMembers={() => void fetchCastRoleMembers({ force: true })}
+              rolesWarningWithSnapshotAge={rolesWarningWithSnapshotAge}
+              onRetryRoles={() => void fetchShowRoles({ force: true })}
+              showCastIntelligenceUnavailable={showCastIntelligenceUnavailable}
+              castRoleMembersError={castRoleMembersError}
+              rolesError={rolesError}
+              castRoleEditorDeepLinkWarning={castRoleEditorDeepLinkWarning}
+              castEligibilityWarning={castSource === "show_fallback" ? castEligibilityWarning : null}
+              castRunFailedMembers={castRunFailedMembers}
+              castFailedMembersOpen={castFailedMembersOpen}
+              onToggleCastFailedMembersOpen={() => setCastFailedMembersOpen((prev) => !prev)}
+              onRetryFailedCastMediaEnrich={() => void retryFailedCastMediaEnrich()}
+              castMatrixSyncLoading={castMatrixSyncLoading}
+              castMatrixSyncError={castMatrixSyncError}
+              castMatrixSyncResult={castMatrixSyncResult}
+              castMatrixSyncScopeLabel={castMatrixSyncScopeLabel}
+              onSyncCastMatrixRoles={() => void syncCastMatrixRoles()}
+              castSearchQuery={castSearchQuery}
+              onSetCastSearchQuery={setCastSearchQuery}
+              castSortBy={castSortBy}
+              onSetCastSortBy={setCastSortBy}
+              castSortOrder={castSortOrder}
+              onSetCastSortOrder={setCastSortOrder}
+              castHasImageFilter={castHasImageFilter}
+              onSetCastHasImageFilter={setCastHasImageFilter}
+              onClearCastFilters={() => {
+                setCastSeasonFilters([]);
+                setCastRoleAndCreditFilters([]);
+                setCastHasImageFilter("all");
+                setCastExactEpisodeCount(null);
+                setCastMinEpisodeCount(null);
+                setCastMaxEpisodeCount(null);
+                setCastSortBy("episodes");
+                setCastSortOrder("desc");
+                setCastSearchQuery("");
+              }}
+              castExactEpisodeCount={castExactEpisodeCount}
+              onSetCastExactEpisodeCount={setCastExactEpisodeCount}
+              castMinEpisodeCount={castMinEpisodeCount}
+              onSetCastMinEpisodeCount={setCastMinEpisodeCount}
+              castMaxEpisodeCount={castMaxEpisodeCount}
+              onSetCastMaxEpisodeCount={setCastMaxEpisodeCount}
+              availableCastSeasons={availableCastSeasons}
+              castSeasonFilters={castSeasonFilters}
+              onToggleCastSeasonFilter={(seasonNumber) =>
+                setCastSeasonFilters((prev) =>
+                  prev.includes(seasonNumber)
+                    ? prev.filter((value) => value !== seasonNumber)
+                    : [...prev, seasonNumber]
+                )
+              }
+              castEpisodeScopeLabel={castEpisodeScopeLabel}
+              shouldShowRoleCreditEmptyState={shouldShowRoleCreditEmptyState}
+              castUiTerminalReady={castUiTerminalReady}
+              availableCastRoleAndCreditFilters={availableCastRoleAndCreditFilters}
+              castRoleAndCreditFilters={castRoleAndCreditFilters}
+              onToggleCastRoleAndCreditFilter={(key) =>
+                setCastRoleAndCreditFilters((prev) =>
+                  prev.includes(key) ? prev.filter((value) => value !== key) : [...prev, key]
+                )
+              }
+              castRoleMembersLoading={castRoleMembersLoading}
+              castLoadedOnce={castLoadedOnce}
+              castRenderProgressLabel={castRenderProgressLabel}
+              castRosterReady={castRosterReady}
+              castViewMode={castViewMode}
+              castGalleryColumns={castGalleryColumns}
+              onSetCastViewMode={setCastViewMode}
+              onSetCastGalleryColumns={setCastGalleryColumns}
+              castGalleryMembers={castGalleryMembers}
+              castCount={cast.length}
+              archiveFootageCount={archiveFootageCast.length}
+              visibleCastMembers={visibleCastMembers}
+              renderCastMember={renderShowCreditsCastMember}
+              crewDisplaySections={crewDisplaySections}
+              visibleCrewSections={visibleCrewSections}
+              archiveFootageCast={archiveFootageCast}
+              getPersonOverviewHref={({ personId, personName }) =>
+                buildPersonAdminUrl({
+                  showSlug: showSlugForRouting,
+                  personSlug: buildPersonRouteSlug({
+                    personName,
+                    personId,
+                  }),
+                  tab: "overview",
+                }) as Route
+              }
+            />
           )}
 
           {/* Surveys Tab */}
@@ -13890,1364 +11536,163 @@ export default function TrrShowDetailPage() {
 
           {/* Settings Tab */}
           {activeTab === "settings" && (
-            <ShowSettingsTab>
-            <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm">
-              <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.3em] text-zinc-400">
-                    Show Settings
-                  </p>
-                  <h3 className="text-xl font-bold text-zinc-900">
-                    Settings
-                  </h3>
-                </div>
-                <div className="flex flex-wrap items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => void syncShowScopedBrandLogos()}
-                    disabled={showLogoSyncing}
-                    className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-zinc-800 disabled:opacity-50"
-                  >
-                    {showLogoSyncing ? "Syncing..." : "Sync Show Logo Targets"}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setRefreshLogOpen(true)}
-                    disabled={showLogoSyncing}
-                    className="rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-50 disabled:opacity-50"
-                  >
-                    {refreshCenterButtonLabel}
-                  </button>
-                </div>
-              </div>
-
-              {(linksError ||
-                linksNotice ||
-                rolesError ||
-                rolesWarning ||
-                showLogoSyncError ||
-                showLogoSyncNotice) && (
-                <div className="mb-4 text-sm space-y-2">
-                  <p
-                    className={`${
-                      linksError || rolesError || showLogoSyncError
-                        ? linksLoadTimedOut || rolesLoadTimedOut
-                          ? "text-amber-700"
-                          : "text-red-600"
-                        : "text-zinc-500"
-                    }`}
-                  >
-                    {linksError ||
-                      rolesError ||
-                      showLogoSyncError ||
-                      rolesWarning ||
-                      linksNotice ||
-                      showLogoSyncNotice}
-                  </p>
-                  {linksError && linksLoadTimedOut && (
-                    <button
-                      type="button"
-                      onClick={() => void fetchShowLinks()}
-                      className="inline-flex items-center rounded-lg border border-amber-300 bg-amber-50 px-3 py-1.5 text-xs font-semibold text-amber-700 transition hover:bg-amber-100"
-                    >
-                      Retry links
-                    </button>
-                  )}
-                  {rolesError && rolesLoadTimedOut && (
-                    <button
-                      type="button"
-                      onClick={() => void fetchShowRoles({ force: true })}
-                      className="inline-flex items-center rounded-lg border border-amber-300 bg-amber-50 px-3 py-1.5 text-xs font-semibold text-amber-700 transition hover:bg-amber-100"
-                    >
-                      Retry roles
-                    </button>
-                  )}
-                </div>
+            <ShowSettingsTab
+              header={{
+                showLogoSyncing,
+                refreshCenterButtonLabel,
+                onSyncShowLogoTargets: syncShowScopedBrandLogos,
+                onOpenRefreshLog: () => setRefreshLogOpen(true),
+              }}
+              status={{
+                linksError,
+                linksNotice,
+                linksLoadTimedOut,
+                rolesError,
+                rolesWarning,
+                rolesLoadTimedOut,
+                showLogoSyncError,
+                showLogoSyncNotice,
+                onRetryLinks: () => fetchShowLinks(),
+                onRetryRoles: () => fetchShowRoles({ force: true }),
+              }}
+              metadata={{
+                form: detailsForm,
+                editing: detailsEditing,
+                saving: detailsSaving,
+                notice: detailsNotice,
+                error: detailsError,
+                onChangeField: (field, value) =>
+                  setDetailsForm((previous) => ({ ...previous, [field]: value })),
+                onStartEdit: startDetailsEdit,
+                onCancelEdit: cancelDetailsEdit,
+                onSave: saveShowDetails,
+              }}
+              roles={{
+                newRoleName,
+                loading: rolesLoading,
+                rows: showRoles,
+                onNewRoleNameChange: setNewRoleName,
+                onCreate: createShowRole,
+                onRename: renameShowRole,
+                onToggleActive: toggleShowRoleActive,
+              }}
+              links={{
+                showIsBravo,
+                refreshing: linksRefreshing,
+                bulkInput: linkBulkInput,
+                bulkSaving: linkBulkSaving,
+                loading: linksLoading,
+                totalCount: showLinks.length,
+                eligibleCastLoading: linksEligibleCastLoading,
+                eligibleCastLoadedOnce: linksEligibleCastLoadedOnce,
+                savingLinkIds,
+                socialLinks: showSocialLinks,
+                showPageLinks,
+                seasonUrlCoverageRows,
+                castMemberLinkCoverageCards,
+                onRefresh: refreshShowLinks,
+                onBulkInputChange: setLinkBulkInput,
+                onAdd: addShowLinks,
+                onUpdateUrl: updateShowLinkUrl,
+                onDelete: deleteShowLink,
+              }}
+              reddit={{
+                loading: redditLoading,
+                error: redditError,
+                groups: overviewRedditGroups,
+                getCommunityHref: (community) =>
+                  buildAdminRedditCommunityUrl({
+                    communitySlug: community.subreddit,
+                    showSlug: showSlugForRouting,
+                  }),
+              }}
+              getShowPageLinkTitle={(link) =>
+                getShowPageLinkTitle(link, show?.name ?? "Show")
+              }
+              renderShowPageLinkBadge={(link) => {
+                const sourceKind = getLinkSourceBadgeKind(link);
+                return (
+                  <SourceBadge
+                    kind={sourceKind}
+                    label={getLinkSourceLabel(link)}
+                    iconUrl={sourceKind === "fandom" ? buildHostFaviconUrl(link.url) : null}
+                    iconOnly={usesBrandIconOnly(sourceKind)}
+                  />
+                );
+              }}
+              renderSourceBadge={({ kind, label, iconUrl, iconOnly }) => (
+                <SourceBadge
+                  kind={kind}
+                  label={label}
+                  iconUrl={iconUrl}
+                  iconOnly={iconOnly}
+                />
               )}
-
-              <div className="space-y-6">
-                <section>
-                  <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-                    <h4 className="text-sm font-semibold text-zinc-700">Editable Metadata</h4>
-                    <div className="flex flex-wrap items-center gap-2">
-                      {detailsEditing ? (
-                        <>
-                          <button
-                            type="button"
-                            onClick={cancelDetailsEdit}
-                            disabled={detailsSaving}
-                            className="rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-semibold text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
-                          >
-                            Cancel
-                          </button>
-                          <button
-                            type="button"
-                            onClick={saveShowDetails}
-                            disabled={detailsSaving}
-                            className="rounded-lg bg-zinc-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-zinc-800 disabled:opacity-50"
-                          >
-                            {detailsSaving ? "Saving..." : "Save"}
-                          </button>
-                        </>
-                      ) : (
-                        <button
-                          type="button"
-                          onClick={startDetailsEdit}
-                          className="rounded-lg bg-zinc-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-zinc-800"
-                        >
-                          Edit Metadata
-                        </button>
-                      )}
-                    </div>
-                  </div>
-                  {(detailsNotice || detailsError) && (
-                    <p className={`mb-3 text-sm ${detailsError ? "text-red-600" : "text-zinc-500"}`}>
-                      {detailsError || detailsNotice}
-                    </p>
-                  )}
-                  <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
-                    <div className="grid gap-4 md:grid-cols-2">
-                      <label className="block md:col-span-2">
-                        <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          Display Name
-                        </span>
-                        <input
-                          type="text"
-                          value={detailsForm.displayName}
-                          onChange={(e) => setDetailsForm((prev) => ({ ...prev, displayName: e.target.value }))}
-                          disabled={!detailsEditing}
-                          className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
-                        />
-                      </label>
-                      <label className="block">
-                        <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          Nickname / Slug
-                        </span>
-                        <input
-                          type="text"
-                          value={detailsForm.nickname}
-                          onChange={(e) => setDetailsForm((prev) => ({ ...prev, nickname: e.target.value }))}
-                          disabled={!detailsEditing}
-                          className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
-                        />
-                        {detailsForm.nickname.trim() && (
-                          <span className="mt-1 block text-xs text-zinc-400">
-                            Canonical slug: <span className="font-mono">{deriveShowDetailsSlugPreview(detailsForm.nickname)}</span>
-                            {" · "}
-                            Hashtag: <span className="font-mono">#{detailsForm.nickname.trim().replace(/\s+/g, "")}</span>
-                          </span>
-                        )}
-                      </label>
-                      <div className="block">
-                        <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          Premiere Date
-                        </span>
-                        <div className="flex items-center gap-2">
-                          <input
-                            type="date"
-                            value={detailsForm.premiereDate}
-                            onChange={(e) => setDetailsForm((prev) => ({ ...prev, premiereDate: e.target.value }))}
-                            disabled={!detailsEditing}
-                            className="flex-1 rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
-                          />
-                          {detailsEditing && detailsForm.premiereDate && (
-                            <button
-                              type="button"
-                              onClick={() => setDetailsForm((prev) => ({ ...prev, premiereDate: "" }))}
-                              className="rounded-lg border border-zinc-200 bg-white px-2 py-2 text-xs text-zinc-500 hover:bg-zinc-50"
-                              title="Clear premiere date"
-                            >
-                              ✕
-                            </button>
-                          )}
-                        </div>
-                      </div>
-                      <label className="block md:col-span-2">
-                        <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          Alt Names
-                        </span>
-                        <textarea
-                          value={detailsForm.altNamesText}
-                          onChange={(e) => setDetailsForm((prev) => ({ ...prev, altNamesText: e.target.value }))}
-                          rows={3}
-                          disabled={!detailsEditing}
-                          className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
-                        />
-                      </label>
-                      <label className="block md:col-span-2">
-                        <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          Description
-                        </span>
-                        <textarea
-                          value={detailsForm.description}
-                          onChange={(e) => setDetailsForm((prev) => ({ ...prev, description: e.target.value }))}
-                          rows={4}
-                          disabled={!detailsEditing}
-                          className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
-                        />
-                      </label>
-                      <label className="block">
-                        <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          TMDb
-                        </span>
-                        <input
-                          type="text"
-                          value={detailsForm.tmdbId}
-                          onChange={(e) => setDetailsForm((prev) => ({ ...prev, tmdbId: e.target.value }))}
-                          disabled={!detailsEditing}
-                          className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
-                        />
-                      </label>
-                      <label className="block">
-                        <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          IMDb
-                        </span>
-                        <input
-                          type="text"
-                          value={detailsForm.imdbId}
-                          onChange={(e) => setDetailsForm((prev) => ({ ...prev, imdbId: e.target.value }))}
-                          disabled={!detailsEditing}
-                          className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
-                        />
-                      </label>
-                      <label className="block">
-                        <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          TVDb
-                        </span>
-                        <input
-                          type="text"
-                          value={detailsForm.tvdbId}
-                          onChange={(e) => setDetailsForm((prev) => ({ ...prev, tvdbId: e.target.value }))}
-                          disabled={!detailsEditing}
-                          className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
-                        />
-                      </label>
-                      <label className="block">
-                        <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          Wikidata
-                        </span>
-                        <input
-                          type="text"
-                          value={detailsForm.wikidataId}
-                          onChange={(e) => setDetailsForm((prev) => ({ ...prev, wikidataId: e.target.value }))}
-                          disabled={!detailsEditing}
-                          className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
-                        />
-                      </label>
-                      <label className="block md:col-span-2">
-                        <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          TV Rage
-                        </span>
-                        <input
-                          type="text"
-                          value={detailsForm.tvRageId}
-                          onChange={(e) => setDetailsForm((prev) => ({ ...prev, tvRageId: e.target.value }))}
-                          disabled={!detailsEditing}
-                          className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
-                        />
-                      </label>
-                      <label className="block md:col-span-2">
-                        <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          Genres
-                        </span>
-                        <textarea
-                          value={detailsForm.genresText}
-                          onChange={(e) => setDetailsForm((prev) => ({ ...prev, genresText: e.target.value }))}
-                          rows={2}
-                          disabled={!detailsEditing}
-                          className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
-                        />
-                      </label>
-                      <label className="block md:col-span-2">
-                        <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          Networks
-                        </span>
-                        <textarea
-                          value={detailsForm.networksText}
-                          onChange={(e) => setDetailsForm((prev) => ({ ...prev, networksText: e.target.value }))}
-                          rows={2}
-                          disabled={!detailsEditing}
-                          className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
-                        />
-                      </label>
-                      <label className="block md:col-span-2">
-                        <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          Streaming
-                        </span>
-                        <textarea
-                          value={detailsForm.streamingProvidersText}
-                          onChange={(e) =>
-                            setDetailsForm((prev) => ({ ...prev, streamingProvidersText: e.target.value }))
-                          }
-                          rows={2}
-                          disabled={!detailsEditing}
-                          className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
-                        />
-                      </label>
-                      <label className="block md:col-span-2">
-                        <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          Tags
-                        </span>
-                        <textarea
-                          value={detailsForm.tagsText}
-                          onChange={(e) => setDetailsForm((prev) => ({ ...prev, tagsText: e.target.value }))}
-                          rows={2}
-                          disabled={!detailsEditing}
-                          className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
-                        />
-                      </label>
-                    </div>
-                  </div>
-                </section>
-
-                <section>
-                  <h4 className="mb-3 text-sm font-semibold text-zinc-700">Role Catalog</h4>
-                  <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
-                    <div className="mb-3 flex flex-wrap gap-2">
-                      <input
-                        value={newRoleName}
-                        onChange={(event) => setNewRoleName(event.target.value)}
-                        placeholder="Housewife"
-                        className="min-w-[220px] flex-1 rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-700"
-                      />
-                      <button
-                        type="button"
-                        onClick={createShowRole}
-                        disabled={rolesLoading}
-                        className="rounded-lg border border-zinc-300 bg-white px-3 py-2 text-xs font-semibold text-zinc-700 hover:bg-zinc-100 disabled:opacity-50"
-                      >
-                        Add Role
-                      </button>
-                    </div>
-                    {showRoles.length === 0 ? (
-                      <p className="text-sm text-zinc-500">No roles configured yet.</p>
-                    ) : (
-                      <div className="flex flex-wrap items-center gap-2">
-                        {showRoles.map((role) => (
-                          <div
-                            key={`settings-role-catalog-${role.id}`}
-                            className="flex items-center gap-1 rounded-full border border-zinc-200 bg-white px-2 py-1"
-                          >
-                            <span
-                              className={`text-xs font-semibold ${
-                                role.is_active ? "text-zinc-700" : "text-zinc-400 line-through"
-                              }`}
-                            >
-                              {role.name}
-                            </span>
-                            <button
-                              type="button"
-                              onClick={() => void renameShowRole(role)}
-                              className="rounded border border-zinc-200 bg-white px-1.5 py-0.5 text-[10px] font-semibold text-zinc-700"
-                            >
-                              Rename
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => void toggleShowRoleActive(role)}
-                              className={`rounded px-1.5 py-0.5 text-[10px] font-semibold ${
-                                role.is_active
-                                  ? "border border-amber-200 bg-amber-50 text-amber-700"
-                                  : "border border-emerald-200 bg-emerald-50 text-emerald-700"
-                              }`}
-                            >
-                              {role.is_active ? "Deactivate" : "Activate"}
-                            </button>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </section>
-
-                <section>
-                  <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-                    <h4 className="text-sm font-semibold text-zinc-700">Links</h4>
-                    <button
-                      type="button"
-                      onClick={() => void refreshShowLinks()}
-                      disabled={linksRefreshing}
-                      className="rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-semibold text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
-                    >
-                      {linksRefreshing ? "Refreshing..." : "Refresh Links"}
-                    </button>
-                  </div>
-                  <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
-                    <div className="mb-4 rounded-lg border border-zinc-200 bg-white p-3">
-                      <p className="text-xs text-zinc-500">
-                        Paste one or more URLs or handles. The classifier auto-assigns show vs season vs cast-member
-                        links and routes social handles (Instagram/TikTok/X/YouTube/Threads/Facebook/Reddit) into
-                        social links, with show pages, season pages, cast-member pages, and Google News topic URLs
-                        routed into the matching sections below.
-                      </p>
-                      <textarea
-                        value={linkBulkInput}
-                        onChange={(event) => setLinkBulkInput(event.target.value)}
-                        rows={4}
-                        placeholder={
-                          "https://thetraitors.fandom.com/wiki/The_Traitors_(US)\nhttps://news.google.com/topics/CAAqKAgKIiJDQkFTRXdvTkwyY3ZNVEZvYlhBeGVtUndNQklDWlc0b0FBUAE?ceid=US:en&oc=3\ninstagram:@thetraitorsus"
-                        }
-                        className="mt-2 block w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-700"
-                      />
-                      <div className="mt-2 flex justify-end">
-                        <button
-                          type="button"
-                          onClick={() => void addShowLinks()}
-                          disabled={linkBulkSaving}
-                          className="rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-semibold text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
-                        >
-                          {linkBulkSaving ? "Adding..." : "Add Link(s)"}
-                        </button>
-                      </div>
-                    </div>
-                    {linksLoading ? (
-                      <p className="text-sm text-zinc-500">Loading links...</p>
-                    ) : showLinks.length === 0 ? (
-                      <p className="text-sm text-zinc-500">No links yet. Run discovery to populate this list.</p>
-                    ) : (
-                      <div className="space-y-5">
-                        <div className="space-y-2">
-                          <div>
-                            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                              {socialLinksSection.title}
-                            </p>
-                            <p className="text-xs text-zinc-500">{socialLinksSection.description}</p>
-                          </div>
-                          {showSocialLinks.length === 0 ? (
-                            <p className="text-sm text-zinc-500">No show-level social handles discovered yet.</p>
-                          ) : (
-                            <div className="space-y-1">
-                              {showSocialLinks.map((pill) => (
-                                <InlineEditableLinkUrl
-                                  key={`settings-social-link-${pill.id}`}
-                                  linkId={pill.link.id}
-                                  url={pill.url}
-                                  openUrl={pill.url}
-                                  label={pill.text}
-                                  saving={Boolean(savingLinkIds[pill.link.id])}
-                                  onSubmit={updateShowLinkUrl}
-                                  containerClassName="rounded-md border border-zinc-200 bg-white px-3 py-2"
-                                  actions={
-                                    <button
-                                      type="button"
-                                      onClick={() => void deleteShowLink(pill.link.id)}
-                                      className="rounded border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-semibold text-red-700"
-                                    >
-                                      Delete
-                                    </button>
-                                  }
-                                >
-                                  <div className="inline-flex min-w-0 flex-1 items-center gap-2" title={pill.url}>
-                                    <SourceBadge kind={pill.sourceKind} label={pill.sourceLabel} iconOnly={true} />
-                                    <span className="truncate text-zinc-900">{pill.text}</span>
-                                  </div>
-                                </InlineEditableLinkUrl>
-                              ))}
-                            </div>
-                          )}
-                        </div>
-
-                        <div className="space-y-2">
-                          <div>
-                            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                              {showPagesSection.title}
-                            </p>
-                            <p className="text-xs text-zinc-500">{showPagesSection.description}</p>
-                          </div>
-                          {showPageLinks.length === 0 ? (
-                            <p className="text-sm text-zinc-500">No links in this category yet.</p>
-                          ) : (
-                            <div className="space-y-1">
-                              {showPageLinks.map((link) => {
-                                const sourceKind = getLinkSourceBadgeKind(link);
-                                const sourceLabel = getLinkSourceLabel(link);
-                                const linkTitle = getShowPageLinkTitle(link, show?.name ?? "Show");
-                                const iconUrl = sourceKind === "fandom" ? buildHostFaviconUrl(link.url) : null;
-                                return (
-                                  <InlineEditableLinkUrl
-                                    key={`settings-link-show-pages-${link.id}`}
-                                    linkId={link.id}
-                                    url={link.url}
-                                    openUrl={link.url}
-                                    label={linkTitle}
-                                    saving={Boolean(savingLinkIds[link.id])}
-                                    onSubmit={updateShowLinkUrl}
-                                    containerClassName="rounded-md border border-zinc-200 bg-white px-3 py-2"
-                                    actions={
-                                      <button
-                                        type="button"
-                                        onClick={() => void deleteShowLink(link.id)}
-                                        className="rounded border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-semibold text-red-700"
-                                      >
-                                        Delete
-                                      </button>
-                                    }
-                                  >
-                                    <div className="inline-flex min-w-0 flex-1 items-center gap-2">
-                                      <SourceBadge
-                                        kind={sourceKind}
-                                        label={sourceLabel}
-                                        iconUrl={iconUrl}
-                                        iconOnly={usesBrandIconOnly(sourceKind)}
-                                      />
-                                      <span className="shrink-0 text-zinc-300">|</span>
-                                      <span className="truncate text-zinc-900">{linkTitle}</span>
-                                    </div>
-                                  </InlineEditableLinkUrl>
-                                );
-                              })}
-                            </div>
-                          )}
-                        </div>
-
-                        <div className="space-y-2">
-                          <div>
-                            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                              {seasonPagesSection.title}
-                            </p>
-                            <p className="text-xs text-zinc-500">{seasonPagesSection.description}</p>
-                          </div>
-                          {seasonUrlCoverageRows.length === 0 ? (
-                            <p className="text-sm text-zinc-500">No season-scoped validated links yet.</p>
-                          ) : (
-                            <div className="space-y-2">
-                              {seasonUrlCoverageRows.map((row) => (
-                                <div
-                                  key={`settings-season-pages-${row.seasonNumber}`}
-                                  className="rounded-lg border border-zinc-200 bg-white px-3 py-2"
-                                >
-                                  <div className="flex flex-wrap items-center gap-2">
-                                    <p className="text-sm font-semibold text-zinc-900">Season {row.seasonNumber}</p>
-                                    <div className="flex flex-wrap items-center gap-2">
-                                      {row.links.map((link) => (
-                                        <a
-                                          key={`settings-season-link-pill-${row.seasonNumber}-${link.id}`}
-                                          href={link.url}
-                                          target="_blank"
-                                          rel="noopener noreferrer"
-                                          className="inline-flex items-center rounded-full border border-zinc-200 bg-zinc-50 px-2 py-1 text-xs font-semibold text-zinc-700 hover:bg-zinc-100"
-                                          title={`${link.sourceLabel} | ${(link.link && resolveLinkPageTitle(link.link)) || `Season ${row.seasonNumber}`}`}
-                                        >
-                                          <SourceBadge
-                                            kind={link.sourceKind}
-                                            label={link.sourceLabel}
-                                            iconUrl={link.iconUrl}
-                                            iconOnly={true}
-                                          />
-                                        </a>
-                                      ))}
-                                    </div>
-                                  </div>
-                                  <div className="mt-3 grid gap-2">
-                                    {row.links.filter((link) => link.link).map((link) => (
-                                      <InlineEditableLinkUrl
-                                        key={`settings-season-link-editor-${row.seasonNumber}-${link.id}`}
-                                        linkId={link.link!.id}
-                                        url={link.url}
-                                        openUrl={link.url}
-                                        label={`${link.sourceLabel} season page`}
-                                        saving={Boolean(savingLinkIds[link.link!.id])}
-                                        onSubmit={updateShowLinkUrl}
-                                        containerClassName="rounded-md border border-zinc-200 bg-zinc-50 px-3 py-2"
-                                        actions={
-                                          <button
-                                            type="button"
-                                            onClick={() => void deleteShowLink(link.link!.id)}
-                                            className="rounded border border-red-200 bg-red-50 px-1.5 py-0.5 text-[10px] font-semibold text-red-700"
-                                          >
-                                            Delete
-                                          </button>
-                                        }
-                                        >
-                                          <div className="flex items-center gap-2 text-xs font-semibold text-zinc-700">
-                                            <SourceBadge
-                                              kind={link.sourceKind}
-                                              label={link.sourceLabel}
-                                            iconUrl={link.iconUrl}
-                                            iconOnly={usesBrandIconOnly(link.sourceKind)}
-                                          />
-                                          <span>{link.sourceLabel}</span>
-                                        </div>
-                                      </InlineEditableLinkUrl>
-                                    ))}
-                                  </div>
-                                </div>
-                              ))}
-                            </div>
-                          )}
-                        </div>
-
-                        <div className="space-y-2">
-                          <div>
-                            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                              {castMemberPagesSection.title}
-                            </p>
-                            <p className="text-xs text-zinc-500">{castMemberPagesSection.description}</p>
-                          </div>
-                          {castMemberLinkCoverageCards.length === 0 ? (
-                            linksEligibleCastLoading && !linksEligibleCastLoadedOnce ? (
-                              <p className="text-sm text-zinc-500">Loading eligible cast roster...</p>
-                            ) : (
-                              <p className="text-sm text-zinc-500">No cast-member links in this category yet.</p>
-                            )
-                          ) : (
-                            <div className="space-y-3">
-                              {castMemberLinkCoverageCards.map((card) => (
-                                <div
-                                  key={`person-link-coverage-${card.personId}`}
-                                  className="rounded-lg border border-zinc-200 bg-white p-3"
-                                >
-                                  <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-                                    <div className="flex min-w-0 items-center gap-2">
-                                      {card.avatarUrl ? (
-                                        <Image
-                                          src={card.avatarUrl}
-                                          alt={card.personName}
-                                          width={32}
-                                          height={32}
-                                          className="h-8 w-8 rounded-full border border-zinc-200 object-cover"
-                                          unoptimized
-                                        />
-                                      ) : (
-                                        <div className="flex h-8 w-8 items-center justify-center rounded-full border border-zinc-200 bg-zinc-100 text-[10px] font-semibold uppercase text-zinc-500">
-                                          {card.personName.slice(0, 1) || "?"}
-                                        </div>
-                                      )}
-                                      <p className="truncate text-sm font-semibold text-zinc-900">{card.personName}</p>
-                                    </div>
-                                    <div className="flex flex-wrap items-center gap-1">
-                                      <span className="rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-[11px] font-semibold text-blue-700">
-                                        {card.approvedLinkCount} approved
-                                      </span>
-                                      {card.seasons.length > 0 && (
-                                        <span className="rounded-full border border-zinc-200 bg-zinc-50 px-2 py-0.5 text-[11px] font-semibold text-zinc-600">
-                                          Seasons {card.seasons.map((season) => `S${season}`).join(", ")}
-                                        </span>
-                                      )}
-                                    </div>
-                                  </div>
-
-                                  {card.approvedLinks.length === 0 ? (
-                                    <p className="text-sm text-zinc-500">No validated links for this person yet.</p>
-                                  ) : (
-                                    <div className="flex flex-wrap gap-2">
-                                      {card.approvedLinks.map((approvedLink) => (
-                                        <InlineEditableLinkUrl
-                                          key={`person-approved-link-${card.personId}-${approvedLink.id}`}
-                                          linkId={approvedLink.link.id}
-                                          url={approvedLink.url}
-                                          openUrl={approvedLink.url}
-                                          label={approvedLink.text}
-                                          saving={Boolean(savingLinkIds[approvedLink.link.id])}
-                                          onSubmit={updateShowLinkUrl}
-                                          containerClassName="rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2"
-                                          actions={
-                                            <button
-                                              type="button"
-                                              onClick={() => void deleteShowLink(approvedLink.link.id)}
-                                              className="rounded border border-red-200 bg-red-50 px-1.5 py-0.5 text-[10px] font-semibold text-red-700"
-                                            >
-                                              Delete
-                                            </button>
-                                          }
-                                        >
-                                          <div
-                                            className="inline-flex min-w-0 max-w-full items-center gap-2 text-xs font-semibold text-zinc-700"
-                                            title={approvedLink.url}
-                                          >
-                                            <SourceBadge
-                                              kind={approvedLink.sourceKind}
-                                              label={approvedLink.sourceLabel}
-                                              iconUrl={approvedLink.iconUrl}
-                                              iconOnly={usesBrandIconOnly(approvedLink.sourceKind)}
-                                            />
-                                            <span className="truncate">{approvedLink.text}</span>
-                                          </div>
-                                        </InlineEditableLinkUrl>
-                                      ))}
-                                    </div>
-                                  )}
-
-                                  {card.missingSources.length > 0 && (
-                                    <details className="mt-3 rounded-lg border border-zinc-200 bg-zinc-50 p-3">
-                                      <summary className="cursor-pointer text-xs font-semibold uppercase tracking-[0.16em] text-zinc-500">
-                                        Missing / Unvalidated Sources
-                                      </summary>
-                                      <div className="mt-3 space-y-2">
-                                        {card.missingSources.map((source) => (
-                                          <InlineEditableLinkUrl
-                                            key={`person-link-source-${card.personId}-${source.key}`}
-                                            linkId={source.link?.id ?? `missing-${card.personId}-${source.key}`}
-                                            url={source.link?.url ?? source.url ?? ""}
-                                            openUrl={source.link?.url ?? source.url ?? null}
-                                            label={source.label}
-                                            saving={source.link ? Boolean(savingLinkIds[source.link.id]) : false}
-                                            onSubmit={updateShowLinkUrl}
-                                            containerClassName="rounded-md border border-amber-200 bg-white px-3 py-2"
-                                            canEdit={Boolean(source.link)}
-                                            actions={
-                                              source.link ? (
-                                                <button
-                                                  type="button"
-                                                  onClick={() => source.link && void deleteShowLink(source.link.id)}
-                                                  className="rounded border border-red-200 bg-red-50 px-2 py-0.5 text-[10px] font-semibold text-red-700"
-                                                >
-                                                  Delete
-                                                </button>
-                                              ) : null
-                                            }
-                                          >
-                                            <div className="space-y-2">
-                                              <div className="flex flex-wrap items-center gap-2">
-                                                <PersonSourceLogo sourceKey={source.key} />
-                                                <span className="text-xs font-semibold text-zinc-800">
-                                                  {source.label}
-                                                </span>
-                                                <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
-                                                  {source.state === "unvalidated" ? "Unvalidated" : "Missing"}
-                                                </span>
-                                              </div>
-                                              <p className="text-xs text-zinc-600">No validated source URL found</p>
-                                              {source.url ? (
-                                                <p className="max-w-full truncate text-xs font-medium text-zinc-700" title={source.url}>
-                                                  {source.url}
-                                                </p>
-                                              ) : null}
-                                            </div>
-                                          </InlineEditableLinkUrl>
-                                        ))}
-                                      </div>
-                                    </details>
-                                  )}
-                                </div>
-                              ))}
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                </section>
-
-                <section>
-                  <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-                    <h4 className="text-sm font-semibold text-zinc-700">Reddit</h4>
-                    <Link
-                      href={"/admin/social/reddit"}
-                      className="rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-semibold text-zinc-700 hover:bg-zinc-50"
-                    >
-                      Open Reddit Admin
-                    </Link>
-                  </div>
-                  <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
-                    {redditLoading ? (
-                      <p className="text-sm text-zinc-500">Loading Reddit communities...</p>
-                    ) : redditError ? (
-                      <p className="text-sm text-red-600">{redditError}</p>
-                    ) : overviewRedditGroups.length === 0 ? (
-                      <p className="text-sm text-zinc-500">No relevant Reddit communities configured for this show.</p>
-                    ) : (
-                      <div className="space-y-4">
-                        {overviewRedditGroups.map((group) => (
-                          <div key={`settings-reddit-group-${group.key}`} className="space-y-2">
-                            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                              {group.label}
-                            </p>
-                            <div className="space-y-2">
-                              {group.communities.map((community) => (
-                                <div
-                                  key={`settings-reddit-community-${community.id}`}
-                                  className="rounded-lg border border-zinc-200 bg-white p-3"
-                                >
-                                  <div className="flex flex-wrap items-center justify-between gap-2">
-                                    <div>
-                                      <p className="text-sm font-semibold text-zinc-900">{community.displayName}</p>
-                                      <p className="text-xs text-zinc-500">r/{community.subreddit}</p>
-                                    </div>
-                                    <Link
-                                      href={buildAdminRedditCommunityUrl({
-                                        communitySlug: community.subreddit,
-                                        showSlug: showSlugForRouting,
-                                      })}
-                                      className="rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-1.5 text-xs font-semibold text-zinc-700 hover:bg-zinc-100"
-                                    >
-                                      Open Community
-                                    </Link>
-                                  </div>
-                                  <div className="mt-3 space-y-2">
-                                    <div>
-                                      <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-500">
-                                        Assigned Flairs
-                                      </p>
-                                      <div className="mt-1 flex flex-wrap gap-1.5">
-                                        {community.assignedFlairs.length > 0 ? (
-                                          community.assignedFlairs.map((flair) => (
-                                            <span
-                                              key={`settings-reddit-flair-${community.id}-${flair}`}
-                                              className="rounded-full border border-zinc-200 bg-zinc-50 px-2 py-0.5 text-[11px] font-semibold text-zinc-700"
-                                            >
-                                              {flair}
-                                            </span>
-                                          ))
-                                        ) : (
-                                          <span className="text-xs text-zinc-500">No assigned flairs</span>
-                                        )}
-                                      </div>
-                                    </div>
-                                    {community.postFlairs.length > 0 && (
-                                      <div>
-                                        <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-500">
-                                          Post Flairs
-                                        </p>
-                                        <div className="mt-1 flex flex-wrap gap-1.5">
-                                          {community.postFlairs.map((flair) => (
-                                            <span
-                                              key={`settings-reddit-post-flair-${community.id}-${flair}`}
-                                              className="rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700"
-                                            >
-                                              {flair}
-                                            </span>
-                                          ))}
-                                        </div>
-                                      </div>
-                                    )}
-                                  </div>
-                                </div>
-                              ))}
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </section>
-              </div>
-            </div>
-            </ShowSettingsTab>
+              usesBrandIconOnly={usesBrandIconOnly}
+            />
           )}
 
           {/* Details Tab - External IDs */}
           {activeTab === "details" && (
-            <ShowOverviewTab>
-            <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm">
-              <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.3em] text-zinc-400">
-                    Show Overview
-                  </p>
-                  <h3 className="text-xl font-bold text-zinc-900">
-                    Details and Metadata
-                  </h3>
-                </div>
-                <div className="flex flex-wrap items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => setTab("settings")}
-                    className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-zinc-800"
-                  >
-                    Open Settings
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setRefreshLogOpen(true)}
-                    className="rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-50 disabled:opacity-50"
-                  >
-                    {refreshCenterButtonLabel}
-                  </button>
-                </div>
-              </div>
-
-              {(refreshTargetNotice.details || refreshTargetError.details) && (
-                <p
-                  className={`mb-4 text-sm ${
-                    refreshTargetError.details ? "text-red-600" : "text-zinc-500"
-                  }`}
-                >
-                  {refreshTargetError.details || refreshTargetNotice.details}
-                </p>
+            <ShowOverviewTab
+              show={show}
+              nickname={detailsBaseline.nickname}
+              alternativeNamesText={overviewAlternativeNamesText}
+              refreshCenterButtonLabel={refreshCenterButtonLabel}
+              refreshNotice={refreshTargetNotice.details}
+              refreshError={refreshTargetError.details}
+              refreshing={refreshingTargets.details}
+              refreshProgress={refreshTargetProgress.details}
+              renderRefreshProgress={(props) => <RefreshProgressBar {...props} />}
+              detailsNotice={detailsNotice}
+              detailsError={detailsError}
+              externalIdLinks={overviewExternalIdLinks}
+              getExternalIdLinkTitle={(link) => getShowPageLinkTitle(link, show.name)}
+              renderExternalIdLinkBadge={(link) => {
+                const sourceKind = getLinkSourceBadgeKind(link);
+                return (
+                  <SourceBadge
+                    kind={sourceKind}
+                    label={getLinkSourceLabel(link)}
+                    iconUrl={sourceKind === "fandom" ? buildHostFaviconUrl(link.url) : null}
+                    iconOnly={usesBrandIconOnly(sourceKind)}
+                  />
+                );
+              }}
+              socialHandleLinks={overviewSocialHandleLinks}
+              renderSocialHandlePill={(pill) => <SocialHandlePill pill={pill} />}
+              redditLoading={redditLoading}
+              redditError={redditError}
+              redditGroups={overviewRedditGroups}
+              getRedditCommunityHref={(community) =>
+                buildAdminRedditCommunityUrl({
+                  communitySlug: community.subreddit,
+                  showSlug: showSlugForRouting,
+                })
+              }
+              seasonUrlCoverageRows={seasonUrlCoverageRows}
+              renderSeasonCoverageBadge={(link) => (
+                <SourceBadge
+                  kind={link.sourceKind}
+                  label={link.sourceLabel}
+                  iconUrl={link.iconUrl}
+                  iconOnly={true}
+                />
               )}
-              <RefreshProgressBar
-                show={refreshingTargets.details}
-                stage={refreshTargetProgress.details?.stage}
-                message={refreshTargetProgress.details?.message}
-                current={refreshTargetProgress.details?.current}
-                total={refreshTargetProgress.details?.total}
-              />
-              {(detailsNotice || detailsError) && (
-                <p className={`mb-4 text-sm ${detailsError ? "text-red-600" : "text-zinc-500"}`}>
-                  {detailsError || detailsNotice}
-                </p>
-              )}
-
-              <div className="space-y-6">
-                <div>
-                  <h4 className="mb-3 text-sm font-semibold text-zinc-700">Show Info</h4>
-                  <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
-                    <div className="grid gap-4 md:grid-cols-2">
-                      <div className="md:col-span-2">
-                        <p className="mb-1 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          Display Name
-                        </p>
-                        <p className="text-sm text-zinc-900">{show.name || "Not set"}</p>
-                      </div>
-                      <div>
-                        <p className="mb-1 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          Nickname
-                        </p>
-                        <p className="text-sm text-zinc-900">{detailsBaseline.nickname || "Not set"}</p>
-                      </div>
-                      <div>
-                        <p className="mb-1 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          Premiere Date
-                        </p>
-                        <p className="text-sm text-zinc-900">
-                          {show.premiere_date
-                            ? new Date(show.premiere_date).toLocaleDateString("en-US", {
-                                year: "numeric",
-                                month: "long",
-                                day: "numeric",
-                              })
-                            : "Not set"}
-                        </p>
-                      </div>
-                      <div className="md:col-span-2">
-                        <p className="mb-1 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          Alt Names
-                        </p>
-                        <p className="text-sm text-zinc-900 whitespace-pre-line">
-                          {overviewAlternativeNamesText || "None"}
-                        </p>
-                      </div>
-                      <div className="md:col-span-2">
-                        <p className="mb-1 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          Description
-                        </p>
-                        <p className="text-sm leading-6 text-zinc-900">
-                          {show.description || "No description available."}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                <div>
-                  <h4 className="mb-3 text-sm font-semibold text-zinc-700">External IDs</h4>
-                  <div className="space-y-3 rounded-lg border border-zinc-200 bg-zinc-50 p-4">
-                    <ExternalLinks
-                      externalIds={(show.external_ids as Record<string, unknown> | null) ?? null}
-                      tmdbId={show.tmdb_id}
-                      imdbId={show.imdb_id}
-                      derivedLinks={show.derived_external_links ?? null}
-                      type="show"
-                    />
-                    {overviewExternalIdLinks.length > 0 ? (
-                      <div className="space-y-2">
-                        {overviewExternalIdLinks.map((link) => (
-                          <a
-                            key={`overview-external-id-link-${link.id}`}
-                            href={link.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="inline-flex min-w-0 max-w-full items-center gap-2 rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs font-semibold text-zinc-700 hover:bg-zinc-100"
-                          >
-                            <SourceBadge
-                              kind={getLinkSourceBadgeKind(link)}
-                              label={getLinkSourceLabel(link)}
-                              iconUrl={getLinkSourceBadgeKind(link) === "fandom" ? buildHostFaviconUrl(link.url) : null}
-                              iconOnly={usesBrandIconOnly(getLinkSourceBadgeKind(link))}
-                            />
-                            <span className="text-zinc-300">|</span>
-                            <span className="truncate">{getShowPageLinkTitle(link, show.name)}</span>
-                          </a>
-                        ))}
-                      </div>
-                    ) : (
-                      !show.tmdb_id &&
-                      !show.imdb_id && (
-                        <p className="text-sm text-zinc-500">No external IDs available for this show.</p>
-                      )
-                    )}
-                  </div>
-                </div>
-
-                <div>
-                  <h4 className="mb-3 text-sm font-semibold text-zinc-700">Social Handles</h4>
-                  <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
-                    {overviewSocialHandleLinks.length === 0 ? (
-                      <p className="text-sm text-zinc-500">No show-level social handles discovered yet.</p>
-                    ) : (
-                      <div className="flex flex-wrap gap-2">
-                        {overviewSocialHandleLinks.map((pill) => (
-                          <SocialHandlePill key={`overview-social-link-${pill.id}`} pill={pill} />
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </div>
-
-                <div>
-                  <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-                    <h4 className="text-sm font-semibold text-zinc-700">Reddit</h4>
-                    <Link
-                      href={"/admin/social/reddit"}
-                      className="rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-semibold text-zinc-700 hover:bg-zinc-50"
-                    >
-                      Open Reddit Admin
-                    </Link>
-                  </div>
-                  <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
-                    {redditLoading ? (
-                      <p className="text-sm text-zinc-500">Loading Reddit communities...</p>
-                    ) : redditError ? (
-                      <p className="text-sm text-red-600">{redditError}</p>
-                    ) : overviewRedditGroups.length === 0 ? (
-                      <p className="text-sm text-zinc-500">No relevant Reddit communities configured for this show.</p>
-                    ) : (
-                      <div className="space-y-4">
-                        {overviewRedditGroups.map((group) => (
-                          <div key={`overview-reddit-group-${group.key}`} className="space-y-2">
-                            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                              {group.label}
-                            </p>
-                            <div className="grid gap-3 md:grid-cols-2">
-                              {group.communities.map((community) => (
-                                <div
-                                  key={`overview-reddit-community-${community.id}`}
-                                  className="rounded-lg border border-zinc-200 bg-white p-3"
-                                >
-                                  <div className="flex flex-wrap items-center justify-between gap-2">
-                                    <div>
-                                      <p className="text-sm font-semibold text-zinc-900">{community.displayName}</p>
-                                      <p className="text-xs text-zinc-500">r/{community.subreddit}</p>
-                                    </div>
-                                    <Link
-                                      href={buildAdminRedditCommunityUrl({
-                                        communitySlug: community.subreddit,
-                                        showSlug: showSlugForRouting,
-                                      })}
-                                      className="rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-1.5 text-xs font-semibold text-zinc-700 hover:bg-zinc-100"
-                                    >
-                                      Open Community
-                                    </Link>
-                                  </div>
-                                  <div className="mt-3 flex flex-wrap gap-1.5">
-                                    {community.assignedFlairs.length > 0 ? (
-                                      community.assignedFlairs.map((flair) => (
-                                        <span
-                                          key={`overview-reddit-flair-${community.id}-${flair}`}
-                                          className="rounded-full border border-zinc-200 bg-zinc-50 px-2 py-0.5 text-[11px] font-semibold text-zinc-700"
-                                        >
-                                          {flair}
-                                        </span>
-                                      ))
-                                    ) : (
-                                      <span className="text-xs text-zinc-500">No assigned flairs</span>
-                                    )}
-                                  </div>
-                                </div>
-                              ))}
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </div>
-
-                <div>
-                  <h4 className="mb-3 text-sm font-semibold text-zinc-700">Season URL Coverage</h4>
-                  <div className="space-y-2 rounded-lg border border-zinc-200 bg-zinc-50 p-4">
-                    {seasonUrlCoverageRows.length === 0 ? (
-                      <p className="text-sm text-zinc-500">No seasons available for URL coverage yet.</p>
-                    ) : (
-                      seasonUrlCoverageRows.map((row) => (
-                        <div
-                          key={`overview-season-url-coverage-${row.seasonNumber}`}
-                          className="rounded-lg border border-zinc-200 bg-white px-3 py-2"
-                        >
-                          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
-                            Season {row.seasonNumber}
-                          </p>
-                          {row.links.length === 0 ? (
-                            <p className="mt-1 text-sm text-zinc-500">No validated season-scoped URLs discovered.</p>
-                          ) : (
-                            <div className="mt-2 flex flex-wrap items-center gap-2">
-                              {row.links.map((link) => (
-                                <a
-                                  key={`overview-season-url-pill-${row.seasonNumber}-${link.id}`}
-                                  href={link.url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="inline-flex items-center rounded-full border border-zinc-200 bg-zinc-50 px-2 py-1 text-xs font-semibold text-zinc-700 hover:bg-zinc-100"
-                                  title={`${link.sourceLabel} | ${link.linkTitle || `Season ${row.seasonNumber}`}`}
-                                >
-                                  <SourceBadge
-                                    kind={link.sourceKind}
-                                    label={link.sourceLabel}
-                                    iconUrl={link.iconUrl}
-                                    iconOnly={true}
-                                  />
-                                </a>
-                              ))}
-                            </div>
-                          )}
-                        </div>
-                      ))
-                    )}
-                  </div>
-                </div>
-
-                {/* Genres */}
-                {show.genres && show.genres.length > 0 && (
-                  <div>
-                    <h4 className="mb-3 text-sm font-semibold text-zinc-700">
-                      Genres
-                    </h4>
-                    <div className="flex flex-wrap gap-2">
-                      {show.genres.map((genre) => (
-                        <span
-                          key={genre}
-                          className="rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1 text-sm text-zinc-700"
-                        >
-                          {genre}
-                        </span>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                <div>
-                  <h4 className="mb-3 text-sm font-semibold text-zinc-700">
-                    Networks & Streaming
-                  </h4>
-                  <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
-                    <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                      Networks
-                    </p>
-                    <div className="mb-4 flex flex-wrap gap-2">
-                      {overviewNetworks.length > 0 ? (
-                        overviewNetworks.map((network) => (
-                          <span
-                            key={network}
-                            className="rounded-full border border-zinc-200 bg-white px-3 py-1 text-sm text-zinc-700"
-                          >
-                            {network}
-                          </span>
-                        ))
-                      ) : (
-                        <p className="text-sm text-zinc-500">No network metadata.</p>
-                      )}
-                    </div>
-                    <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                      Availability
-                    </p>
-                    {watchProviderRegions.length > 0 ? (
-                      <div className="space-y-3">
-                        <div className="flex flex-wrap items-center gap-2">
-                          <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-500">
-                            Region
-                          </span>
-                          <div className="relative inline-flex">
-                            <select
-                              aria-label="Availability region"
-                              className="appearance-none rounded-full border border-zinc-200 bg-white px-3 py-1 pr-8 text-sm font-medium text-zinc-700 shadow-sm"
-                              value={selectedAvailabilityRegion?.regionCode ?? ""}
-                              onChange={(event) => setSelectedAvailabilityRegionCode(event.target.value)}
-                            >
-                              {watchProviderRegionOptions.map((option) => (
-                                <option key={`availability-region-${option.regionCode}`} value={option.regionCode}>
-                                  {option.regionCode} · {option.regionLabel}
-                                </option>
-                              ))}
-                            </select>
-                            <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-xs text-zinc-500">
-                              ▾
-                            </span>
-                          </div>
-                        </div>
-                        {selectedAvailabilityRegion ? (
-                          <div className="rounded-lg border border-zinc-200 bg-white p-3">
-                            <p className="text-sm font-semibold text-zinc-900">
-                              {selectedAvailabilityRegion.regionLabel}
-                            </p>
-                            <div className="mt-3 space-y-3">
-                              <div>
-                                <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-500">
-                                  Stream
-                                </p>
-                                <div className="mt-1 flex flex-wrap gap-1.5">
-                                  {selectedAvailabilityRegion.stream.length > 0 ? (
-                                    selectedAvailabilityRegion.stream.map((provider) => (
-                                      <span
-                                        key={`overview-watch-stream-${selectedAvailabilityRegion.regionCode}-${provider}`}
-                                        className="rounded-full border border-zinc-200 bg-zinc-50 px-2 py-0.5 text-[11px] font-semibold text-zinc-700"
-                                      >
-                                        {provider}
-                                      </span>
-                                    ))
-                                  ) : (
-                                    <span className="text-xs text-zinc-500">None</span>
-                                  )}
-                                </div>
-                              </div>
-                              <div>
-                                <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-500">
-                                  Free
-                                </p>
-                                <div className="mt-1 flex flex-wrap gap-1.5">
-                                  {selectedAvailabilityRegion.free.length > 0 ? (
-                                    selectedAvailabilityRegion.free.map((provider) => (
-                                      <span
-                                        key={`overview-watch-free-${selectedAvailabilityRegion.regionCode}-${provider}`}
-                                        className="rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700"
-                                      >
-                                        {provider}
-                                      </span>
-                                    ))
-                                  ) : (
-                                    <span className="text-xs text-zinc-500">None</span>
-                                  )}
-                                </div>
-                              </div>
-                              <div>
-                                <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-500">
-                                  Rent / Buy
-                                </p>
-                                <div className="mt-1 flex flex-wrap gap-1.5">
-                                  {selectedAvailabilityRegion.buyRent.length > 0 ? (
-                                    selectedAvailabilityRegion.buyRent.map((provider) => (
-                                      <span
-                                        key={`overview-watch-buy-rent-${selectedAvailabilityRegion.regionCode}-${provider}`}
-                                        className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-semibold text-amber-700"
-                                      >
-                                        {provider}
-                                      </span>
-                                    ))
-                                  ) : (
-                                    <span className="text-xs text-zinc-500">None</span>
-                                  )}
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        ) : null}
-                      </div>
-                    ) : (
-                      <div className="space-y-3">
-                        <div className="flex flex-wrap gap-2">
-                          {fallbackWatchProviders.length > 0 ? (
-                            fallbackWatchProviders.map((provider) => (
-                              <span
-                                key={`overview-watch-fallback-${provider}`}
-                                className="rounded-full border border-zinc-200 bg-white px-3 py-1 text-sm text-zinc-700"
-                              >
-                                {provider}
-                              </span>
-                            ))
-                          ) : (
-                            <p className="text-sm text-zinc-500">No streaming providers on this record.</p>
-                          )}
-                        </div>
-                        <p className="text-xs text-zinc-500">
-                          Typed TMDb availability is unavailable for this show.
-                        </p>
-                      </div>
-                    )}
-                  </div>
-                </div>
-
-                {/* Tags */}
-                {show.tags && show.tags.length > 0 && (
-                  <div>
-                    <h4 className="mb-3 text-sm font-semibold text-zinc-700">
-                      Tags
-                    </h4>
-                    <div className="flex flex-wrap gap-2">
-                      {show.tags.map((tag) => (
-                        <span
-                          key={tag}
-                          className="rounded-full bg-blue-50 border border-blue-200 px-3 py-1 text-sm text-blue-700"
-                        >
-                          {tag}
-                        </span>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {/* Premiere Date */}
-                {show.premiere_date && (
-                  <div>
-                    <h4 className="mb-3 text-sm font-semibold text-zinc-700">
-                      Premiere Date
-                    </h4>
-                    <p className="text-sm text-zinc-700">
-                      {new Date(show.premiere_date).toLocaleDateString("en-US", {
-                        year: "numeric",
-                        month: "long",
-                        day: "numeric",
-                      })}
-                    </p>
-                  </div>
-                )}
-
-                <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
-                  <p className="text-sm text-zinc-700">
-                    Link management and role catalog tools are now on the <span className="font-semibold">Settings</span> tab.
-                  </p>
-                  <button
-                    type="button"
-                    onClick={() => setTab("settings")}
-                    className="mt-3 rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-semibold text-zinc-700 hover:bg-zinc-100"
-                  >
-                    Open Settings
-                  </button>
-                </div>
-
-                {/* Internal ID */}
-                <div>
-                  <h4 className="mb-3 text-sm font-semibold text-zinc-700">
-                    Internal ID
-                  </h4>
-                  <code className="text-xs bg-zinc-100 rounded px-2 py-1 text-zinc-600 font-mono">
-                    {show.id}
-                  </code>
-                </div>
-
-                <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
-                  <p className="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                    Show Visibility
-                  </p>
-                  {isCovered ? (
-                    <button type="button"
-                      onClick={removeFromCoveredShows}
-                      disabled={coverageLoading}
-                      className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 px-4 py-2 text-sm font-semibold text-green-700 transition hover:bg-green-100 disabled:opacity-50"
-                    >
-                      <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
-                        <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                      </svg>
-                      {coverageLoading ? "..." : "Remove from Shows"}
-                    </button>
-                  ) : (
-                    <button type="button"
-                      onClick={addToCoveredShows}
-                      disabled={coverageLoading}
-                      className="flex items-center gap-2 rounded-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-zinc-800 disabled:opacity-50"
-                    >
-                      <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-                      </svg>
-                      {coverageLoading ? "..." : "Add to Shows"}
-                    </button>
-                  )}
-                  {coverageError && (
-                    <p className="mt-2 text-xs font-medium text-rose-700">{coverageError}</p>
-                  )}
-                </div>
-              </div>
-            </div>
-            </ShowOverviewTab>
+              networks={overviewNetworks}
+              watchProviderRegions={watchProviderRegions}
+              watchProviderRegionOptions={watchProviderRegionOptions}
+              selectedAvailabilityRegion={selectedAvailabilityRegion}
+              fallbackWatchProviders={fallbackWatchProviders}
+              isCovered={isCovered}
+              coverageLoading={coverageLoading}
+              coverageError={coverageError}
+              onOpenSettings={() => setTab("settings")}
+              onOpenRefreshLog={() => setRefreshLogOpen(true)}
+              onSelectAvailabilityRegion={setSelectedAvailabilityRegionCode}
+              onAddToCoveredShows={addToCoveredShows}
+              onRemoveFromCoveredShows={removeFromCoveredShows}
+            />
           )}
         </main>
 
@@ -15365,302 +11810,58 @@ export default function TrrShowDetailPage() {
           />
         )}
 
-        <AdminModal
-          isOpen={linksRefreshModalOpen}
-          onClose={() => setLinksRefreshModalOpen(false)}
-          closeLabel="Close links discovery progress"
-          ariaLabel="Links discovery progress"
-          panelClassName="max-h-[90vh] max-w-3xl overflow-y-auto"
-          preserveScrollPosition={true}
-        >
-          <div className="mb-4 flex items-start justify-between gap-4">
-            <div>
-              <h3 className="text-lg font-bold text-zinc-900">Links Discovery</h3>
-              <p className="text-sm text-zinc-500">
-                Remote worker-backed refresh for show, season, and cast member pages.
-              </p>
-            </div>
-            <div className="flex items-center gap-2">
-              {canCancelLinksRefresh && (
-                <button
-                  type="button"
-                  onClick={() => void cancelShowLinksRefresh()}
-                  disabled={linksRefreshCancelling}
-                  className="rounded-md border border-rose-200 bg-rose-50 px-3 py-1 text-sm font-semibold text-rose-700 hover:bg-rose-100 disabled:opacity-50"
-                >
-                  {linksRefreshCancelButtonLabel}
-                </button>
-              )}
-              <span
-                className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] ${
-                  linksRefreshStatus === "completed"
-                    ? "border-emerald-200 bg-emerald-50 text-emerald-700"
-                    : linksRefreshStatus === "failed" || linksRefreshStatus === "cancelled"
-                      ? "border-rose-200 bg-rose-50 text-rose-700"
-                      : linksRefreshStatus === "running"
-                        ? "border-blue-200 bg-blue-50 text-blue-700"
-                        : "border-zinc-200 bg-zinc-50 text-zinc-600"
-                }`}
-              >
-                {linksRefreshStatus ?? "queued"}
-              </span>
-              <button
-                type="button"
-                onClick={() => setLinksRefreshModalOpen(false)}
-                className="rounded-md border border-zinc-200 px-3 py-1 text-sm font-semibold text-zinc-600 hover:bg-zinc-50"
-              >
-                Close
-              </button>
-            </div>
-          </div>
+        <ShowLinksDiscoveryModal
+          dialog={{
+            open: linksRefreshModalOpen,
+            onClose: () => setLinksRefreshModalOpen(false),
+            status: linksRefreshStatus,
+            error: linksError,
+            notice: linksNotice,
+            completionNotice: linksRefreshCompletionNotice,
+          }}
+          cancellation={{
+            visible: canCancelLinksRefresh,
+            pending: linksRefreshCancelling,
+            buttonLabel: linksRefreshCancelButtonLabel,
+            onCancel: () => void cancelShowLinksRefresh(),
+          }}
+          execution={{
+            runLabel: linksRefreshRunId ? `Run ${shortenAdminToken(linksRefreshRunId)}` : "Pending",
+            operationLabel: linksRefreshOperationId
+              ? `Op ${shortenAdminToken(linksRefreshOperationId)}`
+              : "Pending",
+            owner: linksRefreshExecutionOwner,
+            backend: linksRefreshExecutionBackend,
+            mode: linksRefreshExecutionMode,
+          }}
+          progress={{
+            summary: linksRefreshSummary,
+            refreshing: linksRefreshing,
+            timeoutMessage: linksRefreshTimeoutMessage,
+            stalled: linksRefreshStalled,
+            stalledReason: linksRefreshStalledReason,
+            lastUpdateLabel: linksRefreshLastUpdateLabel,
+            lastStageChangeLabel: linksRefreshLastStageChangeLabel,
+            validatedSourceCounts: linksRefreshValidatedSourceCounts,
+            deletedSourceCounts: linksRefreshDeletedSourceCounts,
+            hasResult: Boolean(linksRefreshResult),
+          }}
+        />
 
-          {(linksError || linksNotice || linksRefreshCompletionNotice) && (
-            <p className={`mb-4 text-sm ${linksError ? "text-red-600" : "text-zinc-600"}`}>
-              {linksError || linksRefreshCompletionNotice || linksNotice}
-            </p>
-          )}
-
-          <section className="mb-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-            <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-3">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">Run ID</p>
-              <p className="mt-1 text-sm font-semibold text-zinc-900">
-                {linksRefreshRunId ? `Run ${shortenAdminToken(linksRefreshRunId)}` : "Pending"}
-              </p>
-            </div>
-            <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-3">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">Operation ID</p>
-              <p className="mt-1 text-sm font-semibold text-zinc-900">
-                {linksRefreshOperationId ? `Op ${shortenAdminToken(linksRefreshOperationId)}` : "Pending"}
-              </p>
-            </div>
-            <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-3">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">Execution</p>
-              <p className="mt-1 text-sm font-semibold text-zinc-900">
-                {linksRefreshExecutionOwner === "remote_worker"
-                  ? "remote worker"
-                  : linksRefreshExecutionOwner || "Awaiting worker"}
-              </p>
-              {(linksRefreshExecutionBackend || linksRefreshExecutionMode) && (
-                <p className="mt-1 text-xs text-zinc-500">
-                  {[linksRefreshExecutionBackend, linksRefreshExecutionMode ? `mode ${linksRefreshExecutionMode}` : null]
-                    .filter((value): value is string => Boolean(value))
-                    .join(" · ")}
-                </p>
-              )}
-            </div>
-            <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-3">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">Status</p>
-              <p className="mt-1 text-sm font-semibold text-zinc-900">
-                {linksRefreshSummary?.stageLabel || "Discovery"}
-              </p>
-              <p className="mt-1 text-xs text-zinc-500">
-                {linksRefreshSummary?.elapsedLabel || "Waiting for stream updates"}
-              </p>
-            </div>
-          </section>
-
-          <section className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm">
-            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-zinc-400">Progress</p>
-            {linksRefreshSummary ? (
-              <div className="mt-3 space-y-3">
-                <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-3">
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div>
-                      <p className="text-sm font-semibold text-zinc-900">{linksRefreshSummary.headline}</p>
-                      {linksRefreshSummary.detail && (
-                        <p className="mt-1 text-sm text-zinc-600">{linksRefreshSummary.detail}</p>
-                      )}
-                    </div>
-                    <div className="text-right text-xs text-zinc-500">
-                      {linksRefreshSummary.stageElapsedLabel && <p>{linksRefreshSummary.stageElapsedLabel}</p>}
-                      {linksRefreshSummary.elapsedLabel && <p>{linksRefreshSummary.elapsedLabel}</p>}
-                    </div>
-                  </div>
-                  {(linksRefreshSummary.targetSummary ||
-                    linksRefreshSummary.stageProgressLabel ||
-                    linksRefreshSummary.currentTargetLabel ||
-                    linksRefreshSummary.budgetLabel) && (
-                    <div className="mt-3 space-y-1 text-sm text-zinc-600">
-                      {linksRefreshSummary.targetSummary && <p>{linksRefreshSummary.targetSummary}</p>}
-                      {linksRefreshSummary.stageProgressLabel && <p>{linksRefreshSummary.stageProgressLabel}</p>}
-                      {linksRefreshSummary.currentTargetLabel && (
-                        <p>
-                          Checking: <span className="font-semibold text-zinc-900">{linksRefreshSummary.currentTargetLabel}</span>
-                        </p>
-                      )}
-                      {linksRefreshSummary.budgetLabel && <p className="text-amber-700">{linksRefreshSummary.budgetLabel}</p>}
-                    </div>
-                  )}
-                  {linksRefreshSummary.metrics.length > 0 && (
-                    <div className="mt-3 flex flex-wrap gap-2">
-                      {linksRefreshSummary.metrics.map((metric) => (
-                        <span
-                          key={`${metric.label}:${metric.value}`}
-                          className="rounded-full border border-zinc-200 bg-white px-2.5 py-1 text-[11px] font-semibold text-zinc-700"
-                        >
-                          {metric.label}: {metric.value}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                </div>
-
-                {Boolean(linksRefreshLatestPayload?.timeout) && typeof linksRefreshLatestPayload?.timeout === "object" && (
-                  <div className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
-                    {typeof (linksRefreshLatestPayload.timeout as Record<string, unknown>).detail === "string"
-                      ? String((linksRefreshLatestPayload.timeout as Record<string, unknown>).detail)
-                      : "Discovery reported a timeout condition."}
-                  </div>
-                )}
-
-                <div className="grid gap-3 lg:grid-cols-2">
-                  <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-3">
-                    <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">Worker Monitor</p>
-                    <div className="mt-2 space-y-1 text-sm text-zinc-700">
-                      <p>
-                        Worker health:{" "}
-                        <span className={linksRefreshStalled ? "font-semibold text-amber-700" : "font-semibold text-emerald-700"}>
-                          {linksRefreshStalled ? "Stalled" : "Healthy"}
-                        </span>
-                      </p>
-                      {linksRefreshLastUpdateLabel && <p>Last stream update: {linksRefreshLastUpdateLabel}</p>}
-                      {linksRefreshLastStageChangeLabel && <p>Last stage change: {linksRefreshLastStageChangeLabel}</p>}
-                      {linksRefreshStalledReason && (
-                        <p className="text-amber-700">
-                          Reason: <span className="font-semibold">{linksRefreshStalledReason}</span>
-                        </p>
-                      )}
-                    </div>
-                  </div>
-
-                  {(linksRefreshValidatedSourceCounts.length > 0 || linksRefreshDeletedSourceCounts.length > 0) && (
-                    <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-3">
-                      <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                        Correct / Live by Source
-                      </p>
-                      {linksRefreshValidatedSourceCounts.length > 0 ? (
-                        <div className="mt-2 flex flex-wrap gap-2">
-                          {linksRefreshValidatedSourceCounts.map((entry) => (
-                            <span
-                              key={`links-live-source-${entry.key}`}
-                              className="rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-[11px] font-semibold text-emerald-700"
-                            >
-                              {entry.label}: {entry.count}
-                            </span>
-                          ))}
-                        </div>
-                      ) : (
-                        <p className="mt-2 text-sm text-zinc-500">No validated live source counts reported yet.</p>
-                      )}
-                      {linksRefreshDeletedSourceCounts.length > 0 && (
-                        <div className="mt-3">
-                          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
-                            Invalid Deleted
-                          </p>
-                          <div className="mt-2 flex flex-wrap gap-2">
-                            {linksRefreshDeletedSourceCounts.map((entry) => (
-                              <span
-                                key={`links-deleted-source-${entry.key}`}
-                                className="rounded-full border border-rose-200 bg-rose-50 px-2.5 py-1 text-[11px] font-semibold text-rose-700"
-                              >
-                                {entry.label}: {entry.count}
-                              </span>
-                            ))}
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </div>
-
-                {linksRefreshResult && (
-                  <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-3">
-                    <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">Result</p>
-                    <p className="mt-1 text-sm text-zinc-700">
-                      {linksRefreshCompletionNotice || "Links discovery finished."}
-                    </p>
-                    {linksRefreshValidatedSourceCounts.length > 0 && (
-                      <div className="mt-3 flex flex-wrap gap-2">
-                        {linksRefreshValidatedSourceCounts.map((entry) => (
-                          <span
-                            key={`links-result-live-source-${entry.key}`}
-                            className="rounded-full border border-emerald-200 bg-white px-2.5 py-1 text-[11px] font-semibold text-emerald-700"
-                          >
-                            {entry.label}: {entry.count} live
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                    {linksRefreshDeletedSourceCounts.length > 0 && (
-                      <div className="mt-3 flex flex-wrap gap-2">
-                        {linksRefreshDeletedSourceCounts.map((entry) => (
-                          <span
-                            key={`links-result-deleted-source-${entry.key}`}
-                            className="rounded-full border border-rose-200 bg-white px-2.5 py-1 text-[11px] font-semibold text-rose-700"
-                          >
-                            {entry.label}: {entry.count} invalid deleted
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-            ) : (
-              <p className="mt-3 text-sm text-zinc-500">
-                {linksRefreshing ? "Waiting for worker progress..." : "Start a links refresh to see live updates here."}
-              </p>
-            )}
-          </section>
-        </AdminModal>
-
-        <AdminModal
-          isOpen={refreshLogOpen}
-          onClose={() => setRefreshLogOpen(false)}
-          closeLabel="Close health center"
-          ariaLabel="Health Center"
-          panelClassName="max-h-[90vh] max-w-5xl overflow-y-auto"
-          preserveScrollPosition={true}
-        >
-              <div className="mb-4 flex items-start justify-between gap-4">
-                <div>
-                  <h3 className="text-lg font-bold text-zinc-900">Health Center</h3>
-                  <p className="text-sm text-zinc-500">
-                    Content Health, Sync Pipeline, Operations Inbox, and Refresh Log.
-                  </p>
-                </div>
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      if (refreshingShowAll) return;
-                      captureHealthCenterScrollPosition();
-                      void refreshAllShowData();
-                    }}
-                    aria-disabled={refreshingShowAll}
-                    className={`rounded-md px-3 py-1 text-sm font-semibold text-white ${
-                      refreshingShowAll
-                        ? "cursor-not-allowed bg-zinc-500"
-                        : "bg-zinc-900 hover:bg-zinc-800"
-                    }`}
-                  >
-                    {refreshRunButtonLabel}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setRefreshLogOpen(false)}
-                    className="rounded-md border border-zinc-200 px-3 py-1 text-sm font-semibold text-zinc-600 hover:bg-zinc-50"
-                  >
-                    Close
-                  </button>
-                </div>
-              </div>
-
-              {(refreshAllNotice || refreshAllError) && (
-                <p className={`mb-4 text-sm ${refreshAllError ? "text-red-600" : "text-zinc-500"}`}>
-                  {refreshAllError || refreshAllNotice}
-                </p>
-              )}
+        <ShowHealthCenterModal
+          dialog={{
+            open: refreshLogOpen,
+            onClose: () => setRefreshLogOpen(false),
+            onRun: () => {
+              if (refreshingShowAll) return;
+              captureHealthCenterScrollPosition();
+              void refreshAllShowData();
+            },
+            runDisabled: refreshingShowAll,
+            runButtonLabel: refreshRunButtonLabel,
+            notice: refreshAllNotice,
+            error: refreshAllError,
+            progressContent: (
               <RefreshProgressBar
                 show={refreshingShowAll}
                 stage={refreshAllProgress?.stage}
@@ -15668,1478 +11869,148 @@ export default function TrrShowDetailPage() {
                 current={refreshAllProgress?.current}
                 total={refreshAllProgress?.total}
               />
-
-              <section className="mb-6 rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm">
-                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-zinc-400">
-                  Content Health
-                </p>
-                <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-7">
-                  {contentHealthItems.map((item) => (
-                    <button
-                      key={item.key}
-                      type="button"
-                      onClick={item.onClick}
-                      className={`rounded-xl border px-3 py-2 text-left transition hover:shadow-sm ${healthBadgeClassName(
-                        item.status
-                      )}`}
-                    >
-                      <p className="text-[11px] font-semibold uppercase tracking-[0.16em]">
-                        {item.label}
-                      </p>
-                      <p className="mt-1 text-sm font-semibold">
-                        {item.status === "ready"
-                          ? "Ready"
-                          : item.status === "stale"
-                            ? "Stale"
-                            : "Missing"}
-                      </p>
-                      <p className="mt-1 text-xs opacity-80">{item.countLabel}</p>
-                    </button>
-                  ))}
-                </div>
-              </section>
-
-              <section className="mb-6 grid gap-4 lg:grid-cols-[1.3fr_1fr]">
-                <div className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm">
-                  <p className="mb-3 text-xs font-semibold uppercase tracking-[0.3em] text-zinc-400">
-                    Sync Pipeline
-                  </p>
-                  <div className="space-y-2">
-                    {pipelineSteps.map((step) => {
-                      const latestParts = step.latest ? extractRefreshLogSubJob(step.latest) : null;
-                      const statusPillClass =
-                        step.status === "done"
-                          ? "border-emerald-200 bg-emerald-50 text-emerald-700"
-                          : step.status === "active"
-                            ? "border-blue-200 bg-blue-50 text-blue-700"
-                            : step.status === "failed"
-                              ? "border-rose-200 bg-rose-50 text-rose-700"
-                              : "border-zinc-200 bg-zinc-50 text-zinc-600";
-                      const statusText =
-                        step.status === "done"
-                          ? "Done"
-                          : step.status === "active"
-                            ? "Running"
-                            : step.status === "failed"
-                              ? "Failed"
-                              : "Queued";
-                      return (
-                        <div
-                          key={step.topic.key}
-                          className="flex items-center justify-between gap-3 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2"
-                        >
-                          <div className="min-w-0">
-                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-700">
-                              {step.topic.label}
-                              {step.executionOwner && (
-                                <span className="text-xs text-zinc-500 ml-1">
-                                  ({step.executionOwner === "remote_worker" ? "Modal" : step.executionOwner})
-                                </span>
-                              )}
-                            </p>
-                            <p className="truncate text-[11px] text-zinc-500">{step.topic.description}</p>
-                            <p className="truncate text-[11px] text-zinc-600">
-                              {latestParts?.details ?? "No updates yet."}
-                            </p>
-                          </div>
-                          <div className="shrink-0 text-right">
-                            <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${statusPillClass}`}>
-                              {statusText}
-                            </span>
-                            {step.status === "failed" && step.parentOperationId && (
-                              <button type="button"
-                                className="text-xs text-blue-500 hover:text-blue-700 ml-2"
-                                onClick={() => retryRefreshTarget(step.topic.key, step.parentOperationId!)}
-                              >
-                                Retry
-                              </button>
-                            )}
-                            {step.latest && (
-                              <p className="mt-1 text-[10px] text-zinc-400">
-                                {new Date(step.latest.at).toLocaleTimeString()}
-                              </p>
-                            )}
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                </div>
-
-                <div className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm">
-                  <p className="text-xs font-semibold uppercase tracking-[0.3em] text-zinc-400">
-                    Operations Inbox
-                  </p>
-                  {operationsInboxItems.length === 0 ? (
-                    <p className="mt-3 text-sm text-emerald-700">No blocking tasks.</p>
-                  ) : (
-                    <div className="mt-3 space-y-2">
-                      {operationsInboxItems.map((item) => (
-                        <button
-                          key={item.id}
-                          type="button"
-                          onClick={item.onClick}
-                          className="w-full rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-left transition hover:bg-amber-100"
-                        >
-                          <p className="text-sm font-semibold text-amber-800">{item.title}</p>
-                          <p className="mt-1 text-xs text-amber-700">{item.detail}</p>
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </section>
-
-              <section className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm">
-                <p className="mb-3 text-xs font-semibold uppercase tracking-[0.3em] text-zinc-400">
-                  Refresh Log
-                </p>
-                {refreshLogEntries.length === 0 ? (
-                  <p className="text-xs text-zinc-500">No refresh activity yet.</p>
-                ) : (
-                  <div className="max-h-[44vh] space-y-3 overflow-y-auto pr-1">
-                    {refreshLogTopicGroups.map(({ topic, entries, entriesForView, latest, status }) => {
-                      const latestParts = latest ? extractRefreshLogSubJob(latest) : null;
-                      const latestPercent =
-                        latest &&
-                        typeof latest.current === "number" &&
-                        typeof latest.total === "number" &&
-                        latest.total > 0
-                          ? Math.min(100, Math.round((latest.current / latest.total) * 100))
-                          : null;
-
-                      if (status === "done") {
-                        return (
-                          <article
-                            key={topic.key}
-                            className="rounded-lg border border-green-200 bg-green-50 px-3 py-2"
-                          >
-                            <p className="text-xs font-semibold text-green-800">
-                              {topic.label}: Done ✔️
-                            </p>
-                          </article>
-                        );
-                      }
-
-                      return (
-                        <article key={topic.key} className="rounded-lg border border-zinc-200 bg-zinc-50 p-3">
-                          <div className="flex items-start justify-between gap-3">
-                            <div>
-                              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-600">
-                                {topic.label}
-                              </p>
-                              <p className="text-[11px] text-zinc-500">{topic.description}</p>
-                            </div>
-                            {latest && (
-                              <p className="text-[10px] text-zinc-400">
-                                {new Date(latest.at).toLocaleTimeString()}
-                              </p>
-                            )}
-                          </div>
-
-                          {status === "failed" && (
-                            <p className="mt-2 text-xs font-semibold text-red-700">
-                              {topic.label}: Failed ✖
-                            </p>
-                          )}
-
-                          {latest ? (
-                            <div className="mt-2 rounded-md border border-zinc-200 bg-white p-2">
-                              <p className="text-xs font-semibold text-zinc-800">{latestParts?.subJob}</p>
-                              <p className="mt-1 text-xs text-zinc-600">{latestParts?.details}</p>
-                              {typeof latest.current === "number" &&
-                                typeof latest.total === "number" && (
-                                  <p className="mt-1 text-[11px] text-zinc-500">
-                                    {latest.current.toLocaleString()}/{latest.total.toLocaleString()}
-                                    {latestPercent !== null ? ` (${latestPercent}%)` : ""}
-                                  </p>
-                                )}
-                            </div>
-                          ) : (
-                            <p className="mt-2 text-xs text-zinc-500">No updates yet.</p>
-                          )}
-
-                          {entries.length > 0 && (
-                            <details className="mt-2" open={entries.length <= 3}>
-                              <summary className="cursor-pointer text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-500">
-                                Sub-jobs ({entries.length})
-                              </summary>
-                              <div className="mt-2 space-y-1">
-                                {entriesForView.slice(0, 30).map((entry) => {
-                                  const parts = extractRefreshLogSubJob(entry);
-                                  const percent =
-                                    typeof entry.current === "number" &&
-                                    typeof entry.total === "number" &&
-                                    entry.total > 0
-                                      ? Math.min(100, Math.round((entry.current / entry.total) * 100))
-                                      : null;
-                                  return (
-                                    <div
-                                      key={entry.id}
-                                      className="rounded border border-zinc-100 bg-white px-2 py-1.5"
-                                    >
-                                      <div className="flex items-center justify-between gap-2">
-                                        <p className="text-[11px] font-semibold text-zinc-700">
-                                          {parts.subJob}
-                                        </p>
-                                        <p className="text-[10px] text-zinc-400">
-                                          {new Date(entry.at).toLocaleTimeString()}
-                                        </p>
-                                      </div>
-                                      <p className="mt-0.5 text-[11px] text-zinc-600">{parts.details}</p>
-                                      {typeof entry.current === "number" &&
-                                        typeof entry.total === "number" && (
-                                          <p className="mt-0.5 text-[10px] text-zinc-500">
-                                            {entry.current.toLocaleString()}/{entry.total.toLocaleString()}
-                                            {percent !== null ? ` (${percent}%)` : ""}
-                                          </p>
-                                        )}
-                                    </div>
-                                  );
-                                })}
-                              </div>
-                            </details>
-                          )}
-                        </article>
-                      );
-                    })}
-                  </div>
-                )}
-              </section>
-        </AdminModal>
-
-        <AdminModal
-          isOpen={syncBravoModePickerOpen}
-          onClose={() => setSyncBravoModePickerOpen(false)}
-          closeLabel="Close sync mode picker"
-          ariaLabel="Sync by Bravo mode picker"
-          panelClassName="max-w-md"
-        >
-              <h3 className="text-lg font-bold text-zinc-900">Sync by Bravo</h3>
-              <p className="mt-1 text-sm text-zinc-600">
-                Choose what to sync from Bravo for this run.
-              </p>
-              <div className="mt-4 space-y-3">
-                <button
-                  type="button"
-                  onClick={() => startSyncBravoFlow("full")}
-                  className="w-full rounded-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white hover:bg-zinc-800"
-                >
-                  Sync All Info
-                </button>
-                <button
-                  type="button"
-                  onClick={() => startSyncBravoFlow("cast-only")}
-                  className="w-full rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 hover:bg-zinc-50"
-                >
-                  Cast Info only
-                </button>
-              </div>
-              <button
-                type="button"
-                onClick={() => setSyncBravoModePickerOpen(false)}
-                className="mt-4 w-full rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 hover:bg-zinc-50"
-              >
-                Cancel
-              </button>
-        </AdminModal>
-
-        <AdminModal
-          isOpen={syncBravoOpen}
-          onClose={() => {
-            if (syncBravoLoading) return;
-            setSyncBravoOpen(false);
-            setSyncBravoStep("preview");
+            ),
           }}
-          disableClose={syncBravoLoading}
-          closeLabel="Close Bravo sync dialog"
-          ariaLabel="Import by Bravo"
-          panelClassName="max-h-[90vh] max-w-3xl overflow-y-auto"
-        >
-              <div className="mb-4 flex items-start justify-between gap-4">
-                <div>
-                  <h3 className="text-lg font-bold text-zinc-900">
-                    Import by Bravo {syncBravoRunMode === "cast-only" ? "(Cast Info only)" : ""}
-                  </h3>
-                  <p className="text-sm text-zinc-500">Preview and commit persisted Bravo snapshots for this show.</p>
-                  <p className="mt-1 text-xs font-semibold uppercase tracking-[0.18em] text-zinc-400">
-                    Step {syncBravoStep === "preview" ? "1" : "2"} of 2
-                  </p>
-                  <p className="mt-1 text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
-                    Selected Mode: {syncBravoModeSummaryLabel}
-                  </p>
-                  {syncBravoPreviewSignature && (
-                    <p className="mt-1 text-[11px] text-zinc-500">
-                      Preview Signature: {syncBravoPreviewSignature.slice(0, 12)}...
-                    </p>
-                  )}
-                </div>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setSyncBravoOpen(false);
-                    setSyncBravoStep("preview");
-                  }}
-                  disabled={syncBravoLoading}
-                  className="rounded-md border border-zinc-200 px-3 py-1 text-sm font-semibold text-zinc-600 hover:bg-zinc-50"
-                >
-                  Close
-                </button>
-              </div>
+          contentHealthItems={contentHealthItems}
+          pipeline={{
+            steps: pipelineSteps,
+            onRetryStep: retryRefreshTarget,
+          }}
+          operationsInboxItems={operationsInboxItems}
+          refreshLog={{
+            hasEntries: refreshLogEntries.length > 0,
+            topicGroups: refreshLogTopicGroups,
+          }}
+        />
 
-              <div className="mb-4 rounded-lg border border-zinc-200 bg-zinc-50 p-3">
-                <label className="block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                  Sync Season
-                  <select
-                    value={syncBravoTargetSeasonNumber ?? ""}
-                    onChange={(event) => {
-                      const raw = event.target.value;
-                      const parsed = Number.parseInt(raw, 10);
-                      setSyncBravoTargetSeasonNumber(
-                        Number.isFinite(parsed) ? parsed : defaultSyncBravoSeasonNumber
-                      );
-                    }}
-                    disabled={syncBravoLoading || syncBravoSeasonOptions.length === 0}
-                    className="mt-1 block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm font-semibold normal-case tracking-normal text-zinc-800 disabled:opacity-50"
-                  >
-                    {syncBravoSeasonOptions.length === 0 ? (
-                      <option value="">No eligible seasons</option>
-                    ) : (
-                      syncBravoSeasonOptions.map((seasonNumber) => (
-                        <option key={seasonNumber} value={seasonNumber}>
-                          Season {seasonNumber}
-                        </option>
-                      ))
-                    )}
-                  </select>
-                </label>
-                <p className="mt-2 text-xs text-zinc-500">
-                  Bravo profile images from this run will be assigned as season promos for the selected season. Eligible seasons require more than 1 episode or a premiere date.
-                </p>
-              </div>
+        <ShowBravoSyncModal
+          modePicker={{
+            open: syncBravoModePickerOpen,
+            onClose: () => setSyncBravoModePickerOpen(false),
+            onStart: startSyncBravoFlow,
+          }}
+          dialog={{
+            open: syncBravoOpen,
+            step: syncBravoStep,
+            modeSummaryLabel: syncBravoModeSummaryLabel,
+            previewSignature: syncBravoPreviewSignature,
+            commitLoading: syncBravoCommitLoading,
+            onClose: () => {
+              if (syncBravoLoading) return;
+              setSyncBravoOpen(false);
+              setSyncBravoStep("preview");
+            },
+            onBack: () => setSyncBravoStep("preview"),
+            onCancel: () => {
+              setSyncBravoOpen(false);
+              setSyncBravoStep("preview");
+            },
+            onNext: openSyncBravoConfirmStep,
+            onCommit: commitSyncByBravo,
+          }}
+          season={{
+            targetSeasonNumber: syncBravoTargetSeasonNumber,
+            defaultSeasonNumber: defaultSyncBravoSeasonNumber,
+            options: syncBravoSeasonOptions,
+            onChange: setSyncBravoTargetSeasonNumber,
+          }}
+          preview={{
+            runMode: syncBravoRunMode,
+            loading: syncBravoLoading,
+            previewLoading: syncBravoPreviewLoading,
+            showName: show.name,
+            bravoUrl: autoGeneratedBravoUrl,
+            error: syncBravoError,
+            notice: syncBravoNotice,
+            description: syncBravoDescription,
+            airs: syncBravoAirs,
+            applyDescriptionToShow: syncBravoApplyDescriptionToShow,
+            images: syncBravoImages,
+            selectedImages: syncBravoSelectedImages,
+            imageKinds: syncBravoImageKinds,
+            personCandidateResults: syncBravoPersonCandidateResults,
+            fandomPersonCandidateResults: syncFandomPersonCandidateResults,
+            probeSummary: syncBravoProbeSummary,
+            fandomProbeSummary: syncFandomProbeSummary,
+            probeStatusMessage: syncBravoProbeStatusMessage,
+            probeActive: syncBravoProbeActive,
+            probeTotal: syncBravoProbeTotal,
+            validProfileCards: syncBravoValidProfileCards,
+            fandomValidProfileCards: syncFandomValidProfileCards,
+            candidateIssues: syncBravoCandidateIssues,
+            fandomCandidateIssues: syncFandomCandidateIssues,
+            fandomDomainsUsed: syncFandomDomainsUsed,
+            castLinks: syncBravoPreviewCastLinks,
+            newsItems: syncBravoPreviewNews,
+            videos: syncBravoFilteredPreviewVideos,
+            videoSeasonFilter: syncBravoPreviewSeasonFilter,
+            videoSeasonOptions: syncBravoPreviewSeasonOptions,
+            onRefreshPreview: previewSyncByBravo,
+            onDescriptionChange: setSyncBravoDescription,
+            onAirsChange: setSyncBravoAirs,
+            onApplyDescriptionChange: setSyncBravoApplyDescriptionToShow,
+            onImageSelectionChange: (url, selected) => {
+              setSyncBravoSelectedImages((prev) => {
+                const next = new Set(prev);
+                if (selected) next.add(url);
+                else next.delete(url);
+                return next;
+              });
+            },
+            onImageKindChange: (url, kind) => {
+              setSyncBravoImageKinds((prev) => ({ ...prev, [url]: kind }));
+            },
+            onVideoSeasonFilterChange: setSyncBravoPreviewSeasonFilter,
+            inferImageKind: inferBravoImportImageKind,
+            formatPublishedDate: formatBravoPublishedDate,
+          }}
+          confirm={{
+            castSyncCount: syncBravoCastSyncCount,
+            selectedImageSummaries: syncBravoSelectedImageSummaries,
+          }}
+        />
 
-              {syncBravoStep === "preview" ? (
-                <>
-              <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-                <div>
-                  <p className="mb-1 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                    Show Name
-                  </p>
-                  <p className="text-sm font-semibold text-zinc-900">{show.name}</p>
-                  <p className="mt-2 mb-1 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                    Bravo Show URL
-                  </p>
-                  {autoGeneratedBravoUrl ? (
-                    <a
-                      href={autoGeneratedBravoUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="block break-all text-xs text-blue-700 hover:underline"
-                    >
-                      {autoGeneratedBravoUrl}
-                    </a>
-                  ) : (
-                    <p className="text-xs text-zinc-500">Could not infer URL yet.</p>
-                  )}
-                </div>
-                <button
-                  type="button"
-                  onClick={() => void previewSyncByBravo()}
-                  disabled={syncBravoLoading}
-                  className="rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
-                >
-                  {syncBravoPreviewLoading
-                    ? "Refreshing..."
-                    : syncBravoRunMode === "cast-only"
-                      ? "Refresh Cast Preview"
-                      : "Refresh Preview"}
-                </button>
-              </div>
-
-              {(syncBravoError || syncBravoNotice) && (
-                <p className={`mb-4 text-sm ${syncBravoError ? "text-red-600" : "text-zinc-600"}`}>
-                  {syncBravoError || syncBravoNotice}
-                </p>
-              )}
-
-              {syncBravoRunMode === "cast-only" && (
-                <p className="mb-4 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm text-zinc-600">
-                  Cast-only mode probes canonical Bravo (`/people/*`) and Fandom (`/wiki/*`) cast profile URLs and reports
-                  valid, missing, and error candidates for each source.
-                </p>
-              )}
-
-              {syncBravoRunMode !== "cast-only" && (
-                <>
-                  <div className="mb-4 grid gap-4 md:grid-cols-2">
-                    <label className="block">
-                      <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                        Description
-                      </span>
-                      <textarea
-                        value={syncBravoDescription}
-                        onChange={(event) => setSyncBravoDescription(event.target.value)}
-                        rows={4}
-                        className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm text-zinc-900 focus:border-zinc-400 focus:outline-none"
-                      />
-                    </label>
-                    <label className="block">
-                      <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                        Airs / Tune-In
-                      </span>
-                      <textarea
-                        value={syncBravoAirs}
-                        onChange={(event) => setSyncBravoAirs(event.target.value)}
-                        rows={4}
-                        className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm text-zinc-900 focus:border-zinc-400 focus:outline-none"
-                      />
-                    </label>
-                  </div>
-                  <label className="mb-4 flex items-start gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm text-zinc-700">
-                    <input
-                      type="checkbox"
-                      checked={syncBravoApplyDescriptionToShow}
-                      onChange={(event) => setSyncBravoApplyDescriptionToShow(event.target.checked)}
-                      className="mt-0.5"
-                    />
-                    <span>
-                      Apply Bravo description to show profile.
-                      <span className="ml-1 text-xs text-zinc-500">
-                        Off by default. When off, commit keeps canonical show bio sources (IMDb/TMDb/Knowledge/Fandom).
-                      </span>
-                    </span>
-                  </label>
-
-                  <div className="mb-4">
-                    <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                      Show Images
-                    </p>
-                    {syncBravoImages.length === 0 ? (
-                      <p className="text-sm text-zinc-500">Run preview to load image candidates.</p>
-                    ) : (
-                      <div className="grid gap-3 sm:grid-cols-2">
-                        {syncBravoImages.map((image) => {
-                          const checked = syncBravoSelectedImages.has(image.url);
-                          const selectedKind =
-                            syncBravoImageKinds[image.url] ?? inferBravoImportImageKind(image);
-                          return (
-                            <div key={image.url} className="flex items-start gap-3 rounded-lg border border-zinc-200 p-3">
-                              <input
-                                type="checkbox"
-                                checked={checked}
-                                onChange={(event) =>
-                                  setSyncBravoSelectedImages((prev) => {
-                                    const next = new Set(prev);
-                                    if (event.target.checked) next.add(image.url);
-                                    else next.delete(image.url);
-                                    return next;
-                                  })
-                                }
-                                className="mt-1"
-                              />
-                              <div className="relative h-16 w-28 overflow-hidden rounded bg-zinc-100">
-                                <GalleryImage src={image.url} alt={image.alt || "Bravo image"} sizes="120px" />
-                              </div>
-                              <div className="min-w-0 flex-1">
-                                <span className="line-clamp-2 text-xs text-zinc-600">{image.alt || image.url}</span>
-                                <div className="mt-2 flex items-center gap-2">
-                                  <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-zinc-500">
-                                    Type
-                                  </span>
-                                  <select
-                                    value={selectedKind}
-                                    onChange={(event) =>
-                                      setSyncBravoImageKinds((prev) => ({
-                                        ...prev,
-                                        [image.url]: event.target.value as BravoImportImageKind,
-                                      }))
-                                    }
-                                    className="rounded border border-zinc-200 bg-white px-2 py-1 text-xs text-zinc-700"
-                                  >
-                                    {BRAVO_IMPORT_IMAGE_KIND_OPTIONS.map((option) => (
-                                      <option key={option.value} value={option.value}>
-                                        {option.label}
-                                      </option>
-                                    ))}
-                                  </select>
-                                </div>
-                              </div>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    )}
-                  </div>
-                </>
-              )}
-
-              <div className="mb-4">
-                <div className="mb-2 flex items-center justify-between gap-2">
-                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                    Cast Member URLs
-                  </p>
-                  {syncBravoRunMode === "cast-only" && (
-                    <div className="text-right text-[11px] font-semibold text-zinc-500">
-                      <p>
-                        Bravo tested {syncBravoProbeSummary.tested} / valid {syncBravoProbeSummary.valid} /
-                        missing {syncBravoProbeSummary.missing} / error {syncBravoProbeSummary.errors}
-                      </p>
-                      <p>
-                        Fandom tested {syncFandomProbeSummary.tested} / valid {syncFandomProbeSummary.valid} /
-                        missing {syncFandomProbeSummary.missing} / error {syncFandomProbeSummary.errors}
-                      </p>
-                    </div>
-                  )}
-                </div>
-                {syncBravoRunMode === "cast-only" && syncBravoProbeStatusMessage && (
-                  <p className="mb-2 text-xs text-zinc-500">
-                    {syncBravoProbeStatusMessage}
-                    {syncBravoProbeActive && syncBravoProbeTotal > 30 ? " This may take several minutes." : ""}
-                  </p>
-                )}
-
-                {syncBravoRunMode === "cast-only" ? (
-                  <div className="space-y-3">
-                    <div className="rounded-lg border border-zinc-200 bg-white p-3">
-                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                        Probe Queue
-                      </p>
-                      {syncBravoPersonCandidateResults.length === 0 ? (
-                        <p className="mt-2 text-sm text-zinc-500">
-                          Preparing canonical `/people/*` candidate probes...
-                        </p>
-                      ) : (
-                        <div className="mt-2 space-y-2">
-                          {syncBravoPersonCandidateResults.map((result) => {
-                            const status = String(result.status || "pending").trim().toLowerCase();
-                            const badgeClass =
-                              status === "ok"
-                                ? "bg-emerald-100 text-emerald-700"
-                                : status === "missing"
-                                  ? "bg-amber-100 text-amber-700"
-                                  : status === "error"
-                                    ? "bg-red-100 text-red-700"
-                                    : status === "in_progress"
-                                      ? "bg-blue-100 text-blue-700"
-                                      : "bg-zinc-200 text-zinc-700";
-                            return (
-                              <article
-                                key={`candidate-${result.url}`}
-                                className="rounded-md border border-zinc-200 bg-zinc-50 p-2"
-                              >
-                                <div className="flex items-center gap-2">
-                                  <span
-                                    className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] ${badgeClass}`}
-                                  >
-                                    {status}
-                                  </span>
-                                  <div className="min-w-0">
-                                    <p className="truncate text-xs font-semibold text-zinc-800">
-                                      {result.name || "Unresolved cast member"}
-                                    </p>
-                                    <a
-                                      href={result.url}
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                      className="min-w-0 break-all text-xs text-blue-700 hover:underline"
-                                    >
-                                      {result.url}
-                                    </a>
-                                  </div>
-                                </div>
-                                {result.error && (
-                                  <p className="mt-1 text-xs text-zinc-600">{result.error}</p>
-                                )}
-                              </article>
-                            );
-                          })}
-                        </div>
-                      )}
-                    </div>
-
-                    {syncBravoValidProfileCards.length === 0 ? (
-                      <p className="text-sm text-zinc-500">
-                        No valid Bravo profile pages resolved from canonical `/people/*` probes.
-                      </p>
-                    ) : (
-                      <div className="space-y-2">
-                        {syncBravoValidProfileCards.map((person) => (
-                          <article
-                            key={person.url}
-                            className="rounded-lg border border-zinc-200 bg-zinc-50 p-3"
-                          >
-                            <div className="flex gap-3">
-                              <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded bg-zinc-100">
-                                {person.heroImageUrl ? (
-                                  <GalleryImage
-                                    src={person.heroImageUrl}
-                                    alt={person.name || "Bravo profile"}
-                                    sizes="96px"
-                                  />
-                                ) : (
-                                  <div className="flex h-full items-center justify-center text-[11px] text-zinc-400">
-                                    No image
-                                  </div>
-                                )}
-                              </div>
-                              <div className="min-w-0 flex-1">
-                                <p className="text-sm font-semibold text-zinc-900">
-                                  {person.name || "Unresolved cast member"}
-                                </p>
-                                <a
-                                  href={person.url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="mt-1 block break-all text-xs text-blue-700 hover:underline"
-                                >
-                                  {person.url}
-                                </a>
-                                {person.bio && (
-                                  <p className="mt-2 line-clamp-3 text-xs text-zinc-600">{person.bio}</p>
-                                )}
-                                {person.socialLinks.length > 0 && (
-                                  <div className="mt-2 flex flex-wrap gap-1.5">
-                                    {person.socialLinks.map((social) => (
-                                      <a
-                                        key={`${person.url}-${social.key}-${social.url}`}
-                                        href={social.url}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="rounded-full border border-zinc-300 bg-white px-2 py-0.5 text-[11px] font-medium text-zinc-700 hover:bg-zinc-100"
-                                      >
-                                        {social.label}
-                                        {social.handle ? ` ${social.handle}` : ""}
-                                      </a>
-                                    ))}
-                                  </div>
-                                )}
-                              </div>
-                            </div>
-                          </article>
-                        ))}
-                      </div>
-                    )}
-
-                    {syncBravoCandidateIssues.length > 0 && (
-                      <div className="rounded-lg border border-zinc-200 bg-white p-3">
-                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          Missing / Error Profiles
-                        </p>
-                        <div className="mt-2 space-y-2">
-                          {syncBravoCandidateIssues.map((result) => (
-                            <article
-                              key={`${result.status}-${result.url}`}
-                              className="rounded-md border border-zinc-200 bg-zinc-50 p-2"
-                            >
-                              <div className="flex items-center gap-2">
-                                <span
-                                  className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] ${
-                                    result.status === "missing"
-                                      ? "bg-amber-100 text-amber-700"
-                                      : "bg-red-100 text-red-700"
-                                  }`}
-                                >
-                                  {result.status}
-                                </span>
-                                <a
-                                  href={result.url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="min-w-0 break-all text-xs text-blue-700 hover:underline"
-                                >
-                                  {result.url}
-                                </a>
-                              </div>
-                              {result.reason && (
-                                <p className="mt-1 text-xs text-zinc-600">{result.reason}</p>
-                              )}
-                            </article>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-
-                    <div className="rounded-lg border border-zinc-200 bg-white p-3">
-                      <div className="flex items-center justify-between gap-2">
-                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          Fandom Probe Queue
-                        </p>
-                        <p className="text-[11px] font-semibold text-zinc-500">
-                          tested {syncFandomProbeSummary.tested} / valid {syncFandomProbeSummary.valid} /
-                          missing {syncFandomProbeSummary.missing} / error {syncFandomProbeSummary.errors}
-                        </p>
-                      </div>
-                      {syncFandomDomainsUsed.length > 0 && (
-                        <p className="mt-1 text-[11px] text-zinc-500">
-                          Domains: {syncFandomDomainsUsed.join(", ")}
-                        </p>
-                      )}
-                      {syncFandomPersonCandidateResults.length === 0 ? (
-                        <p className="mt-2 text-sm text-zinc-500">
-                          Preparing canonical `/wiki/*` candidate probes...
-                        </p>
-                      ) : (
-                        <div className="mt-2 space-y-2">
-                          {syncFandomPersonCandidateResults.map((result) => {
-                            const status = String(result.status || "pending").trim().toLowerCase();
-                            const badgeClass =
-                              status === "ok"
-                                ? "bg-emerald-100 text-emerald-700"
-                                : status === "missing"
-                                  ? "bg-amber-100 text-amber-700"
-                                  : status === "error"
-                                    ? "bg-red-100 text-red-700"
-                                    : status === "in_progress"
-                                      ? "bg-blue-100 text-blue-700"
-                                      : "bg-zinc-200 text-zinc-700";
-                            return (
-                              <article
-                                key={`fandom-candidate-${result.url}`}
-                                className="rounded-md border border-zinc-200 bg-zinc-50 p-2"
-                              >
-                                <div className="flex items-center gap-2">
-                                  <span
-                                    className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] ${badgeClass}`}
-                                  >
-                                    {status}
-                                  </span>
-                                  <div className="min-w-0">
-                                    <p className="truncate text-xs font-semibold text-zinc-800">
-                                      {result.name || "Unresolved cast member"}
-                                    </p>
-                                    <a
-                                      href={result.url}
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                      className="min-w-0 break-all text-xs text-blue-700 hover:underline"
-                                    >
-                                      {result.url}
-                                    </a>
-                                  </div>
-                                </div>
-                                {result.error && (
-                                  <p className="mt-1 text-xs text-zinc-600">{result.error}</p>
-                                )}
-                              </article>
-                            );
-                          })}
-                        </div>
-                      )}
-                    </div>
-
-                    {syncFandomValidProfileCards.length === 0 ? (
-                      <p className="text-sm text-zinc-500">
-                        No valid Fandom profile pages resolved from canonical `/wiki/*` probes.
-                      </p>
-                    ) : (
-                      <div className="space-y-2">
-                        {syncFandomValidProfileCards.map((person) => (
-                          <article
-                            key={`fandom-profile-${person.url}`}
-                            className="rounded-lg border border-zinc-200 bg-zinc-50 p-3"
-                          >
-                            <div className="flex gap-3">
-                              <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded bg-zinc-100">
-                                {person.heroImageUrl ? (
-                                  <GalleryImage
-                                    src={person.heroImageUrl}
-                                    alt={person.name || "Fandom profile"}
-                                    sizes="96px"
-                                  />
-                                ) : (
-                                  <div className="flex h-full items-center justify-center text-[11px] text-zinc-400">
-                                    No image
-                                  </div>
-                                )}
-                              </div>
-                              <div className="min-w-0 flex-1">
-                                <p className="text-sm font-semibold text-zinc-900">
-                                  {person.name || "Unresolved cast member"}
-                                </p>
-                                <a
-                                  href={person.url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="mt-1 block break-all text-xs text-blue-700 hover:underline"
-                                >
-                                  {person.url}
-                                </a>
-                                {person.bio && (
-                                  <p className="mt-2 line-clamp-3 text-xs text-zinc-600">{person.bio}</p>
-                                )}
-                              </div>
-                            </div>
-                          </article>
-                        ))}
-                      </div>
-                    )}
-
-                    {syncFandomCandidateIssues.length > 0 && (
-                      <div className="rounded-lg border border-zinc-200 bg-white p-3">
-                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          Fandom Missing / Error Profiles
-                        </p>
-                        <div className="mt-2 space-y-2">
-                          {syncFandomCandidateIssues.map((result) => (
-                            <article
-                              key={`fandom-${result.status}-${result.url}`}
-                              className="rounded-md border border-zinc-200 bg-zinc-50 p-2"
-                            >
-                              <div className="flex items-center gap-2">
-                                <span
-                                  className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] ${
-                                    result.status === "missing"
-                                      ? "bg-amber-100 text-amber-700"
-                                      : "bg-red-100 text-red-700"
-                                  }`}
-                                >
-                                  {result.status}
-                                </span>
-                                <a
-                                  href={result.url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="min-w-0 break-all text-xs text-blue-700 hover:underline"
-                                >
-                                  {result.url}
-                                </a>
-                              </div>
-                              {result.reason && (
-                                <p className="mt-1 text-xs text-zinc-600">{result.reason}</p>
-                              )}
-                            </article>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                ) : syncBravoPreviewCastLinks.length === 0 ? (
-                  <p className="text-sm text-zinc-500">No cast member URLs found in this preview.</p>
-                ) : (
-                  <div className="space-y-2">
-                    {syncBravoPreviewCastLinks.map((person) => (
-                      <article
-                        key={person.url}
-                        className="rounded-lg border border-zinc-200 bg-zinc-50 p-3"
-                      >
-                        <p className="text-sm font-semibold text-zinc-900">
-                          {person.name || "Unresolved cast member"}
-                        </p>
-                        <a
-                          href={person.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="mt-1 block break-all text-xs text-blue-700 hover:underline"
-                        >
-                          {person.url}
-                        </a>
-                      </article>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              {syncBravoRunMode !== "cast-only" && (
-                <div className="mb-4">
-                  <div className="mb-2 flex items-center justify-between gap-2">
-                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                      Fandom Cast Coverage
-                    </p>
-                    <p className="text-[11px] font-semibold text-zinc-500">
-                      tested {syncFandomProbeSummary.tested} / valid {syncFandomProbeSummary.valid} /
-                      missing {syncFandomProbeSummary.missing} / error {syncFandomProbeSummary.errors}
-                    </p>
-                  </div>
-                  {syncFandomDomainsUsed.length > 0 && (
-                    <p className="mb-2 text-xs text-zinc-500">
-                      Domains used: {syncFandomDomainsUsed.join(", ")}
-                    </p>
-                  )}
-                  {syncFandomValidProfileCards.length === 0 ? (
-                    <p className="text-sm text-zinc-500">No valid Fandom cast profiles found in this preview.</p>
-                  ) : (
-                    <div className="space-y-2">
-                      {syncFandomValidProfileCards.map((person) => (
-                        <article
-                          key={`full-fandom-${person.url}`}
-                          className="rounded-lg border border-zinc-200 bg-zinc-50 p-3"
-                        >
-                          <p className="text-sm font-semibold text-zinc-900">
-                            {person.name || "Unresolved cast member"}
-                          </p>
-                          <a
-                            href={person.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="mt-1 block break-all text-xs text-blue-700 hover:underline"
-                          >
-                            {person.url}
-                          </a>
-                          {person.bio && (
-                            <p className="mt-2 line-clamp-2 text-xs text-zinc-600">{person.bio}</p>
-                          )}
-                        </article>
-                      ))}
-                    </div>
-                  )}
-                  {syncFandomCandidateIssues.length > 0 && (
-                    <div className="mt-2 rounded-lg border border-zinc-200 bg-white p-3">
-                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                        Fandom Missing / Error Profiles
-                      </p>
-                      <div className="mt-2 space-y-1">
-                        {syncFandomCandidateIssues.map((result) => (
-                          <p key={`full-fandom-issue-${result.url}`} className="text-xs text-zinc-600">
-                            {result.status.toUpperCase()}: {result.url}
-                            {result.reason ? ` (${result.reason})` : ""}
-                          </p>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              )}
-
-              {syncBravoRunMode !== "cast-only" && (
-                <>
-                  <div className="mb-4">
-                    <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                      News
-                    </p>
-                    {syncBravoPreviewNews.length === 0 ? (
-                      <p className="text-sm text-zinc-500">No news items found in this preview.</p>
-                    ) : (
-                      <div className="space-y-2">
-                        {syncBravoPreviewNews.map((item) => (
-                          <article
-                            key={`${item.article_url}-${item.published_at ?? "unknown"}`}
-                            className="rounded-lg border border-zinc-200 bg-zinc-50 p-3"
-                          >
-                            <div className="flex gap-3">
-                              <div className="relative h-16 w-24 shrink-0 overflow-hidden rounded bg-zinc-100">
-                                {item.image_url ? (
-                                  <GalleryImage
-                                    src={item.image_url}
-                                    alt={item.headline || "Bravo news"}
-                                    sizes="120px"
-                                  />
-                                ) : (
-                                  <div className="flex h-full items-center justify-center text-xs text-zinc-400">
-                                    No image
-                                  </div>
-                                )}
-                              </div>
-                              <div className="min-w-0 flex-1">
-                                <a
-                                  href={item.article_url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="line-clamp-2 text-sm font-semibold text-zinc-900 hover:text-blue-700"
-                                >
-                                  {item.headline || "Untitled story"}
-                                </a>
-                                {formatBravoPublishedDate(item.published_at) && (
-                                  <p className="mt-1 text-xs text-zinc-500">
-                                    Posted {formatBravoPublishedDate(item.published_at)}
-                                  </p>
-                                )}
-                              </div>
-                            </div>
-                          </article>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-
-                  <div className="mb-4">
-                    <div className="mb-2 flex items-center justify-between gap-3">
-                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                        Videos
-                      </p>
-                      {syncBravoPreviewSeasonOptions.length > 0 && (
-                        <label className="flex items-center gap-2 text-xs text-zinc-600">
-                          <span>Season</span>
-                          <select
-                            value={syncBravoPreviewSeasonFilter}
-                            onChange={(event) => {
-                              const nextValue = event.target.value;
-                              setSyncBravoPreviewSeasonFilter(
-                                nextValue === "all" ? "all" : Number.parseInt(nextValue, 10)
-                              );
-                            }}
-                            className="rounded border border-zinc-200 bg-white px-2 py-1 text-xs text-zinc-700"
-                          >
-                            <option value="all">All</option>
-                            {syncBravoPreviewSeasonOptions.map((season) => (
-                              <option key={season} value={season}>
-                                Season {season}
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-                      )}
-                    </div>
-                    {syncBravoFilteredPreviewVideos.length === 0 ? (
-                      <p className="text-sm text-zinc-500">No videos found for this preview/season filter.</p>
-                    ) : (
-                      <div className="space-y-2">
-                        {syncBravoFilteredPreviewVideos.map((video) => (
-                          <article
-                            key={`${video.clip_url}-${video.published_at ?? "unknown"}`}
-                            className="rounded-lg border border-zinc-200 bg-zinc-50 p-3"
-                          >
-                            <div className="flex gap-3">
-                              <div className="relative h-16 w-24 shrink-0 overflow-hidden rounded bg-zinc-100">
-                                {video.image_url ? (
-                                  <GalleryImage
-                                    src={video.image_url}
-                                    alt={video.title || "Bravo video"}
-                                    sizes="120px"
-                                  />
-                                ) : (
-                                  <div className="flex h-full items-center justify-center text-xs text-zinc-400">
-                                    No image
-                                  </div>
-                                )}
-                              </div>
-                              <div className="min-w-0 flex-1">
-                                <a
-                                  href={video.clip_url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="line-clamp-2 text-sm font-semibold text-zinc-900 hover:text-blue-700"
-                                >
-                                  {video.title || "Untitled video"}
-                                </a>
-                                <div className="mt-1 flex flex-wrap gap-2 text-xs text-zinc-500">
-                                  {video.runtime && <span>{video.runtime}</span>}
-                                  {typeof video.season_number === "number" && (
-                                    <span>Season {video.season_number}</span>
-                                  )}
-                                  {formatBravoPublishedDate(video.published_at) && (
-                                    <span>Posted {formatBravoPublishedDate(video.published_at)}</span>
-                                  )}
-                                </div>
-                              </div>
-                            </div>
-                          </article>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </>
-              )}
-                </>
-              ) : (
-                <div className="space-y-4">
-                  <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
-                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                      Show Name
-                    </p>
-                    <p className="mt-1 text-sm font-semibold text-zinc-800">{show.name}</p>
-                    <p className="mt-3 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                      Bravo Show URL
-                    </p>
-                    {autoGeneratedBravoUrl ? (
-                      <a
-                        href={autoGeneratedBravoUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="mt-1 block break-all text-xs text-blue-700 hover:underline"
-                      >
-                        {autoGeneratedBravoUrl}
-                      </a>
-                    ) : (
-                      <p className="mt-1 text-xs text-zinc-500">Could not infer URL yet.</p>
-                    )}
-                    {syncBravoRunMode !== "cast-only" && syncBravoDescription.trim() && (
-                      <>
-                        <p className="mt-3 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          Description
-                        </p>
-                        <p className="mt-1 text-sm text-zinc-700">{syncBravoDescription.trim()}</p>
-                        <p className="mt-1 text-xs text-zinc-500">
-                          {syncBravoApplyDescriptionToShow
-                            ? "Will be applied to show profile."
-                            : "Will not overwrite show profile unless enabled in preview step."}
-                        </p>
-                      </>
-                    )}
-                    {syncBravoRunMode !== "cast-only" && syncBravoAirs.trim() && (
-                      <>
-                        <p className="mt-3 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                          Airs / Tune-In
-                        </p>
-                        <p className="mt-1 text-sm text-zinc-700">{syncBravoAirs.trim()}</p>
-                      </>
-                    )}
-                  </div>
-
-                  <div>
-                    <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                      Cast Members Being Synced ({syncBravoCastSyncCount})
-                    </p>
-                    {syncBravoRunMode === "cast-only" && (
-                      <>
-                        <p className="mb-1 text-xs text-zinc-500">
-                          Bravo summary: tested {syncBravoProbeSummary.tested}, valid{" "}
-                          {syncBravoProbeSummary.valid}, missing {syncBravoProbeSummary.missing},
-                          errors {syncBravoProbeSummary.errors}.
-                        </p>
-                        <p className="mb-2 text-xs text-zinc-500">
-                          Fandom summary: tested {syncFandomProbeSummary.tested}, valid{" "}
-                          {syncFandomProbeSummary.valid}, missing {syncFandomProbeSummary.missing},
-                          errors {syncFandomProbeSummary.errors}.
-                        </p>
-                        {syncFandomDomainsUsed.length > 0 && (
-                          <p className="mb-2 text-xs text-zinc-500">
-                            Fandom domains used: {syncFandomDomainsUsed.join(", ")}
-                          </p>
-                        )}
-                      </>
-                    )}
-                    {syncBravoRunMode === "cast-only" ? (
-                      <div className="space-y-3">
-                        <div>
-                          <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                            Bravo Profiles ({syncBravoValidProfileCards.length})
-                          </p>
-                          {syncBravoValidProfileCards.length === 0 ? (
-                            <p className="text-sm text-zinc-500">
-                              No valid Bravo cast profile URLs were detected in this preview.
-                            </p>
-                          ) : (
-                            <div className="space-y-2">
-                              {syncBravoValidProfileCards.map((person) => (
-                                <article
-                                  key={person.url}
-                                  className="rounded-lg border border-zinc-200 bg-zinc-50 p-3"
-                                >
-                                  <p className="text-sm font-semibold text-zinc-900">
-                                    {person.name || "Unresolved cast member"}
-                                  </p>
-                                  <p className="mt-1 break-all text-xs text-zinc-600">{person.url}</p>
-                                </article>
-                              ))}
-                            </div>
-                          )}
-                        </div>
-                        <div>
-                          <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                            Fandom Profiles ({syncFandomValidProfileCards.length})
-                          </p>
-                          {syncFandomValidProfileCards.length === 0 ? (
-                            <p className="text-sm text-zinc-500">
-                              No valid Fandom cast profile URLs were detected in this preview.
-                            </p>
-                          ) : (
-                            <div className="space-y-2">
-                              {syncFandomValidProfileCards.map((person) => (
-                                <article
-                                  key={`confirm-fandom-${person.url}`}
-                                  className="rounded-lg border border-zinc-200 bg-zinc-50 p-3"
-                                >
-                                  <p className="text-sm font-semibold text-zinc-900">
-                                    {person.name || "Unresolved cast member"}
-                                  </p>
-                                  <p className="mt-1 break-all text-xs text-zinc-600">{person.url}</p>
-                                </article>
-                              ))}
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    ) : syncBravoPreviewCastLinks.length === 0 ? (
-                      <p className="text-sm text-zinc-500">No cast member URLs found in this preview.</p>
-                    ) : (
-                      <div className="space-y-2">
-                        {syncBravoPreviewCastLinks.map((person) => (
-                          <article
-                            key={person.url}
-                            className="rounded-lg border border-zinc-200 bg-zinc-50 p-3"
-                          >
-                            <p className="text-sm font-semibold text-zinc-900">
-                              {person.name || "Unresolved cast member"}
-                            </p>
-                            <p className="mt-1 break-all text-xs text-zinc-600">{person.url}</p>
-                          </article>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-
-                  {syncBravoRunMode !== "cast-only" && (
-                    <div>
-                      <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                        Show Images Being Synced ({syncBravoSelectedImageSummaries.length})
-                      </p>
-                      {syncBravoSelectedImageSummaries.length === 0 ? (
-                        <p className="text-sm text-zinc-500">No show images selected for sync.</p>
-                      ) : (
-                        <div className="space-y-2">
-                          {syncBravoSelectedImageSummaries.map((image) => (
-                            <article
-                              key={image.url}
-                              className="flex items-start gap-3 rounded-lg border border-zinc-200 bg-zinc-50 p-3"
-                            >
-                              <div className="relative h-16 w-24 shrink-0 overflow-hidden rounded bg-zinc-100">
-                                <GalleryImage src={image.url} alt={image.alt || "Selected show image"} sizes="120px" />
-                              </div>
-                              <div className="min-w-0">
-                                <p className="line-clamp-2 text-sm font-semibold text-zinc-900">
-                                  {image.alt || "Show image"}
-                                </p>
-                                <p className="mt-1 text-xs uppercase tracking-[0.16em] text-zinc-500">
-                                  Type: {image.kind}
-                                </p>
-                                <p className="mt-1 break-all text-xs text-zinc-600">{image.url}</p>
-                              </div>
-                            </article>
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </div>
-              )}
-
-              {syncBravoStep === "confirm" && (syncBravoError || syncBravoNotice) && (
-                <p className={`mb-4 text-sm ${syncBravoError ? "text-red-600" : "text-zinc-600"}`}>
-                  {syncBravoError || syncBravoNotice}
-                </p>
-              )}
-
-              <div className="flex justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={() => {
-                    if (syncBravoStep === "confirm") {
-                      setSyncBravoStep("preview");
-                      return;
-                    }
-                    setSyncBravoOpen(false);
-                    setSyncBravoStep("preview");
-                  }}
-                  disabled={syncBravoLoading}
-                  className="rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 hover:bg-zinc-50"
-                >
-                  {syncBravoStep === "confirm" ? "Back" : "Cancel"}
-                </button>
-                <button
-                  type="button"
-                  onClick={syncBravoStep === "confirm" ? commitSyncByBravo : openSyncBravoConfirmStep}
-                  disabled={syncBravoLoading}
-                  className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white hover:bg-zinc-800 disabled:opacity-50"
-                >
-                  {syncBravoStep === "confirm"
-                    ? syncBravoCommitLoading
-                      ? "Syncing..."
-                      : syncBravoRunMode === "cast-only"
-                        ? "Sync Cast Info only"
-                        : "Sync All Info"
-                    : "Next"}
-                </button>
-              </div>
-        </AdminModal>
-
-        <AdminModal
-          isOpen={batchJobsOpen}
-          onClose={() => setBatchJobsOpen(false)}
-          disableClose={batchJobsRunning}
-          closeLabel="Close batch jobs dialog"
-          ariaLabel="Run image batch jobs"
-          panelClassName="max-w-2xl p-5"
-        >
-          <div className="mb-4 flex items-start justify-between gap-4">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                Batch Jobs
-              </p>
-              <h4 className="text-lg font-semibold text-zinc-900">Run Image Jobs</h4>
-              <p className="mt-1 text-xs text-zinc-500">
-                Select one or more operations and content types. Jobs run on the currently visible gallery assets.
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={() => {
-                if (!batchJobsRunning) setBatchJobsOpen(false);
-              }}
-              className="rounded-lg border border-zinc-200 px-3 py-1 text-xs font-semibold text-zinc-600 hover:bg-zinc-50"
-              disabled={batchJobsRunning}
-            >
-              Close
-            </button>
-          </div>
-
-          <div className="space-y-4">
-            <div>
-              <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                Operations
-              </p>
-              <div className="flex flex-wrap gap-2">
-                {(Object.keys(BATCH_JOB_OPERATION_LABELS) as BatchJobOperation[]).map((operation) => (
-                  <label
-                    key={operation}
-                    className="inline-flex items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm text-zinc-700"
-                  >
-                    <input
-                      type="checkbox"
-                      checked={batchJobOperations.includes(operation)}
-                      onChange={() => toggleBatchJobOperation(operation)}
-                      disabled={batchJobsRunning}
-                    />
-                    {BATCH_JOB_OPERATION_LABELS[operation]}
-                  </label>
-                ))}
-              </div>
-            </div>
-
-            <div>
-              <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                Content Types
-              </p>
-              <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                {SHOW_GALLERY_ALLOWED_SECTIONS.map((section) => (
-                  <label
-                    key={section}
-                    className="inline-flex items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-xs text-zinc-700"
-                  >
-                    <input
-                      type="checkbox"
-                      checked={batchJobContentSections.includes(section)}
-                      onChange={() => toggleBatchJobContentSection(section)}
-                      disabled={batchJobsRunning}
-                    />
-                    {ASSET_SECTION_LABELS[section]}
-                  </label>
-                ))}
-              </div>
-            </div>
-            <p className="rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-xs text-zinc-600">
-              {showBatchPreflightSummary}
-            </p>
-          </div>
-
-          <div className="mt-5 flex justify-end gap-2">
-            <button
-              type="button"
-              onClick={() => setBatchJobsOpen(false)}
-              className="rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
-              disabled={batchJobsRunning}
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              onClick={runBatchJobs}
-              className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white hover:bg-zinc-800 disabled:opacity-50"
-              disabled={batchJobsRunning}
-            >
-              {batchJobsRunning ? "Running..." : "Run Batch Jobs"}
-            </button>
-          </div>
-        </AdminModal>
-
-        <AdminModal
-          isOpen={Boolean(roleRenameDraft)}
-          onClose={cancelRoleRename}
-          disableClose={roleRenameSaving}
-          closeLabel="Close role rename dialog"
-          ariaLabel="Rename role"
-          panelClassName="max-w-md"
-        >
-          {roleRenameDraft && (
-            <>
-              <h4 className="text-lg font-semibold text-zinc-900">Rename Role</h4>
-              <p className="mt-1 text-sm text-zinc-500">Current: {roleRenameDraft.originalName}</p>
-              <label className="mt-4 block text-xs font-semibold uppercase tracking-[0.16em] text-zinc-500">
-                New Name
-                <input
-                  value={roleRenameDraft.nextName}
-                  onChange={(event) =>
-                    setRoleRenameDraft((prev) =>
-                      prev ? { ...prev, nextName: event.target.value } : prev,
-                    )
-                  }
-                  className="mt-1 block w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-700"
-                  placeholder="Housewife"
-                  required
-                />
-              </label>
-              <div className="mt-5 flex justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={cancelRoleRename}
-                  disabled={roleRenameSaving}
-                  className="rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  onClick={() => void saveRenamedShowRole()}
-                  disabled={roleRenameSaving}
-                  className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white hover:bg-zinc-800 disabled:opacity-50"
-                >
-                  {roleRenameSaving ? "Saving..." : "Save Role"}
-                </button>
-              </div>
-            </>
-          )}
-        </AdminModal>
-
-        <AdminModal
-          isOpen={Boolean(castRoleEditDraft)}
-          onClose={cancelCastRoleEditor}
-          disableClose={castRoleEditSaving}
-          closeLabel="Close cast role editor"
-          ariaLabel="Assign cast roles"
-          panelClassName="max-w-xl"
-        >
-          {castRoleEditDraft && (
-            <>
-              <h4 className="text-lg font-semibold text-zinc-900">
-                Assign Roles for {castRoleEditDraft.personName}
-              </h4>
-              <p className="mt-1 text-sm text-zinc-500">
-                Enter comma-separated role names. Missing roles will be created automatically.
-              </p>
-              <label className="mt-4 block text-xs font-semibold uppercase tracking-[0.16em] text-zinc-500">
-                Roles
-                <textarea
-                  value={castRoleEditDraft.roleCsv}
-                  onChange={(event) =>
-                    setCastRoleEditDraft((prev) =>
-                      prev ? { ...prev, roleCsv: event.target.value } : prev,
-                    )
-                  }
-                  className="mt-1 block w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-700"
-                  rows={4}
-                  placeholder="Housewife, Friend Of"
-                />
-              </label>
-              <div className="mt-5 flex justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={cancelCastRoleEditor}
-                  disabled={castRoleEditSaving}
-                  className="rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  onClick={() => void saveCastRoleAssignments()}
-                  disabled={castRoleEditSaving}
-                  className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white hover:bg-zinc-800 disabled:opacity-50"
-                >
-                  {castRoleEditSaving ? "Saving..." : "Save Roles"}
-                </button>
-              </div>
-            </>
-          )}
-        </AdminModal>
+        <ShowBatchRoleModals
+          batchJobs={{
+            open: batchJobsOpen,
+            running: batchJobsRunning,
+            operationOptions: (Object.keys(BATCH_JOB_OPERATION_LABELS) as BatchJobOperation[]).map(
+              (operation) => ({
+                key: operation,
+                label: BATCH_JOB_OPERATION_LABELS[operation],
+                checked: batchJobOperations.includes(operation),
+                onToggle: () => toggleBatchJobOperation(operation),
+              }),
+            ),
+            contentSectionOptions: SHOW_GALLERY_ALLOWED_SECTIONS.map((section) => ({
+              key: section,
+              label: ASSET_SECTION_LABELS[section],
+              checked: batchJobContentSections.includes(section),
+              onToggle: () => toggleBatchJobContentSection(section),
+            })),
+            preflightSummary: showBatchPreflightSummary,
+            onClose: () => {
+              if (!batchJobsRunning) setBatchJobsOpen(false);
+            },
+            onRun: () => void runBatchJobs(),
+          }}
+          roleRename={{
+            draft: roleRenameDraft,
+            saving: roleRenameSaving,
+            onClose: cancelRoleRename,
+            onNameChange: (nextName) =>
+              setRoleRenameDraft((prev) => (prev ? { ...prev, nextName } : prev)),
+            onSave: () => void saveRenamedShowRole(),
+          }}
+          castRoles={{
+            draft: castRoleEditDraft,
+            saving: castRoleEditSaving,
+            onClose: cancelCastRoleEditor,
+            onRoleCsvChange: (roleCsv) =>
+              setCastRoleEditDraft((prev) => (prev ? { ...prev, roleCsv } : prev)),
+            onSave: () => void saveCastRoleAssignments(),
+          }}
+        />
 
         <AdvancedFilterDrawer
           isOpen={advancedFiltersOpen}

--- a/apps/web/src/components/admin/ShowBatchRoleModals.tsx
+++ b/apps/web/src/components/admin/ShowBatchRoleModals.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import AdminModal from "@/components/admin/AdminModal";
+
+export type ShowBatchRoleToggleOption = Readonly<{
+  key: string;
+  label: string;
+  checked: boolean;
+  onToggle: () => void;
+}>;
+
+export type ShowBatchRoleModalsProps = {
+  batchJobs: {
+    open: boolean;
+    running: boolean;
+    operationOptions: ReadonlyArray<ShowBatchRoleToggleOption>;
+    contentSectionOptions: ReadonlyArray<ShowBatchRoleToggleOption>;
+    preflightSummary: string;
+    onClose: () => void;
+    onRun: () => void;
+  };
+  roleRename: {
+    draft: Readonly<{
+      originalName: string;
+      nextName: string;
+    }> | null;
+    saving: boolean;
+    onClose: () => void;
+    onNameChange: (name: string) => void;
+    onSave: () => void;
+  };
+  castRoles: {
+    draft: Readonly<{
+      personName: string;
+      roleCsv: string;
+    }> | null;
+    saving: boolean;
+    onClose: () => void;
+    onRoleCsvChange: (roleCsv: string) => void;
+    onSave: () => void;
+  };
+};
+
+export default function ShowBatchRoleModals({
+  batchJobs,
+  roleRename,
+  castRoles,
+}: ShowBatchRoleModalsProps) {
+  return (
+    <>
+      <AdminModal
+        isOpen={batchJobs.open}
+        onClose={batchJobs.onClose}
+        disableClose={batchJobs.running}
+        closeLabel="Close batch jobs dialog"
+        ariaLabel="Run image batch jobs"
+        panelClassName="max-w-2xl p-5"
+      >
+        <div className="mb-4 flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+              Batch Jobs
+            </p>
+            <h4 className="text-lg font-semibold text-zinc-900">Run Image Jobs</h4>
+            <p className="mt-1 text-xs text-zinc-500">
+              Select one or more operations and content types. Jobs run on the currently visible gallery assets.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={batchJobs.onClose}
+            className="rounded-lg border border-zinc-200 px-3 py-1 text-xs font-semibold text-zinc-600 hover:bg-zinc-50"
+            disabled={batchJobs.running}
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="space-y-4">
+          <div>
+            <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+              Operations
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {batchJobs.operationOptions.map((option) => (
+                <label
+                  key={option.key}
+                  className="inline-flex items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm text-zinc-700"
+                >
+                  <input
+                    type="checkbox"
+                    checked={option.checked}
+                    onChange={option.onToggle}
+                    disabled={batchJobs.running}
+                  />
+                  {option.label}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+              Content Types
+            </p>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+              {batchJobs.contentSectionOptions.map((option) => (
+                <label
+                  key={option.key}
+                  className="inline-flex items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-xs text-zinc-700"
+                >
+                  <input
+                    type="checkbox"
+                    checked={option.checked}
+                    onChange={option.onToggle}
+                    disabled={batchJobs.running}
+                  />
+                  {option.label}
+                </label>
+              ))}
+            </div>
+          </div>
+          <p className="rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-xs text-zinc-600">
+            {batchJobs.preflightSummary}
+          </p>
+        </div>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={batchJobs.onClose}
+            className="rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
+            disabled={batchJobs.running}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={batchJobs.onRun}
+            className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white hover:bg-zinc-800 disabled:opacity-50"
+            disabled={batchJobs.running}
+          >
+            {batchJobs.running ? "Running..." : "Run Batch Jobs"}
+          </button>
+        </div>
+      </AdminModal>
+
+      <AdminModal
+        isOpen={Boolean(roleRename.draft)}
+        onClose={roleRename.onClose}
+        disableClose={roleRename.saving}
+        closeLabel="Close role rename dialog"
+        ariaLabel="Rename role"
+        panelClassName="max-w-md"
+      >
+        {roleRename.draft && (
+          <>
+            <h4 className="text-lg font-semibold text-zinc-900">Rename Role</h4>
+            <p className="mt-1 text-sm text-zinc-500">
+              Current: {roleRename.draft.originalName}
+            </p>
+            <label className="mt-4 block text-xs font-semibold uppercase tracking-[0.16em] text-zinc-500">
+              New Name
+              <input
+                value={roleRename.draft.nextName}
+                onChange={(event) => roleRename.onNameChange(event.target.value)}
+                className="mt-1 block w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-700"
+                placeholder="Housewife"
+                required
+              />
+            </label>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={roleRename.onClose}
+                disabled={roleRename.saving}
+                className="rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={roleRename.onSave}
+                disabled={roleRename.saving}
+                className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white hover:bg-zinc-800 disabled:opacity-50"
+              >
+                {roleRename.saving ? "Saving..." : "Save Role"}
+              </button>
+            </div>
+          </>
+        )}
+      </AdminModal>
+
+      <AdminModal
+        isOpen={Boolean(castRoles.draft)}
+        onClose={castRoles.onClose}
+        disableClose={castRoles.saving}
+        closeLabel="Close cast role editor"
+        ariaLabel="Assign cast roles"
+        panelClassName="max-w-xl"
+      >
+        {castRoles.draft && (
+          <>
+            <h4 className="text-lg font-semibold text-zinc-900">
+              Assign Roles for {castRoles.draft.personName}
+            </h4>
+            <p className="mt-1 text-sm text-zinc-500">
+              Enter comma-separated role names. Missing roles will be created automatically.
+            </p>
+            <label className="mt-4 block text-xs font-semibold uppercase tracking-[0.16em] text-zinc-500">
+              Roles
+              <textarea
+                value={castRoles.draft.roleCsv}
+                onChange={(event) => castRoles.onRoleCsvChange(event.target.value)}
+                className="mt-1 block w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-700"
+                rows={4}
+                placeholder="Housewife, Friend Of"
+              />
+            </label>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={castRoles.onClose}
+                disabled={castRoles.saving}
+                className="rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={castRoles.onSave}
+                disabled={castRoles.saving}
+                className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white hover:bg-zinc-800 disabled:opacity-50"
+              >
+                {castRoles.saving ? "Saving..." : "Save Roles"}
+              </button>
+            </div>
+          </>
+        )}
+      </AdminModal>
+    </>
+  );
+}

--- a/apps/web/src/components/admin/ShowBravoSyncModal.tsx
+++ b/apps/web/src/components/admin/ShowBravoSyncModal.tsx
@@ -1,0 +1,404 @@
+"use client";
+
+import { GalleryImage } from "@/app/admin/trr-shows/[showId]/ShowPageMedia";
+import AdminModal from "@/components/admin/AdminModal";
+import ShowBravoSyncPreviewStep, {
+  type BravoSyncRunMode,
+  type BravoSyncSelectedImageSummary,
+  type ShowBravoSyncPreviewStepProps,
+} from "@/components/admin/ShowBravoSyncPreviewStep";
+
+export type ShowBravoSyncModalProps = {
+  modePicker: {
+    open: boolean;
+    onClose: () => void;
+    onStart: (mode: BravoSyncRunMode) => void;
+  };
+  dialog: {
+    open: boolean;
+    step: "preview" | "confirm";
+    modeSummaryLabel: string;
+    previewSignature: string | null;
+    commitLoading: boolean;
+    onClose: () => void;
+    onBack: () => void;
+    onCancel: () => void;
+    onNext: () => void;
+    onCommit: () => void | Promise<void>;
+  };
+  season: {
+    targetSeasonNumber: number | null;
+    defaultSeasonNumber: number | null;
+    options: ReadonlyArray<number>;
+    onChange: (seasonNumber: number | null) => void;
+  };
+  preview: ShowBravoSyncPreviewStepProps;
+  confirm: {
+    castSyncCount: number;
+    selectedImageSummaries: ReadonlyArray<BravoSyncSelectedImageSummary>;
+  };
+};
+
+export default function ShowBravoSyncModal({
+  modePicker,
+  dialog,
+  season,
+  preview,
+  confirm,
+}: ShowBravoSyncModalProps) {
+  const {
+    open: syncBravoModePickerOpen,
+    onClose: closeModePicker,
+    onStart: startSyncBravoFlow,
+  } = modePicker;
+  const {
+    open: syncBravoOpen,
+    step: syncBravoStep,
+    modeSummaryLabel: syncBravoModeSummaryLabel,
+    previewSignature: syncBravoPreviewSignature,
+    commitLoading: syncBravoCommitLoading,
+    onNext: openSyncBravoConfirmStep,
+    onCommit: commitSyncByBravo,
+  } = dialog;
+  const {
+    targetSeasonNumber: syncBravoTargetSeasonNumber,
+    defaultSeasonNumber: defaultSyncBravoSeasonNumber,
+    options: syncBravoSeasonOptions,
+    onChange: setSyncBravoTargetSeasonNumber,
+  } = season;
+  const {
+    runMode: syncBravoRunMode,
+    loading: syncBravoLoading,
+    showName,
+    bravoUrl,
+    error: syncBravoError,
+    notice: syncBravoNotice,
+    description: syncBravoDescription,
+    airs: syncBravoAirs,
+    applyDescriptionToShow: syncBravoApplyDescriptionToShow,
+    probeSummary: syncBravoProbeSummary,
+    fandomProbeSummary: syncFandomProbeSummary,
+    fandomDomainsUsed: syncFandomDomainsUsed,
+    validProfileCards: syncBravoValidProfileCards,
+    fandomValidProfileCards: syncFandomValidProfileCards,
+    castLinks: syncBravoPreviewCastLinks,
+  } = preview;
+  const {
+    castSyncCount: syncBravoCastSyncCount,
+    selectedImageSummaries: syncBravoSelectedImageSummaries,
+  } = confirm;
+
+  return (
+    <>
+        <AdminModal
+          isOpen={syncBravoModePickerOpen}
+          onClose={() => closeModePicker()}
+          closeLabel="Close sync mode picker"
+          ariaLabel="Sync by Bravo mode picker"
+          panelClassName="max-w-md"
+        >
+              <h3 className="text-lg font-bold text-zinc-900">Sync by Bravo</h3>
+              <p className="mt-1 text-sm text-zinc-600">
+                Choose what to sync from Bravo for this run.
+              </p>
+              <div className="mt-4 space-y-3">
+                <button
+                  type="button"
+                  onClick={() => startSyncBravoFlow("full")}
+                  className="w-full rounded-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white hover:bg-zinc-800"
+                >
+                  Sync All Info
+                </button>
+                <button
+                  type="button"
+                  onClick={() => startSyncBravoFlow("cast-only")}
+                  className="w-full rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 hover:bg-zinc-50"
+                >
+                  Cast Info only
+                </button>
+              </div>
+              <button
+                type="button"
+                onClick={() => closeModePicker()}
+                className="mt-4 w-full rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 hover:bg-zinc-50"
+              >
+                Cancel
+              </button>
+        </AdminModal>
+
+        <AdminModal
+          isOpen={syncBravoOpen}
+          onClose={dialog.onClose}
+          disableClose={syncBravoLoading}
+          closeLabel="Close Bravo sync dialog"
+          ariaLabel="Import by Bravo"
+          panelClassName="max-h-[90vh] max-w-3xl overflow-y-auto"
+        >
+              <div className="mb-4 flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-lg font-bold text-zinc-900">
+                    Import by Bravo {syncBravoRunMode === "cast-only" ? "(Cast Info only)" : ""}
+                  </h3>
+                  <p className="text-sm text-zinc-500">Preview and commit persisted Bravo snapshots for this show.</p>
+                  <p className="mt-1 text-xs font-semibold uppercase tracking-[0.18em] text-zinc-400">
+                    Step {syncBravoStep === "preview" ? "1" : "2"} of 2
+                  </p>
+                  <p className="mt-1 text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                    Selected Mode: {syncBravoModeSummaryLabel}
+                  </p>
+                  {syncBravoPreviewSignature && (
+                    <p className="mt-1 text-[11px] text-zinc-500">
+                      Preview Signature: {syncBravoPreviewSignature.slice(0, 12)}...
+                    </p>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={dialog.onClose}
+                  disabled={syncBravoLoading}
+                  className="rounded-md border border-zinc-200 px-3 py-1 text-sm font-semibold text-zinc-600 hover:bg-zinc-50"
+                >
+                  Close
+                </button>
+              </div>
+
+              <div className="mb-4 rounded-lg border border-zinc-200 bg-zinc-50 p-3">
+                <label className="block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                  Sync Season
+                  <select
+                    value={syncBravoTargetSeasonNumber ?? ""}
+                    onChange={(event) => {
+                      const raw = event.target.value;
+                      const parsed = Number.parseInt(raw, 10);
+                      setSyncBravoTargetSeasonNumber(
+                        Number.isFinite(parsed) ? parsed : defaultSyncBravoSeasonNumber
+                      );
+                    }}
+                    disabled={syncBravoLoading || syncBravoSeasonOptions.length === 0}
+                    className="mt-1 block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm font-semibold normal-case tracking-normal text-zinc-800 disabled:opacity-50"
+                  >
+                    {syncBravoSeasonOptions.length === 0 ? (
+                      <option value="">No eligible seasons</option>
+                    ) : (
+                      syncBravoSeasonOptions.map((seasonNumber) => (
+                        <option key={seasonNumber} value={seasonNumber}>
+                          Season {seasonNumber}
+                        </option>
+                      ))
+                    )}
+                  </select>
+                </label>
+                <p className="mt-2 text-xs text-zinc-500">
+                  Bravo profile images from this run will be assigned as season promos for the selected season. Eligible seasons require more than 1 episode or a premiere date.
+                </p>
+              </div>
+
+              {syncBravoStep === "preview" ? (
+                <ShowBravoSyncPreviewStep {...preview} />
+              ) : (
+                <div className="space-y-4">
+                  <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                      Show Name
+                    </p>
+                    <p className="mt-1 text-sm font-semibold text-zinc-800">{showName}</p>
+                    <p className="mt-3 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                      Bravo Show URL
+                    </p>
+                    {bravoUrl ? (
+                      <a
+                        href={bravoUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="mt-1 block break-all text-xs text-blue-700 hover:underline"
+                      >
+                        {bravoUrl}
+                      </a>
+                    ) : (
+                      <p className="mt-1 text-xs text-zinc-500">Could not infer URL yet.</p>
+                    )}
+                    {syncBravoRunMode !== "cast-only" && syncBravoDescription.trim() && (
+                      <>
+                        <p className="mt-3 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                          Description
+                        </p>
+                        <p className="mt-1 text-sm text-zinc-700">{syncBravoDescription.trim()}</p>
+                        <p className="mt-1 text-xs text-zinc-500">
+                          {syncBravoApplyDescriptionToShow
+                            ? "Will be applied to show profile."
+                            : "Will not overwrite show profile unless enabled in preview step."}
+                        </p>
+                      </>
+                    )}
+                    {syncBravoRunMode !== "cast-only" && syncBravoAirs.trim() && (
+                      <>
+                        <p className="mt-3 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                          Airs / Tune-In
+                        </p>
+                        <p className="mt-1 text-sm text-zinc-700">{syncBravoAirs.trim()}</p>
+                      </>
+                    )}
+                  </div>
+
+                  <div>
+                    <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                      Cast Members Being Synced ({syncBravoCastSyncCount})
+                    </p>
+                    {syncBravoRunMode === "cast-only" && (
+                      <>
+                        <p className="mb-1 text-xs text-zinc-500">
+                          Bravo summary: tested {syncBravoProbeSummary.tested}, valid{" "}
+                          {syncBravoProbeSummary.valid}, missing {syncBravoProbeSummary.missing},
+                          errors {syncBravoProbeSummary.errors}.
+                        </p>
+                        <p className="mb-2 text-xs text-zinc-500">
+                          Fandom summary: tested {syncFandomProbeSummary.tested}, valid{" "}
+                          {syncFandomProbeSummary.valid}, missing {syncFandomProbeSummary.missing},
+                          errors {syncFandomProbeSummary.errors}.
+                        </p>
+                        {syncFandomDomainsUsed.length > 0 && (
+                          <p className="mb-2 text-xs text-zinc-500">
+                            Fandom domains used: {syncFandomDomainsUsed.join(", ")}
+                          </p>
+                        )}
+                      </>
+                    )}
+                    {syncBravoRunMode === "cast-only" ? (
+                      <div className="space-y-3">
+                        <div>
+                          <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                            Bravo Profiles ({syncBravoValidProfileCards.length})
+                          </p>
+                          {syncBravoValidProfileCards.length === 0 ? (
+                            <p className="text-sm text-zinc-500">
+                              No valid Bravo cast profile URLs were detected in this preview.
+                            </p>
+                          ) : (
+                            <div className="space-y-2">
+                              {syncBravoValidProfileCards.map((person) => (
+                                <article
+                                  key={person.url}
+                                  className="rounded-lg border border-zinc-200 bg-zinc-50 p-3"
+                                >
+                                  <p className="text-sm font-semibold text-zinc-900">
+                                    {person.name || "Unresolved cast member"}
+                                  </p>
+                                  <p className="mt-1 break-all text-xs text-zinc-600">{person.url}</p>
+                                </article>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                        <div>
+                          <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                            Fandom Profiles ({syncFandomValidProfileCards.length})
+                          </p>
+                          {syncFandomValidProfileCards.length === 0 ? (
+                            <p className="text-sm text-zinc-500">
+                              No valid Fandom cast profile URLs were detected in this preview.
+                            </p>
+                          ) : (
+                            <div className="space-y-2">
+                              {syncFandomValidProfileCards.map((person) => (
+                                <article
+                                  key={`confirm-fandom-${person.url}`}
+                                  className="rounded-lg border border-zinc-200 bg-zinc-50 p-3"
+                                >
+                                  <p className="text-sm font-semibold text-zinc-900">
+                                    {person.name || "Unresolved cast member"}
+                                  </p>
+                                  <p className="mt-1 break-all text-xs text-zinc-600">{person.url}</p>
+                                </article>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    ) : syncBravoPreviewCastLinks.length === 0 ? (
+                      <p className="text-sm text-zinc-500">No cast member URLs found in this preview.</p>
+                    ) : (
+                      <div className="space-y-2">
+                        {syncBravoPreviewCastLinks.map((person) => (
+                          <article
+                            key={person.url}
+                            className="rounded-lg border border-zinc-200 bg-zinc-50 p-3"
+                          >
+                            <p className="text-sm font-semibold text-zinc-900">
+                              {person.name || "Unresolved cast member"}
+                            </p>
+                            <p className="mt-1 break-all text-xs text-zinc-600">{person.url}</p>
+                          </article>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+
+                  {syncBravoRunMode !== "cast-only" && (
+                    <div>
+                      <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        Show Images Being Synced ({syncBravoSelectedImageSummaries.length})
+                      </p>
+                      {syncBravoSelectedImageSummaries.length === 0 ? (
+                        <p className="text-sm text-zinc-500">No show images selected for sync.</p>
+                      ) : (
+                        <div className="space-y-2">
+                          {syncBravoSelectedImageSummaries.map((image) => (
+                            <article
+                              key={image.url}
+                              className="flex items-start gap-3 rounded-lg border border-zinc-200 bg-zinc-50 p-3"
+                            >
+                              <div className="relative h-16 w-24 shrink-0 overflow-hidden rounded bg-zinc-100">
+                                <GalleryImage src={image.url} alt={image.alt || "Selected show image"} sizes="120px" />
+                              </div>
+                              <div className="min-w-0">
+                                <p className="line-clamp-2 text-sm font-semibold text-zinc-900">
+                                  {image.alt || "Show image"}
+                                </p>
+                                <p className="mt-1 text-xs uppercase tracking-[0.16em] text-zinc-500">
+                                  Type: {image.kind}
+                                </p>
+                                <p className="mt-1 break-all text-xs text-zinc-600">{image.url}</p>
+                              </div>
+                            </article>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {syncBravoStep === "confirm" && (syncBravoError || syncBravoNotice) && (
+                <p className={`mb-4 text-sm ${syncBravoError ? "text-red-600" : "text-zinc-600"}`}>
+                  {syncBravoError || syncBravoNotice}
+                </p>
+              )}
+
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={syncBravoStep === "confirm" ? dialog.onBack : dialog.onCancel}
+                  disabled={syncBravoLoading}
+                  className="rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 hover:bg-zinc-50"
+                >
+                  {syncBravoStep === "confirm" ? "Back" : "Cancel"}
+                </button>
+                <button
+                  type="button"
+                  onClick={syncBravoStep === "confirm" ? commitSyncByBravo : openSyncBravoConfirmStep}
+                  disabled={syncBravoLoading}
+                  className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white hover:bg-zinc-800 disabled:opacity-50"
+                >
+                  {syncBravoStep === "confirm"
+                    ? syncBravoCommitLoading
+                      ? "Syncing..."
+                      : syncBravoRunMode === "cast-only"
+                        ? "Sync Cast Info only"
+                        : "Sync All Info"
+                    : "Next"}
+                </button>
+              </div>
+        </AdminModal>
+    </>
+  );
+}

--- a/apps/web/src/components/admin/ShowBravoSyncPreviewStep.tsx
+++ b/apps/web/src/components/admin/ShowBravoSyncPreviewStep.tsx
@@ -1,0 +1,889 @@
+"use client";
+
+import { GalleryImage } from "@/app/admin/trr-shows/[showId]/ShowPageMedia";
+
+export type BravoImportImageKind =
+  | "poster"
+  | "backdrop"
+  | "logo"
+  | "episode_still"
+  | "cast"
+  | "promo"
+  | "intro"
+  | "reunion"
+  | "other";
+
+export type BravoSyncRunMode = "full" | "cast-only";
+
+export type BravoSyncCandidateResult = {
+  url: string;
+  name?: string | null;
+  status?: string;
+  error?: string | null;
+};
+
+export type BravoSyncCandidateSummary = {
+  tested: number;
+  valid: number;
+  missing: number;
+  errors: number;
+};
+
+export type BravoSyncProfileCard = {
+  url: string;
+  name: string | null;
+  bio: string | null;
+  heroImageUrl: string | null;
+  socialLinks: Array<{
+    key: string;
+    label: string;
+    url: string;
+    handle: string | null;
+  }>;
+};
+
+export type BravoSyncCandidateIssue = {
+  url: string;
+  status: "missing" | "error";
+  reason: string | null;
+};
+
+export type BravoSyncImage = {
+  url: string;
+  alt?: string | null;
+};
+
+export type BravoSyncCastLink = {
+  name: string | null;
+  url: string;
+};
+
+export type BravoSyncNewsItem = {
+  headline?: string | null;
+  image_url?: string | null;
+  article_url: string;
+  published_at?: string | null;
+};
+
+export type BravoSyncVideoItem = {
+  title?: string | null;
+  runtime?: string | null;
+  image_url?: string | null;
+  clip_url: string;
+  season_number?: number | null;
+  published_at?: string | null;
+};
+
+export type BravoSyncSelectedImageSummary = {
+  url: string;
+  alt: string | null;
+  kind: BravoImportImageKind;
+};
+
+export type ShowBravoSyncPreviewStepProps = {
+  runMode: BravoSyncRunMode;
+  loading: boolean;
+  previewLoading: boolean;
+  showName: string;
+  bravoUrl: string | null;
+  error: string | null;
+  notice: string | null;
+  description: string;
+  airs: string;
+  applyDescriptionToShow: boolean;
+  images: ReadonlyArray<BravoSyncImage>;
+  selectedImages: ReadonlySet<string>;
+  imageKinds: Readonly<Record<string, BravoImportImageKind>>;
+  personCandidateResults: ReadonlyArray<BravoSyncCandidateResult>;
+  fandomPersonCandidateResults: ReadonlyArray<BravoSyncCandidateResult>;
+  probeSummary: BravoSyncCandidateSummary;
+  fandomProbeSummary: BravoSyncCandidateSummary;
+  probeStatusMessage: string | null;
+  probeActive: boolean;
+  probeTotal: number;
+  validProfileCards: ReadonlyArray<BravoSyncProfileCard>;
+  fandomValidProfileCards: ReadonlyArray<BravoSyncProfileCard>;
+  candidateIssues: ReadonlyArray<BravoSyncCandidateIssue>;
+  fandomCandidateIssues: ReadonlyArray<BravoSyncCandidateIssue>;
+  fandomDomainsUsed: ReadonlyArray<string>;
+  castLinks: ReadonlyArray<BravoSyncCastLink>;
+  newsItems: ReadonlyArray<BravoSyncNewsItem>;
+  videos: ReadonlyArray<BravoSyncVideoItem>;
+  videoSeasonFilter: "all" | number;
+  videoSeasonOptions: ReadonlyArray<number>;
+  onRefreshPreview: () => void | Promise<void>;
+  onDescriptionChange: (value: string) => void;
+  onAirsChange: (value: string) => void;
+  onApplyDescriptionChange: (value: boolean) => void;
+  onImageSelectionChange: (url: string, selected: boolean) => void;
+  onImageKindChange: (url: string, kind: BravoImportImageKind) => void;
+  onVideoSeasonFilterChange: (value: "all" | number) => void;
+  inferImageKind: (image: BravoSyncImage) => BravoImportImageKind;
+  formatPublishedDate: (value: string | null | undefined) => string | null;
+};
+
+const BRAVO_IMPORT_IMAGE_KIND_OPTIONS: Array<{
+  value: BravoImportImageKind;
+  label: string;
+}> = [
+  { value: "poster", label: "Poster" },
+  { value: "backdrop", label: "Backdrop" },
+  { value: "logo", label: "Logo" },
+  { value: "episode_still", label: "Episode Still" },
+  { value: "cast", label: "Cast" },
+  { value: "promo", label: "Promo" },
+  { value: "intro", label: "Intro" },
+  { value: "reunion", label: "Reunion" },
+  { value: "other", label: "Other" },
+];
+
+export default function ShowBravoSyncPreviewStep({
+  runMode: syncBravoRunMode,
+  loading: syncBravoLoading,
+  previewLoading: syncBravoPreviewLoading,
+  showName,
+  bravoUrl,
+  error: syncBravoError,
+  notice: syncBravoNotice,
+  description: syncBravoDescription,
+  airs: syncBravoAirs,
+  applyDescriptionToShow: syncBravoApplyDescriptionToShow,
+  images: syncBravoImages,
+  selectedImages: syncBravoSelectedImages,
+  imageKinds: syncBravoImageKinds,
+  personCandidateResults: syncBravoPersonCandidateResults,
+  fandomPersonCandidateResults: syncFandomPersonCandidateResults,
+  probeSummary: syncBravoProbeSummary,
+  fandomProbeSummary: syncFandomProbeSummary,
+  probeStatusMessage: syncBravoProbeStatusMessage,
+  probeActive: syncBravoProbeActive,
+  probeTotal: syncBravoProbeTotal,
+  validProfileCards: syncBravoValidProfileCards,
+  fandomValidProfileCards: syncFandomValidProfileCards,
+  candidateIssues: syncBravoCandidateIssues,
+  fandomCandidateIssues: syncFandomCandidateIssues,
+  fandomDomainsUsed: syncFandomDomainsUsed,
+  castLinks: syncBravoPreviewCastLinks,
+  newsItems: syncBravoPreviewNews,
+  videos: syncBravoFilteredPreviewVideos,
+  videoSeasonFilter: syncBravoPreviewSeasonFilter,
+  videoSeasonOptions: syncBravoPreviewSeasonOptions,
+  onRefreshPreview,
+  onDescriptionChange,
+  onAirsChange,
+  onApplyDescriptionChange,
+  onImageSelectionChange,
+  onImageKindChange,
+  onVideoSeasonFilterChange,
+  inferImageKind: inferBravoImportImageKind,
+  formatPublishedDate: formatBravoPublishedDate,
+}: ShowBravoSyncPreviewStepProps) {
+  return (
+    <>
+              <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                <div>
+                  <p className="mb-1 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Show Name
+                  </p>
+                  <p className="text-sm font-semibold text-zinc-900">{showName}</p>
+                  <p className="mt-2 mb-1 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Bravo Show URL
+                  </p>
+                  {bravoUrl ? (
+                    <a
+                      href={bravoUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="block break-all text-xs text-blue-700 hover:underline"
+                    >
+                      {bravoUrl}
+                    </a>
+                  ) : (
+                    <p className="text-xs text-zinc-500">Could not infer URL yet.</p>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => void onRefreshPreview()}
+                  disabled={syncBravoLoading}
+                  className="rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
+                >
+                  {syncBravoPreviewLoading
+                    ? "Refreshing..."
+                    : syncBravoRunMode === "cast-only"
+                      ? "Refresh Cast Preview"
+                      : "Refresh Preview"}
+                </button>
+              </div>
+
+              {(syncBravoError || syncBravoNotice) && (
+                <p className={`mb-4 text-sm ${syncBravoError ? "text-red-600" : "text-zinc-600"}`}>
+                  {syncBravoError || syncBravoNotice}
+                </p>
+              )}
+
+              {syncBravoRunMode === "cast-only" && (
+                <p className="mb-4 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm text-zinc-600">
+                  Cast-only mode probes canonical Bravo (`/people/*`) and Fandom (`/wiki/*`) cast profile URLs and reports
+                  valid, missing, and error candidates for each source.
+                </p>
+              )}
+
+              {syncBravoRunMode !== "cast-only" && (
+                <>
+                  <div className="mb-4 grid gap-4 md:grid-cols-2">
+                    <label className="block">
+                      <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        Description
+                      </span>
+                      <textarea
+                        value={syncBravoDescription}
+                        onChange={(event) => onDescriptionChange(event.target.value)}
+                        rows={4}
+                        className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm text-zinc-900 focus:border-zinc-400 focus:outline-none"
+                      />
+                    </label>
+                    <label className="block">
+                      <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        Airs / Tune-In
+                      </span>
+                      <textarea
+                        value={syncBravoAirs}
+                        onChange={(event) => onAirsChange(event.target.value)}
+                        rows={4}
+                        className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm text-zinc-900 focus:border-zinc-400 focus:outline-none"
+                      />
+                    </label>
+                  </div>
+                  <label className="mb-4 flex items-start gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm text-zinc-700">
+                    <input
+                      type="checkbox"
+                      checked={syncBravoApplyDescriptionToShow}
+                      onChange={(event) => onApplyDescriptionChange(event.target.checked)}
+                      className="mt-0.5"
+                    />
+                    <span>
+                      Apply Bravo description to show profile.
+                      <span className="ml-1 text-xs text-zinc-500">
+                        Off by default. When off, commit keeps canonical show bio sources (IMDb/TMDb/Knowledge/Fandom).
+                      </span>
+                    </span>
+                  </label>
+
+                  <div className="mb-4">
+                    <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                      Show Images
+                    </p>
+                    {syncBravoImages.length === 0 ? (
+                      <p className="text-sm text-zinc-500">Run preview to load image candidates.</p>
+                    ) : (
+                      <div className="grid gap-3 sm:grid-cols-2">
+                        {syncBravoImages.map((image) => {
+                          const checked = syncBravoSelectedImages.has(image.url);
+                          const selectedKind =
+                            syncBravoImageKinds[image.url] ?? inferBravoImportImageKind(image);
+                          return (
+                            <div key={image.url} className="flex items-start gap-3 rounded-lg border border-zinc-200 p-3">
+                              <input
+                                type="checkbox"
+                                checked={checked}
+                                onChange={(event) =>
+                                  onImageSelectionChange(image.url, event.target.checked)
+                                }
+                                className="mt-1"
+                              />
+                              <div className="relative h-16 w-28 overflow-hidden rounded bg-zinc-100">
+                                <GalleryImage src={image.url} alt={image.alt || "Bravo image"} sizes="120px" />
+                              </div>
+                              <div className="min-w-0 flex-1">
+                                <span className="line-clamp-2 text-xs text-zinc-600">{image.alt || image.url}</span>
+                                <div className="mt-2 flex items-center gap-2">
+                                  <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-zinc-500">
+                                    Type
+                                  </span>
+                                  <select
+                                    value={selectedKind}
+                                    onChange={(event) =>
+                                      onImageKindChange(
+                                        image.url,
+                                        event.target.value as BravoImportImageKind
+                                      )
+                                    }
+                                    className="rounded border border-zinc-200 bg-white px-2 py-1 text-xs text-zinc-700"
+                                  >
+                                    {BRAVO_IMPORT_IMAGE_KIND_OPTIONS.map((option) => (
+                                      <option key={option.value} value={option.value}>
+                                        {option.label}
+                                      </option>
+                                    ))}
+                                  </select>
+                                </div>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                </>
+              )}
+
+              <div className="mb-4">
+                <div className="mb-2 flex items-center justify-between gap-2">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Cast Member URLs
+                  </p>
+                  {syncBravoRunMode === "cast-only" && (
+                    <div className="text-right text-[11px] font-semibold text-zinc-500">
+                      <p>
+                        Bravo tested {syncBravoProbeSummary.tested} / valid {syncBravoProbeSummary.valid} /
+                        missing {syncBravoProbeSummary.missing} / error {syncBravoProbeSummary.errors}
+                      </p>
+                      <p>
+                        Fandom tested {syncFandomProbeSummary.tested} / valid {syncFandomProbeSummary.valid} /
+                        missing {syncFandomProbeSummary.missing} / error {syncFandomProbeSummary.errors}
+                      </p>
+                    </div>
+                  )}
+                </div>
+                {syncBravoRunMode === "cast-only" && syncBravoProbeStatusMessage && (
+                  <p className="mb-2 text-xs text-zinc-500">
+                    {syncBravoProbeStatusMessage}
+                    {syncBravoProbeActive && syncBravoProbeTotal > 30 ? " This may take several minutes." : ""}
+                  </p>
+                )}
+
+                {syncBravoRunMode === "cast-only" ? (
+                  <div className="space-y-3">
+                    <div className="rounded-lg border border-zinc-200 bg-white p-3">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        Probe Queue
+                      </p>
+                      {syncBravoPersonCandidateResults.length === 0 ? (
+                        <p className="mt-2 text-sm text-zinc-500">
+                          Preparing canonical `/people/*` candidate probes...
+                        </p>
+                      ) : (
+                        <div className="mt-2 space-y-2">
+                          {syncBravoPersonCandidateResults.map((result) => {
+                            const status = String(result.status || "pending").trim().toLowerCase();
+                            const badgeClass =
+                              status === "ok"
+                                ? "bg-emerald-100 text-emerald-700"
+                                : status === "missing"
+                                  ? "bg-amber-100 text-amber-700"
+                                  : status === "error"
+                                    ? "bg-red-100 text-red-700"
+                                    : status === "in_progress"
+                                      ? "bg-blue-100 text-blue-700"
+                                      : "bg-zinc-200 text-zinc-700";
+                            return (
+                              <article
+                                key={`candidate-${result.url}`}
+                                className="rounded-md border border-zinc-200 bg-zinc-50 p-2"
+                              >
+                                <div className="flex items-center gap-2">
+                                  <span
+                                    className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] ${badgeClass}`}
+                                  >
+                                    {status}
+                                  </span>
+                                  <div className="min-w-0">
+                                    <p className="truncate text-xs font-semibold text-zinc-800">
+                                      {result.name || "Unresolved cast member"}
+                                    </p>
+                                    <a
+                                      href={result.url}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      className="min-w-0 break-all text-xs text-blue-700 hover:underline"
+                                    >
+                                      {result.url}
+                                    </a>
+                                  </div>
+                                </div>
+                                {result.error && (
+                                  <p className="mt-1 text-xs text-zinc-600">{result.error}</p>
+                                )}
+                              </article>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+
+                    {syncBravoValidProfileCards.length === 0 ? (
+                      <p className="text-sm text-zinc-500">
+                        No valid Bravo profile pages resolved from canonical `/people/*` probes.
+                      </p>
+                    ) : (
+                      <div className="space-y-2">
+                        {syncBravoValidProfileCards.map((person) => (
+                          <article
+                            key={person.url}
+                            className="rounded-lg border border-zinc-200 bg-zinc-50 p-3"
+                          >
+                            <div className="flex gap-3">
+                              <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded bg-zinc-100">
+                                {person.heroImageUrl ? (
+                                  <GalleryImage
+                                    src={person.heroImageUrl}
+                                    alt={person.name || "Bravo profile"}
+                                    sizes="96px"
+                                  />
+                                ) : (
+                                  <div className="flex h-full items-center justify-center text-[11px] text-zinc-400">
+                                    No image
+                                  </div>
+                                )}
+                              </div>
+                              <div className="min-w-0 flex-1">
+                                <p className="text-sm font-semibold text-zinc-900">
+                                  {person.name || "Unresolved cast member"}
+                                </p>
+                                <a
+                                  href={person.url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="mt-1 block break-all text-xs text-blue-700 hover:underline"
+                                >
+                                  {person.url}
+                                </a>
+                                {person.bio && (
+                                  <p className="mt-2 line-clamp-3 text-xs text-zinc-600">{person.bio}</p>
+                                )}
+                                {person.socialLinks.length > 0 && (
+                                  <div className="mt-2 flex flex-wrap gap-1.5">
+                                    {person.socialLinks.map((social) => (
+                                      <a
+                                        key={`${person.url}-${social.key}-${social.url}`}
+                                        href={social.url}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="rounded-full border border-zinc-300 bg-white px-2 py-0.5 text-[11px] font-medium text-zinc-700 hover:bg-zinc-100"
+                                      >
+                                        {social.label}
+                                        {social.handle ? ` ${social.handle}` : ""}
+                                      </a>
+                                    ))}
+                                  </div>
+                                )}
+                              </div>
+                            </div>
+                          </article>
+                        ))}
+                      </div>
+                    )}
+
+                    {syncBravoCandidateIssues.length > 0 && (
+                      <div className="rounded-lg border border-zinc-200 bg-white p-3">
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                          Missing / Error Profiles
+                        </p>
+                        <div className="mt-2 space-y-2">
+                          {syncBravoCandidateIssues.map((result) => (
+                            <article
+                              key={`${result.status}-${result.url}`}
+                              className="rounded-md border border-zinc-200 bg-zinc-50 p-2"
+                            >
+                              <div className="flex items-center gap-2">
+                                <span
+                                  className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] ${
+                                    result.status === "missing"
+                                      ? "bg-amber-100 text-amber-700"
+                                      : "bg-red-100 text-red-700"
+                                  }`}
+                                >
+                                  {result.status}
+                                </span>
+                                <a
+                                  href={result.url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="min-w-0 break-all text-xs text-blue-700 hover:underline"
+                                >
+                                  {result.url}
+                                </a>
+                              </div>
+                              {result.reason && (
+                                <p className="mt-1 text-xs text-zinc-600">{result.reason}</p>
+                              )}
+                            </article>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+
+                    <div className="rounded-lg border border-zinc-200 bg-white p-3">
+                      <div className="flex items-center justify-between gap-2">
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                          Fandom Probe Queue
+                        </p>
+                        <p className="text-[11px] font-semibold text-zinc-500">
+                          tested {syncFandomProbeSummary.tested} / valid {syncFandomProbeSummary.valid} /
+                          missing {syncFandomProbeSummary.missing} / error {syncFandomProbeSummary.errors}
+                        </p>
+                      </div>
+                      {syncFandomDomainsUsed.length > 0 && (
+                        <p className="mt-1 text-[11px] text-zinc-500">
+                          Domains: {syncFandomDomainsUsed.join(", ")}
+                        </p>
+                      )}
+                      {syncFandomPersonCandidateResults.length === 0 ? (
+                        <p className="mt-2 text-sm text-zinc-500">
+                          Preparing canonical `/wiki/*` candidate probes...
+                        </p>
+                      ) : (
+                        <div className="mt-2 space-y-2">
+                          {syncFandomPersonCandidateResults.map((result) => {
+                            const status = String(result.status || "pending").trim().toLowerCase();
+                            const badgeClass =
+                              status === "ok"
+                                ? "bg-emerald-100 text-emerald-700"
+                                : status === "missing"
+                                  ? "bg-amber-100 text-amber-700"
+                                  : status === "error"
+                                    ? "bg-red-100 text-red-700"
+                                    : status === "in_progress"
+                                      ? "bg-blue-100 text-blue-700"
+                                      : "bg-zinc-200 text-zinc-700";
+                            return (
+                              <article
+                                key={`fandom-candidate-${result.url}`}
+                                className="rounded-md border border-zinc-200 bg-zinc-50 p-2"
+                              >
+                                <div className="flex items-center gap-2">
+                                  <span
+                                    className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] ${badgeClass}`}
+                                  >
+                                    {status}
+                                  </span>
+                                  <div className="min-w-0">
+                                    <p className="truncate text-xs font-semibold text-zinc-800">
+                                      {result.name || "Unresolved cast member"}
+                                    </p>
+                                    <a
+                                      href={result.url}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      className="min-w-0 break-all text-xs text-blue-700 hover:underline"
+                                    >
+                                      {result.url}
+                                    </a>
+                                  </div>
+                                </div>
+                                {result.error && (
+                                  <p className="mt-1 text-xs text-zinc-600">{result.error}</p>
+                                )}
+                              </article>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+
+                    {syncFandomValidProfileCards.length === 0 ? (
+                      <p className="text-sm text-zinc-500">
+                        No valid Fandom profile pages resolved from canonical `/wiki/*` probes.
+                      </p>
+                    ) : (
+                      <div className="space-y-2">
+                        {syncFandomValidProfileCards.map((person) => (
+                          <article
+                            key={`fandom-profile-${person.url}`}
+                            className="rounded-lg border border-zinc-200 bg-zinc-50 p-3"
+                          >
+                            <div className="flex gap-3">
+                              <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded bg-zinc-100">
+                                {person.heroImageUrl ? (
+                                  <GalleryImage
+                                    src={person.heroImageUrl}
+                                    alt={person.name || "Fandom profile"}
+                                    sizes="96px"
+                                  />
+                                ) : (
+                                  <div className="flex h-full items-center justify-center text-[11px] text-zinc-400">
+                                    No image
+                                  </div>
+                                )}
+                              </div>
+                              <div className="min-w-0 flex-1">
+                                <p className="text-sm font-semibold text-zinc-900">
+                                  {person.name || "Unresolved cast member"}
+                                </p>
+                                <a
+                                  href={person.url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="mt-1 block break-all text-xs text-blue-700 hover:underline"
+                                >
+                                  {person.url}
+                                </a>
+                                {person.bio && (
+                                  <p className="mt-2 line-clamp-3 text-xs text-zinc-600">{person.bio}</p>
+                                )}
+                              </div>
+                            </div>
+                          </article>
+                        ))}
+                      </div>
+                    )}
+
+                    {syncFandomCandidateIssues.length > 0 && (
+                      <div className="rounded-lg border border-zinc-200 bg-white p-3">
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                          Fandom Missing / Error Profiles
+                        </p>
+                        <div className="mt-2 space-y-2">
+                          {syncFandomCandidateIssues.map((result) => (
+                            <article
+                              key={`fandom-${result.status}-${result.url}`}
+                              className="rounded-md border border-zinc-200 bg-zinc-50 p-2"
+                            >
+                              <div className="flex items-center gap-2">
+                                <span
+                                  className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] ${
+                                    result.status === "missing"
+                                      ? "bg-amber-100 text-amber-700"
+                                      : "bg-red-100 text-red-700"
+                                  }`}
+                                >
+                                  {result.status}
+                                </span>
+                                <a
+                                  href={result.url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="min-w-0 break-all text-xs text-blue-700 hover:underline"
+                                >
+                                  {result.url}
+                                </a>
+                              </div>
+                              {result.reason && (
+                                <p className="mt-1 text-xs text-zinc-600">{result.reason}</p>
+                              )}
+                            </article>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ) : syncBravoPreviewCastLinks.length === 0 ? (
+                  <p className="text-sm text-zinc-500">No cast member URLs found in this preview.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {syncBravoPreviewCastLinks.map((person) => (
+                      <article
+                        key={person.url}
+                        className="rounded-lg border border-zinc-200 bg-zinc-50 p-3"
+                      >
+                        <p className="text-sm font-semibold text-zinc-900">
+                          {person.name || "Unresolved cast member"}
+                        </p>
+                        <a
+                          href={person.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="mt-1 block break-all text-xs text-blue-700 hover:underline"
+                        >
+                          {person.url}
+                        </a>
+                      </article>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {syncBravoRunMode !== "cast-only" && (
+                <div className="mb-4">
+                  <div className="mb-2 flex items-center justify-between gap-2">
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                      Fandom Cast Coverage
+                    </p>
+                    <p className="text-[11px] font-semibold text-zinc-500">
+                      tested {syncFandomProbeSummary.tested} / valid {syncFandomProbeSummary.valid} /
+                      missing {syncFandomProbeSummary.missing} / error {syncFandomProbeSummary.errors}
+                    </p>
+                  </div>
+                  {syncFandomDomainsUsed.length > 0 && (
+                    <p className="mb-2 text-xs text-zinc-500">
+                      Domains used: {syncFandomDomainsUsed.join(", ")}
+                    </p>
+                  )}
+                  {syncFandomValidProfileCards.length === 0 ? (
+                    <p className="text-sm text-zinc-500">No valid Fandom cast profiles found in this preview.</p>
+                  ) : (
+                    <div className="space-y-2">
+                      {syncFandomValidProfileCards.map((person) => (
+                        <article
+                          key={`full-fandom-${person.url}`}
+                          className="rounded-lg border border-zinc-200 bg-zinc-50 p-3"
+                        >
+                          <p className="text-sm font-semibold text-zinc-900">
+                            {person.name || "Unresolved cast member"}
+                          </p>
+                          <a
+                            href={person.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="mt-1 block break-all text-xs text-blue-700 hover:underline"
+                          >
+                            {person.url}
+                          </a>
+                          {person.bio && (
+                            <p className="mt-2 line-clamp-2 text-xs text-zinc-600">{person.bio}</p>
+                          )}
+                        </article>
+                      ))}
+                    </div>
+                  )}
+                  {syncFandomCandidateIssues.length > 0 && (
+                    <div className="mt-2 rounded-lg border border-zinc-200 bg-white p-3">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        Fandom Missing / Error Profiles
+                      </p>
+                      <div className="mt-2 space-y-1">
+                        {syncFandomCandidateIssues.map((result) => (
+                          <p key={`full-fandom-issue-${result.url}`} className="text-xs text-zinc-600">
+                            {result.status.toUpperCase()}: {result.url}
+                            {result.reason ? ` (${result.reason})` : ""}
+                          </p>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {syncBravoRunMode !== "cast-only" && (
+                <>
+                  <div className="mb-4">
+                    <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                      News
+                    </p>
+                    {syncBravoPreviewNews.length === 0 ? (
+                      <p className="text-sm text-zinc-500">No news items found in this preview.</p>
+                    ) : (
+                      <div className="space-y-2">
+                        {syncBravoPreviewNews.map((item) => (
+                          <article
+                            key={`${item.article_url}-${item.published_at ?? "unknown"}`}
+                            className="rounded-lg border border-zinc-200 bg-zinc-50 p-3"
+                          >
+                            <div className="flex gap-3">
+                              <div className="relative h-16 w-24 shrink-0 overflow-hidden rounded bg-zinc-100">
+                                {item.image_url ? (
+                                  <GalleryImage
+                                    src={item.image_url}
+                                    alt={item.headline || "Bravo news"}
+                                    sizes="120px"
+                                  />
+                                ) : (
+                                  <div className="flex h-full items-center justify-center text-xs text-zinc-400">
+                                    No image
+                                  </div>
+                                )}
+                              </div>
+                              <div className="min-w-0 flex-1">
+                                <a
+                                  href={item.article_url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="line-clamp-2 text-sm font-semibold text-zinc-900 hover:text-blue-700"
+                                >
+                                  {item.headline || "Untitled story"}
+                                </a>
+                                {formatBravoPublishedDate(item.published_at) && (
+                                  <p className="mt-1 text-xs text-zinc-500">
+                                    Posted {formatBravoPublishedDate(item.published_at)}
+                                  </p>
+                                )}
+                              </div>
+                            </div>
+                          </article>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="mb-4">
+                    <div className="mb-2 flex items-center justify-between gap-3">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        Videos
+                      </p>
+                      {syncBravoPreviewSeasonOptions.length > 0 && (
+                        <label className="flex items-center gap-2 text-xs text-zinc-600">
+                          <span>Season</span>
+                          <select
+                            value={syncBravoPreviewSeasonFilter}
+                            onChange={(event) => {
+                              const nextValue = event.target.value;
+                              onVideoSeasonFilterChange(
+                                nextValue === "all" ? "all" : Number.parseInt(nextValue, 10)
+                              );
+                            }}
+                            className="rounded border border-zinc-200 bg-white px-2 py-1 text-xs text-zinc-700"
+                          >
+                            <option value="all">All</option>
+                            {syncBravoPreviewSeasonOptions.map((season) => (
+                              <option key={season} value={season}>
+                                Season {season}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      )}
+                    </div>
+                    {syncBravoFilteredPreviewVideos.length === 0 ? (
+                      <p className="text-sm text-zinc-500">No videos found for this preview/season filter.</p>
+                    ) : (
+                      <div className="space-y-2">
+                        {syncBravoFilteredPreviewVideos.map((video) => (
+                          <article
+                            key={`${video.clip_url}-${video.published_at ?? "unknown"}`}
+                            className="rounded-lg border border-zinc-200 bg-zinc-50 p-3"
+                          >
+                            <div className="flex gap-3">
+                              <div className="relative h-16 w-24 shrink-0 overflow-hidden rounded bg-zinc-100">
+                                {video.image_url ? (
+                                  <GalleryImage
+                                    src={video.image_url}
+                                    alt={video.title || "Bravo video"}
+                                    sizes="120px"
+                                  />
+                                ) : (
+                                  <div className="flex h-full items-center justify-center text-xs text-zinc-400">
+                                    No image
+                                  </div>
+                                )}
+                              </div>
+                              <div className="min-w-0 flex-1">
+                                <a
+                                  href={video.clip_url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="line-clamp-2 text-sm font-semibold text-zinc-900 hover:text-blue-700"
+                                >
+                                  {video.title || "Untitled video"}
+                                </a>
+                                <div className="mt-1 flex flex-wrap gap-2 text-xs text-zinc-500">
+                                  {video.runtime && <span>{video.runtime}</span>}
+                                  {typeof video.season_number === "number" && (
+                                    <span>Season {video.season_number}</span>
+                                  )}
+                                  {formatBravoPublishedDate(video.published_at) && (
+                                    <span>Posted {formatBravoPublishedDate(video.published_at)}</span>
+                                  )}
+                                </div>
+                              </div>
+                            </div>
+                          </article>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </>
+              )}
+    </>
+  );
+}

--- a/apps/web/src/components/admin/ShowHealthCenterModal.tsx
+++ b/apps/web/src/components/admin/ShowHealthCenterModal.tsx
@@ -1,0 +1,408 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import AdminModal from "@/components/admin/AdminModal";
+import type { RefreshLogStatus, RefreshLogTopicKey } from "@/lib/admin/refresh-log-pipeline";
+
+const UUID_LIKE_RE =
+  /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+
+const normalizeRefreshLogMessage = (value: string): string => {
+  return value
+    .replace(UUID_LIKE_RE, "person")
+    .replace(/\s+/g, " ")
+    .trim();
+};
+
+const extractRefreshLogSubJob = (entry: ShowHealthCenterRefreshLogEntry): { subJob: string; details: string } => {
+  const normalizedMessage = normalizeRefreshLogMessage(entry.message);
+  const prefixMatch = normalizedMessage.match(/^([^:]{2,50}):\s+(.+)$/);
+  if (prefixMatch) {
+    return {
+      subJob: prefixMatch[1].trim(),
+      details: prefixMatch[2].trim(),
+    };
+  }
+  const fallbackSubJob = entry.category.trim() || "Update";
+  return {
+    subJob: fallbackSubJob,
+    details: normalizedMessage,
+  };
+};
+
+const healthBadgeClassName = (status: ShowHealthCenterHealthStatus): string => {
+  if (status === "ready") return "border-emerald-200 bg-emerald-50 text-emerald-700";
+  if (status === "stale") return "border-amber-200 bg-amber-50 text-amber-700";
+  return "border-rose-200 bg-rose-50 text-rose-700";
+};
+
+const pipelineStatusPillClass = (status: RefreshLogStatus): string => {
+  if (status === "done") return "border-emerald-200 bg-emerald-50 text-emerald-700";
+  if (status === "active") return "border-blue-200 bg-blue-50 text-blue-700";
+  if (status === "failed") return "border-rose-200 bg-rose-50 text-rose-700";
+  return "border-zinc-200 bg-zinc-50 text-zinc-600";
+};
+
+const pipelineStatusText = (status: RefreshLogStatus): string => {
+  if (status === "done") return "Done";
+  if (status === "active") return "Running";
+  if (status === "failed") return "Failed";
+  return "Queued";
+};
+
+export type ShowHealthCenterHealthStatus = "ready" | "missing" | "stale";
+
+export type ShowHealthCenterRefreshLogEntry = {
+  id: string;
+  at: string;
+  category: string;
+  message: string;
+  current: number | null;
+  total: number | null;
+};
+
+export type ShowHealthCenterContentHealthItem = {
+  key: string;
+  label: string;
+  countLabel: string;
+  status: ShowHealthCenterHealthStatus;
+  onClick: () => void;
+};
+
+export type ShowHealthCenterPipelineStep = {
+  topic: {
+    key: RefreshLogTopicKey;
+    label: string;
+    description: string;
+  };
+  status: RefreshLogStatus;
+  latest: ShowHealthCenterRefreshLogEntry | null;
+  executionOwner?: string;
+  parentOperationId?: string;
+};
+
+export type ShowHealthCenterOperationsInboxItem = {
+  id: string;
+  title: string;
+  detail: string;
+  onClick: () => void;
+};
+
+export type ShowHealthCenterRefreshLogTopicGroup = {
+  topic: {
+    key: RefreshLogTopicKey;
+    label: string;
+    description: string;
+  };
+  entries: ReadonlyArray<ShowHealthCenterRefreshLogEntry>;
+  entriesForView: ReadonlyArray<ShowHealthCenterRefreshLogEntry>;
+  latest: ShowHealthCenterRefreshLogEntry | null;
+  status: RefreshLogStatus;
+};
+
+export type ShowHealthCenterModalProps = {
+  dialog: {
+    open: boolean;
+    onClose: () => void;
+    onRun: () => void;
+    runDisabled: boolean;
+    runButtonLabel: string;
+    notice: string | null;
+    error: string | null;
+    progressContent: ReactNode;
+  };
+  contentHealthItems: ReadonlyArray<ShowHealthCenterContentHealthItem>;
+  pipeline: {
+    steps: ReadonlyArray<ShowHealthCenterPipelineStep>;
+    onRetryStep: (topicKey: RefreshLogTopicKey, parentOperationId: string) => void;
+  };
+  operationsInboxItems: ReadonlyArray<ShowHealthCenterOperationsInboxItem>;
+  refreshLog: {
+    hasEntries: boolean;
+    topicGroups: ReadonlyArray<ShowHealthCenterRefreshLogTopicGroup>;
+  };
+};
+
+export default function ShowHealthCenterModal({
+  dialog,
+  contentHealthItems,
+  pipeline,
+  operationsInboxItems,
+  refreshLog,
+}: ShowHealthCenterModalProps) {
+  return (
+    <AdminModal
+      isOpen={dialog.open}
+      onClose={dialog.onClose}
+      closeLabel="Close health center"
+      ariaLabel="Health Center"
+      panelClassName="max-h-[90vh] max-w-5xl overflow-y-auto"
+      preserveScrollPosition={true}
+    >
+      <div className="mb-4 flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-lg font-bold text-zinc-900">Health Center</h3>
+          <p className="text-sm text-zinc-500">
+            Content Health, Sync Pipeline, Operations Inbox, and Refresh Log.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={dialog.onRun}
+            aria-disabled={dialog.runDisabled}
+            className={`rounded-md px-3 py-1 text-sm font-semibold text-white ${
+              dialog.runDisabled
+                ? "cursor-not-allowed bg-zinc-500"
+                : "bg-zinc-900 hover:bg-zinc-800"
+            }`}
+          >
+            {dialog.runButtonLabel}
+          </button>
+          <button
+            type="button"
+            onClick={dialog.onClose}
+            className="rounded-md border border-zinc-200 px-3 py-1 text-sm font-semibold text-zinc-600 hover:bg-zinc-50"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+
+      {(dialog.notice || dialog.error) && (
+        <p className={`mb-4 text-sm ${dialog.error ? "text-red-600" : "text-zinc-500"}`}>
+          {dialog.error || dialog.notice}
+        </p>
+      )}
+      {dialog.progressContent}
+
+      <section className="mb-6 rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-zinc-400">
+          Content Health
+        </p>
+        <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-7">
+          {contentHealthItems.map((item) => (
+            <button
+              key={item.key}
+              type="button"
+              onClick={item.onClick}
+              className={`rounded-xl border px-3 py-2 text-left transition hover:shadow-sm ${healthBadgeClassName(
+                item.status
+              )}`}
+            >
+              <p className="text-[11px] font-semibold uppercase tracking-[0.16em]">
+                {item.label}
+              </p>
+              <p className="mt-1 text-sm font-semibold">
+                {item.status === "ready"
+                  ? "Ready"
+                  : item.status === "stale"
+                    ? "Stale"
+                    : "Missing"}
+              </p>
+              <p className="mt-1 text-xs opacity-80">{item.countLabel}</p>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className="mb-6 grid gap-4 lg:grid-cols-[1.3fr_1fr]">
+        <div className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.3em] text-zinc-400">
+            Sync Pipeline
+          </p>
+          <div className="space-y-2">
+            {pipeline.steps.map((step) => {
+              const latestParts = step.latest ? extractRefreshLogSubJob(step.latest) : null;
+              return (
+                <div
+                  key={step.topic.key}
+                  className="flex items-center justify-between gap-3 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-700">
+                      {step.topic.label}
+                      {step.executionOwner && (
+                        <span className="ml-1 text-xs text-zinc-500">
+                          ({step.executionOwner === "remote_worker" ? "Modal" : step.executionOwner})
+                        </span>
+                      )}
+                    </p>
+                    <p className="truncate text-[11px] text-zinc-500">{step.topic.description}</p>
+                    <p className="truncate text-[11px] text-zinc-600">
+                      {latestParts?.details ?? "No updates yet."}
+                    </p>
+                  </div>
+                  <div className="shrink-0 text-right">
+                    <span
+                      className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${pipelineStatusPillClass(
+                        step.status
+                      )}`}
+                    >
+                      {pipelineStatusText(step.status)}
+                    </span>
+                    {step.status === "failed" && step.parentOperationId && (
+                      <button
+                        type="button"
+                        className="ml-2 text-xs text-blue-500 hover:text-blue-700"
+                        onClick={() => pipeline.onRetryStep(step.topic.key, step.parentOperationId!)}
+                      >
+                        Retry
+                      </button>
+                    )}
+                    {step.latest && (
+                      <p className="mt-1 text-[10px] text-zinc-400">
+                        {new Date(step.latest.at).toLocaleTimeString()}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-zinc-400">
+            Operations Inbox
+          </p>
+          {operationsInboxItems.length === 0 ? (
+            <p className="mt-3 text-sm text-emerald-700">No blocking tasks.</p>
+          ) : (
+            <div className="mt-3 space-y-2">
+              {operationsInboxItems.map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={item.onClick}
+                  className="w-full rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-left transition hover:bg-amber-100"
+                >
+                  <p className="text-sm font-semibold text-amber-800">{item.title}</p>
+                  <p className="mt-1 text-xs text-amber-700">{item.detail}</p>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm">
+        <p className="mb-3 text-xs font-semibold uppercase tracking-[0.3em] text-zinc-400">
+          Refresh Log
+        </p>
+        {!refreshLog.hasEntries ? (
+          <p className="text-xs text-zinc-500">No refresh activity yet.</p>
+        ) : (
+          <div className="max-h-[44vh] space-y-3 overflow-y-auto pr-1">
+            {refreshLog.topicGroups.map(({ topic, entries, entriesForView, latest, status }) => {
+              const latestParts = latest ? extractRefreshLogSubJob(latest) : null;
+              const latestPercent =
+                latest &&
+                typeof latest.current === "number" &&
+                typeof latest.total === "number" &&
+                latest.total > 0
+                  ? Math.min(100, Math.round((latest.current / latest.total) * 100))
+                  : null;
+
+              if (status === "done") {
+                return (
+                  <article
+                    key={topic.key}
+                    className="rounded-lg border border-green-200 bg-green-50 px-3 py-2"
+                  >
+                    <p className="text-xs font-semibold text-green-800">
+                      {topic.label}: Done ✔️
+                    </p>
+                  </article>
+                );
+              }
+
+              return (
+                <article key={topic.key} className="rounded-lg border border-zinc-200 bg-zinc-50 p-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-600">
+                        {topic.label}
+                      </p>
+                      <p className="text-[11px] text-zinc-500">{topic.description}</p>
+                    </div>
+                    {latest && (
+                      <p className="text-[10px] text-zinc-400">
+                        {new Date(latest.at).toLocaleTimeString()}
+                      </p>
+                    )}
+                  </div>
+
+                  {status === "failed" && (
+                    <p className="mt-2 text-xs font-semibold text-red-700">
+                      {topic.label}: Failed ✖
+                    </p>
+                  )}
+
+                  {latest ? (
+                    <div className="mt-2 rounded-md border border-zinc-200 bg-white p-2">
+                      <p className="text-xs font-semibold text-zinc-800">{latestParts?.subJob}</p>
+                      <p className="mt-1 text-xs text-zinc-600">{latestParts?.details}</p>
+                      {typeof latest.current === "number" &&
+                        typeof latest.total === "number" && (
+                          <p className="mt-1 text-[11px] text-zinc-500">
+                            {latest.current.toLocaleString()}/{latest.total.toLocaleString()}
+                            {latestPercent !== null ? ` (${latestPercent}%)` : ""}
+                          </p>
+                        )}
+                    </div>
+                  ) : (
+                    <p className="mt-2 text-xs text-zinc-500">No updates yet.</p>
+                  )}
+
+                  {entries.length > 0 && (
+                    <details className="mt-2" open={entries.length <= 3}>
+                      <summary className="cursor-pointer text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-500">
+                        Sub-jobs ({entries.length})
+                      </summary>
+                      <div className="mt-2 space-y-1">
+                        {entriesForView.slice(0, 30).map((entry) => {
+                          const parts = extractRefreshLogSubJob(entry);
+                          const percent =
+                            typeof entry.current === "number" &&
+                            typeof entry.total === "number" &&
+                            entry.total > 0
+                              ? Math.min(100, Math.round((entry.current / entry.total) * 100))
+                              : null;
+                          return (
+                            <div
+                              key={entry.id}
+                              className="rounded border border-zinc-100 bg-white px-2 py-1.5"
+                            >
+                              <div className="flex items-center justify-between gap-2">
+                                <p className="text-[11px] font-semibold text-zinc-700">
+                                  {parts.subJob}
+                                </p>
+                                <p className="text-[10px] text-zinc-400">
+                                  {new Date(entry.at).toLocaleTimeString()}
+                                </p>
+                              </div>
+                              <p className="mt-0.5 text-[11px] text-zinc-600">{parts.details}</p>
+                              {typeof entry.current === "number" &&
+                                typeof entry.total === "number" && (
+                                  <p className="mt-0.5 text-[10px] text-zinc-500">
+                                    {entry.current.toLocaleString()}/{entry.total.toLocaleString()}
+                                    {percent !== null ? ` (${percent}%)` : ""}
+                                  </p>
+                                )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </details>
+                  )}
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </section>
+    </AdminModal>
+  );
+}

--- a/apps/web/src/components/admin/ShowLinkBadges.tsx
+++ b/apps/web/src/components/admin/ShowLinkBadges.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import Image from "next/image";
+
+import SocialPlatformTabIcon from "@/components/admin/SocialPlatformTabIcon";
+import { toSocialPlatformIconKey } from "@/lib/admin/show-page/show-link-display-model";
+import type {
+  LinkSourceBadgeKind,
+  PersonLinkSourceKey,
+  ShowSocialLinkPill,
+} from "@/lib/admin/show-page/workspace-model";
+
+export function PersonSourceLogo({ sourceKey }: { sourceKey: PersonLinkSourceKey }) {
+  const baseClass =
+    "inline-flex h-5 min-w-[2.1rem] items-center justify-center rounded border px-1 text-[10px] font-bold uppercase tracking-[0.08em]";
+  if (sourceKey === "imdb") {
+    return <span className={`${baseClass} border-zinc-300 bg-[#f5c518] text-zinc-900`}>IMDb</span>;
+  }
+  if (sourceKey === "tmdb") {
+    return <span className={`${baseClass} border-zinc-300 bg-[#01d277] text-zinc-900`}>TMDb</span>;
+  }
+  if (sourceKey === "bravo") {
+    return <span className={`${baseClass} border-zinc-300 bg-zinc-900 text-white`}>Bravo</span>;
+  }
+  if (sourceKey === "wikipedia") {
+    return <span className={`${baseClass} border-zinc-300 bg-sky-600 text-white`}>Wiki</span>;
+  }
+  if (sourceKey === "wikidata") {
+    return <span className={`${baseClass} border-zinc-300 bg-cyan-700 text-white`}>WD</span>;
+  }
+  return (
+    <span className={`${baseClass} border-zinc-300 bg-[#f3f4f6] text-zinc-800`}>Fandom</span>
+  );
+}
+
+export function SourceBadge({
+  kind,
+  label,
+  iconUrl,
+  iconOnly = false,
+}: {
+  kind: LinkSourceBadgeKind;
+  label: string;
+  iconUrl?: string | null;
+  iconOnly?: boolean;
+}) {
+  const socialIconKey = toSocialPlatformIconKey(kind);
+  if (socialIconKey) {
+    return (
+      <span className="inline-flex items-center justify-center">
+        <SocialPlatformTabIcon tab={socialIconKey} />
+        {!iconOnly ? <span className="sr-only">{label}</span> : null}
+      </span>
+    );
+  }
+
+  if (kind === "imdb") return <PersonSourceLogo sourceKey="imdb" />;
+  if (kind === "tmdb") return <PersonSourceLogo sourceKey="tmdb" />;
+  if (kind === "bravo") return <PersonSourceLogo sourceKey="bravo" />;
+  if (kind === "wikipedia") return <PersonSourceLogo sourceKey="wikipedia" />;
+  if (kind === "wikidata") return <PersonSourceLogo sourceKey="wikidata" />;
+  if (kind === "fandom") {
+    if (iconUrl) {
+      return (
+        <span className="inline-flex items-center gap-1">
+          <Image
+            src={iconUrl}
+            alt=""
+            width={14}
+            height={14}
+            className="h-3.5 w-3.5 shrink-0 rounded-sm"
+            unoptimized
+          />
+          {!iconOnly ? <span className="text-xs font-semibold text-zinc-700">{label}</span> : null}
+        </span>
+      );
+    }
+    return iconOnly ? (
+      <PersonSourceLogo sourceKey="fandom" />
+    ) : (
+      <span className="text-xs font-semibold text-zinc-700">{label}</span>
+    );
+  }
+
+  const baseClass =
+    "inline-flex h-5 min-w-[2.1rem] items-center justify-center rounded border px-1 text-[10px] font-bold uppercase tracking-[0.08em]";
+  const tokenText = (() => {
+    if (kind === "official") return "Site";
+    if (kind === "tvdb") return "TVDB";
+    if (kind === "tvmaze") return "TVM";
+    if (kind === "trakt") return "Trakt";
+    if (kind === "freebase") return "FB";
+    if (kind === "google_kg") return "GKG";
+    if (kind === "ratinggraph") return "RG";
+    if (kind === "x_topic") return "X";
+    if (kind === "google_news") return "News";
+    return label.slice(0, 6) || "Link";
+  })();
+  return (
+    <span className={`${baseClass} border-zinc-300 bg-zinc-100 text-zinc-700`}>{tokenText}</span>
+  );
+}
+
+export function SocialHandlePill({ pill }: { pill: ShowSocialLinkPill }) {
+  return (
+    <a
+      href={pill.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex max-w-full items-center gap-2 rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs font-semibold text-zinc-700 hover:bg-zinc-100"
+      title={pill.url}
+    >
+      <SourceBadge kind={pill.sourceKind} label={pill.sourceLabel} iconOnly />
+      <span className="truncate">{pill.text}</span>
+    </a>
+  );
+}

--- a/apps/web/src/components/admin/ShowLinksDiscoveryModal.tsx
+++ b/apps/web/src/components/admin/ShowLinksDiscoveryModal.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+import AdminModal from "@/components/admin/AdminModal";
+import type { CanonicalOperationStatus } from "@/lib/admin/async-handles";
+import type { LinkDiscoveryProgressSummary } from "@/lib/admin/show-page/link-discovery-progress";
+
+export type ShowLinksDiscoverySourceCount = Readonly<{
+  key: string;
+  label: string;
+  count: number;
+}>;
+
+export type ShowLinksDiscoveryModalProps = {
+  dialog: {
+    open: boolean;
+    onClose: () => void;
+    status: CanonicalOperationStatus | null;
+    error: string | null;
+    notice: string | null;
+    completionNotice: string | null;
+  };
+  cancellation: {
+    visible: boolean;
+    pending: boolean;
+    buttonLabel: string;
+    onCancel: () => void;
+  };
+  execution: {
+    runLabel: string;
+    operationLabel: string;
+    owner: string | null;
+    backend: string | null;
+    mode: string | null;
+  };
+  progress: {
+    summary: LinkDiscoveryProgressSummary | null;
+    refreshing: boolean;
+    timeoutMessage: string | null;
+    stalled: boolean;
+    stalledReason: string | null;
+    lastUpdateLabel: string | null;
+    lastStageChangeLabel: string | null;
+    validatedSourceCounts: ReadonlyArray<ShowLinksDiscoverySourceCount>;
+    deletedSourceCounts: ReadonlyArray<ShowLinksDiscoverySourceCount>;
+    hasResult: boolean;
+  };
+};
+
+const statusClassName = (status: CanonicalOperationStatus | null): string => {
+  if (status === "completed") return "border-emerald-200 bg-emerald-50 text-emerald-700";
+  if (status === "failed" || status === "cancelled") {
+    return "border-rose-200 bg-rose-50 text-rose-700";
+  }
+  if (status === "running") return "border-blue-200 bg-blue-50 text-blue-700";
+  return "border-zinc-200 bg-zinc-50 text-zinc-600";
+};
+
+export default function ShowLinksDiscoveryModal({
+  dialog,
+  cancellation,
+  execution,
+  progress,
+}: ShowLinksDiscoveryModalProps) {
+  const message = dialog.error || dialog.completionNotice || dialog.notice;
+
+  return (
+    <AdminModal
+      isOpen={dialog.open}
+      onClose={dialog.onClose}
+      closeLabel="Close links discovery progress"
+      ariaLabel="Links discovery progress"
+      panelClassName="max-h-[90vh] max-w-3xl overflow-y-auto"
+      preserveScrollPosition={true}
+    >
+      <div className="mb-4 flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-lg font-bold text-zinc-900">Links Discovery</h3>
+          <p className="text-sm text-zinc-500">
+            Remote worker-backed refresh for show, season, and cast member pages.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {cancellation.visible && (
+            <button
+              type="button"
+              onClick={cancellation.onCancel}
+              disabled={cancellation.pending}
+              className="rounded-md border border-rose-200 bg-rose-50 px-3 py-1 text-sm font-semibold text-rose-700 hover:bg-rose-100 disabled:opacity-50"
+            >
+              {cancellation.buttonLabel}
+            </button>
+          )}
+          <span
+            className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] ${statusClassName(dialog.status)}`}
+          >
+            {dialog.status ?? "queued"}
+          </span>
+          <button
+            type="button"
+            onClick={dialog.onClose}
+            className="rounded-md border border-zinc-200 px-3 py-1 text-sm font-semibold text-zinc-600 hover:bg-zinc-50"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+
+      {message && (
+        <p className={`mb-4 text-sm ${dialog.error ? "text-red-600" : "text-zinc-600"}`}>
+          {message}
+        </p>
+      )}
+
+      <section className="mb-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-3">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">Run ID</p>
+          <p className="mt-1 text-sm font-semibold text-zinc-900">{execution.runLabel}</p>
+        </div>
+        <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-3">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">Operation ID</p>
+          <p className="mt-1 text-sm font-semibold text-zinc-900">{execution.operationLabel}</p>
+        </div>
+        <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-3">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">Execution</p>
+          <p className="mt-1 text-sm font-semibold text-zinc-900">
+            {execution.owner === "remote_worker"
+              ? "remote worker"
+              : execution.owner || "Awaiting worker"}
+          </p>
+          {(execution.backend || execution.mode) && (
+            <p className="mt-1 text-xs text-zinc-500">
+              {[execution.backend, execution.mode ? `mode ${execution.mode}` : null]
+                .filter((value): value is string => Boolean(value))
+                .join(" · ")}
+            </p>
+          )}
+        </div>
+        <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-3">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">Status</p>
+          <p className="mt-1 text-sm font-semibold text-zinc-900">
+            {progress.summary?.stageLabel || "Discovery"}
+          </p>
+          <p className="mt-1 text-xs text-zinc-500">
+            {progress.summary?.elapsedLabel || "Waiting for stream updates"}
+          </p>
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-zinc-400">Progress</p>
+        {progress.summary ? (
+          <div className="mt-3 space-y-3">
+            <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-3">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-zinc-900">{progress.summary.headline}</p>
+                  {progress.summary.detail && (
+                    <p className="mt-1 text-sm text-zinc-600">{progress.summary.detail}</p>
+                  )}
+                </div>
+                <div className="text-right text-xs text-zinc-500">
+                  {progress.summary.stageElapsedLabel && <p>{progress.summary.stageElapsedLabel}</p>}
+                  {progress.summary.elapsedLabel && <p>{progress.summary.elapsedLabel}</p>}
+                </div>
+              </div>
+              {(progress.summary.targetSummary ||
+                progress.summary.stageProgressLabel ||
+                progress.summary.currentTargetLabel ||
+                progress.summary.budgetLabel) && (
+                <div className="mt-3 space-y-1 text-sm text-zinc-600">
+                  {progress.summary.targetSummary && <p>{progress.summary.targetSummary}</p>}
+                  {progress.summary.stageProgressLabel && <p>{progress.summary.stageProgressLabel}</p>}
+                  {progress.summary.currentTargetLabel && (
+                    <p>
+                      Checking:{" "}
+                      <span className="font-semibold text-zinc-900">
+                        {progress.summary.currentTargetLabel}
+                      </span>
+                    </p>
+                  )}
+                  {progress.summary.budgetLabel && (
+                    <p className="text-amber-700">{progress.summary.budgetLabel}</p>
+                  )}
+                </div>
+              )}
+              {progress.summary.metrics.length > 0 && (
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {progress.summary.metrics.map((metric) => (
+                    <span
+                      key={`${metric.label}:${metric.value}`}
+                      className="rounded-full border border-zinc-200 bg-white px-2.5 py-1 text-[11px] font-semibold text-zinc-700"
+                    >
+                      {metric.label}: {metric.value}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {progress.timeoutMessage !== null && (
+              <div className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+                {progress.timeoutMessage}
+              </div>
+            )}
+
+            <div className="grid gap-3 lg:grid-cols-2">
+              <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-3">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                  Worker Monitor
+                </p>
+                <div className="mt-2 space-y-1 text-sm text-zinc-700">
+                  <p>
+                    Worker health:{" "}
+                    <span
+                      className={
+                        progress.stalled
+                          ? "font-semibold text-amber-700"
+                          : "font-semibold text-emerald-700"
+                      }
+                    >
+                      {progress.stalled ? "Stalled" : "Healthy"}
+                    </span>
+                  </p>
+                  {progress.lastUpdateLabel && <p>Last stream update: {progress.lastUpdateLabel}</p>}
+                  {progress.lastStageChangeLabel && (
+                    <p>Last stage change: {progress.lastStageChangeLabel}</p>
+                  )}
+                  {progress.stalledReason && (
+                    <p className="text-amber-700">
+                      Reason: <span className="font-semibold">{progress.stalledReason}</span>
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              {(progress.validatedSourceCounts.length > 0 || progress.deletedSourceCounts.length > 0) && (
+                <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-3">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Correct / Live by Source
+                  </p>
+                  {progress.validatedSourceCounts.length > 0 ? (
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {progress.validatedSourceCounts.map((entry) => (
+                        <span
+                          key={`links-live-source-${entry.key}`}
+                          className="rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-[11px] font-semibold text-emerald-700"
+                        >
+                          {entry.label}: {entry.count}
+                        </span>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="mt-2 text-sm text-zinc-500">
+                      No validated live source counts reported yet.
+                    </p>
+                  )}
+                  {progress.deletedSourceCounts.length > 0 && (
+                    <div className="mt-3">
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                        Invalid Deleted
+                      </p>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {progress.deletedSourceCounts.map((entry) => (
+                          <span
+                            key={`links-deleted-source-${entry.key}`}
+                            className="rounded-full border border-rose-200 bg-rose-50 px-2.5 py-1 text-[11px] font-semibold text-rose-700"
+                          >
+                            {entry.label}: {entry.count}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {progress.hasResult && (
+              <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-3">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">Result</p>
+                <p className="mt-1 text-sm text-zinc-700">
+                  {dialog.completionNotice || "Links discovery finished."}
+                </p>
+                {progress.validatedSourceCounts.length > 0 && (
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {progress.validatedSourceCounts.map((entry) => (
+                      <span
+                        key={`links-result-live-source-${entry.key}`}
+                        className="rounded-full border border-emerald-200 bg-white px-2.5 py-1 text-[11px] font-semibold text-emerald-700"
+                      >
+                        {entry.label}: {entry.count} live
+                      </span>
+                    ))}
+                  </div>
+                )}
+                {progress.deletedSourceCounts.length > 0 && (
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {progress.deletedSourceCounts.map((entry) => (
+                      <span
+                        key={`links-result-deleted-source-${entry.key}`}
+                        className="rounded-full border border-rose-200 bg-white px-2.5 py-1 text-[11px] font-semibold text-rose-700"
+                      >
+                        {entry.label}: {entry.count} invalid deleted
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        ) : (
+          <p className="mt-3 text-sm text-zinc-500">
+            {progress.refreshing
+              ? "Waiting for worker progress..."
+              : "Start a links refresh to see live updates here."}
+          </p>
+        )}
+      </section>
+    </AdminModal>
+  );
+}

--- a/apps/web/src/components/admin/show-tabs/FeaturedLogoDrawer.tsx
+++ b/apps/web/src/components/admin/show-tabs/FeaturedLogoDrawer.tsx
@@ -3,8 +3,8 @@
 import Image from "next/image";
 import AdminModal from "@/components/admin/AdminModal";
 import type { SeasonAsset } from "@/lib/server/trr-api/trr-shows-repository";
-import type { ShowLogoVariant } from "./ShowBrandLogosSection";
 import { resolveFeaturedLogoPayload } from "@/lib/admin/show-logo-featured";
+import type { ShowLogoVariant } from "./show-logo-types";
 
 interface FeaturedLogoDrawerProps {
   isOpen: boolean;

--- a/apps/web/src/components/admin/show-tabs/ShowAssetsTab.tsx
+++ b/apps/web/src/components/admin/show-tabs/ShowAssetsTab.tsx
@@ -2,14 +2,611 @@
 
 import type { ReactNode } from "react";
 
-export default function ShowAssetsTab({ children }: { children: ReactNode }) {
+import { BravotvImageRunPanel } from "@/components/admin/BravotvImageRunPanel";
+import ShowBrandEditor, {
+  type TrrCastMemberLike,
+  type TrrSeasonLike,
+} from "@/components/admin/ShowBrandEditor";
+import { ShowAssetsImageSections } from "@/components/admin/show-tabs/ShowAssetsImageSections";
+import {
+  ShowBrandLogosSection,
+  type ShowLogoVariant,
+} from "@/components/admin/show-tabs/ShowBrandLogosSection";
+import { ShowFeaturedMediaSelectors } from "@/components/admin/show-tabs/ShowFeaturedMediaSelectors";
+import type { SeasonAsset } from "@/lib/server/trr-api/trr-shows-repository";
+
+type MaybeAsyncResult = void | Promise<void>;
+
+type ShowAssetsView = "images" | "videos" | "branding";
+
+type ShowAssetsSeasonOption = {
+  id: string;
+  season_number: number;
+};
+
+type ShowAssetsProgress = {
+  stage?: string | null;
+  message?: string | null;
+  current?: number | null;
+  total?: number | null;
+};
+
+type ShowAssetsFallbackTelemetry = {
+  fallbackRecoveredCount: number;
+  allCandidatesFailedCount: number;
+  totalImageAttempts: number;
+};
+
+type ShowAssetsMirrorTelemetry = {
+  mirroredCount: number;
+  totalCount: number;
+  mirroredRatio: number;
+};
+
+type ShowAssetsSourceFailure = {
+  sourceId: string;
+  label: string;
+  message: string;
+  status: number;
+  retryable: boolean;
+  code?: string;
+  reason?: string;
+  detail?: Record<string, unknown>;
+};
+
+type ShowAssetsGallerySections = {
+  backdrops: SeasonAsset[];
+  banners: SeasonAsset[];
+  posters: SeasonAsset[];
+  profile_pictures: SeasonAsset[];
+  hasMoreBySection: {
+    backdrops?: boolean;
+    banners?: boolean;
+    posters?: boolean;
+    profile_pictures?: boolean;
+    cast_photos?: boolean;
+  };
+};
+
+type ShowAssetsVideo = {
+  title?: string | null;
+  runtime?: string | null;
+  kicker?: string | null;
+  image_url?: string | null;
+  hosted_image_url?: string | null;
+  original_image_url?: string | null;
+  media_asset_id?: string | null;
+  thumbnail_sync_status?: string | null;
+  thumbnail_sync_error?: string | null;
+  clip_url: string;
+  season_number?: number | null;
+  published_at?: string | null;
+};
+
+export type ShowAssetsImageRenderArgs = {
+  asset: SeasonAsset;
+  alt: string;
+  sizes: string;
+  className?: string;
+  useResolvedUrl?: boolean;
+};
+
+export type ShowAssetsVideoThumbnailRenderArgs = {
+  src: string;
+  alt: string;
+  sizes: string;
+  className?: string;
+};
+
+type ShowAssetsImagesProps = {
+  selectedSeason: "all" | number;
+  seasonOptions: ShowAssetsSeasonOption[];
+  refreshCenterButtonLabel: string;
+  autoAdvanceMode: "manual" | "auto";
+  hasActiveAdvancedFilters: boolean;
+  activeAdvancedFilterCount: number;
+  refreshingGetImages: boolean;
+  photosNotice: string | null | undefined;
+  photosError: string | null | undefined;
+  getImagesNotice: string | null | undefined;
+  getImagesError: string | null | undefined;
+  getImagesProgress: ShowAssetsProgress | null | undefined;
+  batchJobsNotice: string | null;
+  batchJobsError: string | null;
+  batchJobsRunning: boolean;
+  batchJobsProgress: ShowAssetsProgress | null | undefined;
+  truncatedWarning: string | null;
+  fallbackTelemetry: ShowAssetsFallbackTelemetry;
+  mirrorTelemetry: ShowAssetsMirrorTelemetry;
+  sourceFailures: ShowAssetsSourceFailure[];
+  loading: boolean;
+  filteredAssetCount: number;
+  sections: ShowAssetsGallerySections;
+  castPromoAssets: SeasonAsset[];
+  onRunCompleted: () => MaybeAsyncResult;
+  onSelectSeason: (value: string) => void;
+  onOpenRefreshCenter: () => void;
+  onOpenFilters: () => void;
+  onToggleAutoAdvance: () => void;
+  onClearFilters: () => void;
+  onOpenBatchJobs: () => void;
+  onGetImages: () => MaybeAsyncResult;
+  onOpenImport: () => void;
+  onLoadMoreBackdrops: () => void;
+  onLoadMoreBanners: () => void;
+  onLoadMorePosters: () => void;
+  onLoadMoreProfilePictures: () => void;
+  onLoadMoreCastPromos: () => void;
+  onOpenAssetLightbox: (
+    asset: SeasonAsset,
+    index: number,
+    assets: SeasonAsset[],
+    target: HTMLButtonElement,
+  ) => void;
+  formatSourceFailure: (failure: ShowAssetsSourceFailure) => string;
+};
+
+type ShowAssetsVideosProps = {
+  error: string | null;
+  loading: boolean;
+  thumbnailSyncing: boolean;
+  thumbnailSyncWarning: string | null;
+  rows: ShowAssetsVideo[];
+  getThumbnailUrl: (video: ShowAssetsVideo) => string | null;
+  formatPublishedDate: (value?: string | null) => string | null;
+};
+
+type ShowAssetsBrandingProps = {
+  posterAssets: SeasonAsset[];
+  backdropAssets: SeasonAsset[];
+  featuredPosterImageId: string | null | undefined;
+  featuredBackdropImageId: string | null | undefined;
+  logoAssets: SeasonAsset[];
+  featuredLogoAssetId: string | null;
+  featuredLogoSavingAssetId: string | null;
+  featuredLogoVariant: ShowLogoVariant;
+  seasons: TrrSeasonLike[];
+  cast: TrrCastMemberLike[];
+  getAssetDisplayUrl: (asset: SeasonAsset) => string;
+  onSetFeaturedPoster: (showImageId: string | null) => void;
+  onSetFeaturedBackdrop: (showImageId: string | null) => void;
+  onSelectFeaturedLogoVariant: (asset: SeasonAsset, variant: ShowLogoVariant) => void;
+  onSetFeaturedLogo: (asset: SeasonAsset) => void;
+};
+
+export type ShowAssetsTabProps = {
+  assetsView: ShowAssetsView;
+  showId: string;
+  showName: string;
+  featuredPosterImageId: string | null | undefined;
+  featuredBackdropImageId: string | null | undefined;
+  images: ShowAssetsImagesProps;
+  videos: ShowAssetsVideosProps;
+  branding: ShowAssetsBrandingProps;
+  renderProgress: (progress: ShowAssetsProgress & { show: boolean }) => ReactNode;
+  renderAssetImage: (args: ShowAssetsImageRenderArgs) => ReactNode;
+  renderVideoThumbnail: (args: ShowAssetsVideoThumbnailRenderArgs) => ReactNode;
+};
+
+export default function ShowAssetsTab({
+  assetsView,
+  showId,
+  showName,
+  featuredPosterImageId,
+  featuredBackdropImageId,
+  images,
+  videos,
+  branding,
+  renderProgress,
+  renderAssetImage,
+  renderVideoThumbnail,
+}: ShowAssetsTabProps) {
   return (
     <section
       id="show-tabpanel-assets"
       role="tabpanel"
       aria-labelledby="show-tab-assets"
     >
-      {children}
+      {assetsView === "images" && (
+        <div className="mb-6">
+          <BravotvImageRunPanel
+            mode="show"
+            targetId={showId}
+            title={`BRAVOTV Get Images for ${showName}`}
+            season={images.selectedSeason === "all" ? null : images.selectedSeason}
+            onCompleted={images.onRunCompleted}
+          />
+        </div>
+      )}
+
+      <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm">
+        {assetsView === "images" ? (
+          <>
+            <div className="mb-6 flex items-center justify-between">
+              <div className="flex items-center gap-4">
+                <label
+                  htmlFor="show-assets-season-filter"
+                  className="text-sm font-medium text-zinc-700"
+                >
+                  Filter by season:
+                </label>
+                <select
+                  id="show-assets-season-filter"
+                  value={images.selectedSeason}
+                  onChange={(event) => images.onSelectSeason(event.target.value)}
+                  className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm"
+                >
+                  <option value="all">All Seasons</option>
+                  {images.seasonOptions.map((season) => (
+                    <option key={season.id} value={season.season_number}>
+                      Season {season.season_number}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={images.onOpenRefreshCenter}
+                  className="flex items-center gap-2 rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-50 disabled:opacity-50"
+                >
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M4 4v6h6M20 20v-6h-6M20 8a8 8 0 00-14-4M4 16a8 8 0 0014 4"
+                    />
+                  </svg>
+                  {images.refreshCenterButtonLabel}
+                </button>
+
+                <button
+                  type="button"
+                  onClick={images.onOpenFilters}
+                  className="flex items-center gap-2 rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-50"
+                >
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M3 6h18M7 12h10M10 18h4"
+                    />
+                  </svg>
+                  Filters
+                </button>
+
+                <button
+                  type="button"
+                  onClick={images.onToggleAutoAdvance}
+                  className="rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-50"
+                >
+                  Auto-Load: {images.autoAdvanceMode === "auto" ? "On" : "Off"}
+                </button>
+
+                {images.hasActiveAdvancedFilters && (
+                  <button
+                    type="button"
+                    onClick={images.onClearFilters}
+                    className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm font-semibold text-red-700 transition hover:bg-red-100"
+                  >
+                    Clear Filters ({images.activeAdvancedFilterCount})
+                  </button>
+                )}
+
+                <button
+                  type="button"
+                  onClick={images.onOpenBatchJobs}
+                  className="flex items-center gap-2 rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-50"
+                >
+                  Batch Jobs
+                </button>
+
+                <button
+                  type="button"
+                  disabled={images.refreshingGetImages}
+                  onClick={images.onGetImages}
+                  className="flex items-center gap-2 rounded-lg border border-indigo-200 bg-indigo-50 px-4 py-2 text-sm font-semibold text-indigo-700 transition hover:bg-indigo-100 disabled:opacity-50"
+                >
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                    />
+                  </svg>
+                  {images.refreshingGetImages ? "Getting Images..." : "Get Images"}
+                </button>
+
+                <button
+                  type="button"
+                  onClick={images.onOpenImport}
+                  className="flex items-center gap-2 rounded-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-zinc-800"
+                >
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                    />
+                  </svg>
+                  Import Images
+                </button>
+              </div>
+            </div>
+
+            {(images.photosNotice || images.photosError) && (
+              <p className={`mb-4 text-sm ${images.photosError ? "text-red-600" : "text-zinc-500"}`}>
+                {images.photosError || images.photosNotice}
+              </p>
+            )}
+
+            {(images.getImagesNotice || images.getImagesError || images.refreshingGetImages) && (
+              <div className="mb-4">
+                {images.getImagesProgress &&
+                  images.refreshingGetImages &&
+                  renderProgress({ show: true, ...images.getImagesProgress })}
+                {(images.getImagesNotice || images.getImagesError) && (
+                  <p className={`text-sm ${images.getImagesError ? "text-red-600" : "text-indigo-600"}`}>
+                    {images.getImagesError || images.getImagesNotice}
+                  </p>
+                )}
+              </div>
+            )}
+
+            {(images.batchJobsNotice || images.batchJobsError) && (
+              <p className={`mb-4 text-sm ${images.batchJobsError ? "text-red-600" : "text-zinc-500"}`}>
+                {images.batchJobsError || images.batchJobsNotice}
+              </p>
+            )}
+
+            {renderProgress({ show: images.batchJobsRunning, ...images.batchJobsProgress })}
+
+            {images.truncatedWarning && (
+              <p className="mb-4 text-xs font-medium text-amber-700">{images.truncatedWarning}</p>
+            )}
+
+            <p className="mb-4 text-xs text-zinc-500">
+              Fallback diagnostics: {images.fallbackTelemetry.fallbackRecoveredCount} recovered,{" "}
+              {images.fallbackTelemetry.allCandidatesFailedCount} failed,{" "}
+              {images.fallbackTelemetry.totalImageAttempts} attempted. Mirrored URL usage:{" "}
+              {images.mirrorTelemetry.mirroredCount}/{images.mirrorTelemetry.totalCount} ({Math.round(
+                images.mirrorTelemetry.mirroredRatio * 100,
+              )}
+              %).
+            </p>
+
+            {process.env.NODE_ENV === "development" && images.sourceFailures.length > 0 && (
+              <details className="mb-4 rounded border border-zinc-200 bg-zinc-50 px-3 py-2 text-xs text-zinc-700">
+                <summary className="cursor-pointer font-medium text-zinc-900">
+                  Gallery source debug
+                </summary>
+                <ul className="mt-2 space-y-1">
+                  {images.sourceFailures.map((failure) => (
+                    <li key={failure.sourceId}>{images.formatSourceFailure(failure)}</li>
+                  ))}
+                </ul>
+              </details>
+            )}
+
+            {images.loading ? (
+              <div className="flex items-center justify-center py-12">
+                <div className="h-8 w-8 animate-spin rounded-full border-4 border-zinc-300 border-t-blue-500" />
+              </div>
+            ) : images.filteredAssetCount === 0 ? (
+              <p className="py-8 text-center text-zinc-500">
+                No images found for this selection.
+              </p>
+            ) : (
+              <div className="space-y-8">
+                <ShowAssetsImageSections
+                  backdrops={images.sections.backdrops}
+                  banners={images.sections.banners}
+                  posters={images.sections.posters}
+                  featuredBackdropImageId={featuredBackdropImageId}
+                  featuredPosterImageId={featuredPosterImageId}
+                  autoAdvanceMode={images.autoAdvanceMode}
+                  hasMoreBackdrops={Boolean(images.sections.hasMoreBySection.backdrops)}
+                  hasMoreBanners={Boolean(images.sections.hasMoreBySection.banners)}
+                  hasMorePosters={Boolean(images.sections.hasMoreBySection.posters)}
+                  onLoadMoreBackdrops={images.onLoadMoreBackdrops}
+                  onLoadMoreBanners={images.onLoadMoreBanners}
+                  onLoadMorePosters={images.onLoadMorePosters}
+                  onOpenAssetLightbox={images.onOpenAssetLightbox}
+                  renderGalleryImage={(args) => renderAssetImage(args)}
+                />
+
+                {images.sections.profile_pictures.length > 0 && (
+                  <section>
+                    <h4 className="mb-3 text-sm font-semibold text-zinc-900">
+                      Profile Pictures
+                    </h4>
+                    <div className="grid grid-cols-5 gap-4">
+                      {images.sections.profile_pictures.map((asset, index, assets) => (
+                        <button
+                          key={asset.id}
+                          type="button"
+                          onClick={(event) =>
+                            images.onOpenAssetLightbox(asset, index, assets, event.currentTarget)
+                          }
+                          className="relative aspect-[2/3] cursor-zoom-in overflow-hidden rounded-lg bg-zinc-200 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        >
+                          {renderAssetImage({
+                            asset,
+                            alt: asset.caption || "Profile picture",
+                            sizes: "180px",
+                          })}
+                          {asset.person_name && (
+                            <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent p-2">
+                              <p className="truncate text-xs text-white">{asset.person_name}</p>
+                            </div>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                    {images.sections.hasMoreBySection.profile_pictures && (
+                      <div className="mt-3 flex justify-center">
+                        <button
+                          type="button"
+                          onClick={images.onLoadMoreProfilePictures}
+                          className="rounded-lg border border-zinc-300 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-50"
+                        >
+                          Load More Profile Pictures
+                        </button>
+                      </div>
+                    )}
+                  </section>
+                )}
+
+                {images.castPromoAssets.length > 0 && (
+                  <section>
+                    <h4 className="mb-3 text-sm font-semibold text-zinc-900">Cast Promos</h4>
+                    <div className="grid grid-cols-5 gap-4">
+                      {images.castPromoAssets.map((asset, index, assets) => (
+                        <button
+                          key={asset.id}
+                          type="button"
+                          onClick={(event) =>
+                            images.onOpenAssetLightbox(asset, index, assets, event.currentTarget)
+                          }
+                          className="relative aspect-[2/3] cursor-zoom-in overflow-hidden rounded-lg bg-zinc-200 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        >
+                          {renderAssetImage({
+                            asset,
+                            alt: asset.caption || "Cast photo",
+                            sizes: "180px",
+                            useResolvedUrl: true,
+                          })}
+                          {asset.person_name && (
+                            <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent p-2">
+                              <p className="truncate text-xs text-white">{asset.person_name}</p>
+                            </div>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                    {images.sections.hasMoreBySection.cast_photos && (
+                      <div className="mt-3 flex justify-center">
+                        <button
+                          type="button"
+                          onClick={images.onLoadMoreCastPromos}
+                          className="rounded-lg border border-zinc-300 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-50"
+                        >
+                          Load More Cast Promos
+                        </button>
+                      </div>
+                    )}
+                  </section>
+                )}
+              </div>
+            )}
+          </>
+        ) : assetsView === "videos" ? (
+          <div className="space-y-4">
+            {(videos.error || videos.loading) && (
+              <p className={`text-sm ${videos.error ? "text-red-600" : "text-zinc-500"}`}>
+                {videos.error || "Loading Bravo videos..."}
+              </p>
+            )}
+            {videos.thumbnailSyncing && (
+              <p className="text-sm text-zinc-500">Syncing high-quality video thumbnails...</p>
+            )}
+            {videos.thumbnailSyncWarning && !videos.error && (
+              <p className="text-sm text-amber-700">{videos.thumbnailSyncWarning}</p>
+            )}
+            {!videos.loading && videos.rows.length === 0 && !videos.error && (
+              <p className="text-sm text-zinc-500">
+                No persisted Bravo videos found for this show.
+              </p>
+            )}
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {videos.rows.map((video) => {
+                const thumbnailUrl = videos.getThumbnailUrl(video);
+                const publishedDate = videos.formatPublishedDate(video.published_at);
+                return (
+                  <article
+                    key={`${video.clip_url}-${video.published_at ?? "unknown"}`}
+                    className="rounded-xl border border-zinc-200 bg-zinc-50 p-3"
+                  >
+                    <a
+                      href={video.clip_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="group block"
+                    >
+                      <div className="relative mb-3 aspect-video overflow-hidden rounded-lg bg-zinc-200">
+                        {thumbnailUrl ? (
+                          renderVideoThumbnail({
+                            src: thumbnailUrl,
+                            alt: video.title || "Bravo video",
+                            sizes: "400px",
+                            className: "object-cover transition group-hover:scale-105",
+                          })
+                        ) : (
+                          <div className="flex h-full items-center justify-center text-zinc-400">
+                            No image
+                          </div>
+                        )}
+                      </div>
+                      <h4 className="text-sm font-semibold text-zinc-900 group-hover:text-blue-700">
+                        {video.title || "Untitled video"}
+                      </h4>
+                    </a>
+                    <div className="mt-1 flex flex-wrap gap-2 text-xs text-zinc-500">
+                      {video.runtime && <span>{video.runtime}</span>}
+                      {typeof video.season_number === "number" && (
+                        <span>Season {video.season_number}</span>
+                      )}
+                      {video.kicker && <span>{video.kicker}</span>}
+                      {publishedDate && <span>Posted {publishedDate}</span>}
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            <section>
+              <h4 className="mb-3 text-sm font-semibold text-zinc-900">Featured Images</h4>
+              <ShowFeaturedMediaSelectors
+                posterAssets={branding.posterAssets}
+                backdropAssets={branding.backdropAssets}
+                featuredPosterImageId={branding.featuredPosterImageId}
+                featuredBackdropImageId={branding.featuredBackdropImageId}
+                getAssetDisplayUrl={branding.getAssetDisplayUrl}
+                onSetFeaturedPoster={branding.onSetFeaturedPoster}
+                onSetFeaturedBackdrop={branding.onSetFeaturedBackdrop}
+              />
+            </section>
+
+            <section>
+              <h4 className="mb-3 text-sm font-semibold text-zinc-900">Logos</h4>
+              <ShowBrandLogosSection
+                logoAssets={branding.logoAssets}
+                featuredLogoAssetId={branding.featuredLogoAssetId}
+                featuredLogoSavingAssetId={branding.featuredLogoSavingAssetId}
+                selectedFeaturedLogoVariant={branding.featuredLogoVariant}
+                getAssetDisplayUrl={branding.getAssetDisplayUrl}
+                onSelectFeaturedLogoVariant={branding.onSelectFeaturedLogoVariant}
+                onSetFeaturedLogo={branding.onSetFeaturedLogo}
+              />
+            </section>
+
+            <ShowBrandEditor
+              trrShowId={showId}
+              trrShowName={showName}
+              trrSeasons={branding.seasons}
+              trrCast={branding.cast}
+              showDefaultMediaSection={false}
+            />
+          </div>
+        )}
+      </div>
     </section>
   );
 }

--- a/apps/web/src/components/admin/show-tabs/ShowBrandLogosSection.tsx
+++ b/apps/web/src/components/admin/show-tabs/ShowBrandLogosSection.tsx
@@ -5,8 +5,9 @@ import Image from "next/image";
 import { canonicalizeHostedMediaUrl } from "@/lib/hosted-media";
 import type { SeasonAsset } from "@/lib/server/trr-api/trr-shows-repository";
 import { FeaturedLogoDrawer } from "./FeaturedLogoDrawer";
+import type { ShowLogoVariant } from "./show-logo-types";
 
-export type ShowLogoVariant = "color" | "black" | "white";
+export type { ShowLogoVariant } from "./show-logo-types";
 
 interface ShowBrandLogosSectionProps {
   logoAssets: SeasonAsset[];

--- a/apps/web/src/components/admin/show-tabs/ShowCastTab.tsx
+++ b/apps/web/src/components/admin/show-tabs/ShowCastTab.tsx
@@ -1,15 +1,844 @@
 "use client";
 
+import Link from "next/link";
 import type { ReactNode } from "react";
 
-export default function ShowCastTab({ children }: { children: ReactNode }) {
+import { CastMatrixSyncPanel, type CastMatrixSyncResult } from "@/components/admin/CastMatrixSyncPanel";
+import {
+  CastPhoto,
+} from "@/app/admin/trr-shows/[showId]/ShowPageMedia";
+import {
+  ShowCreditsCastMembers,
+  ShowCreditsCastViewControls,
+  ShowCreditsCrewSections,
+  type ShowCreditsCastViewMode,
+  type ShowCreditsCrewSectionData,
+  type ShowCreditsGalleryColumns,
+} from "@/components/admin/show-tabs/ShowCreditsViews";
+
+type ShowCastTabWrapperProps = {
+  children: ReactNode;
+};
+
+export type ShowCastTabPhaseRow = {
+  id: string;
+  label: string;
+  message: string | null;
+  statusClassName: string;
+  statusLabel: string;
+};
+
+export type ShowCastTabRoleCreditFilterOption = {
+  key: string;
+  label: string;
+};
+
+export type ShowCastArchiveFootageMember = {
+  id: string;
+  person_id: string;
+  full_name: string | null;
+  cast_member_name: string | null;
+  photo_url: string | null;
+  cover_photo_url: string | null;
+  thumbnail_focus_x?: number | null;
+  thumbnail_focus_y?: number | null;
+  thumbnail_zoom?: number | null;
+  thumbnail_crop_mode?: "manual" | "auto" | null;
+  archive_episode_count?: number | null;
+};
+
+export type ShowCastTabProps<TCastMember extends { id: string | number } = { id: string | number }> =
+  | ShowCastTabWrapperProps
+  | {
+      renderedCastCount: number;
+      matchedCastCount: number;
+      totalCastCount: number;
+      renderedCrewCount: number;
+      matchedCrewCount: number;
+      totalCrewCount: number;
+      renderedVisibleCount: number;
+      matchedVisibleCount: number;
+      totalVisibleCount: number;
+      castMediaEnriching: boolean;
+      isCastRefreshBusy: boolean;
+      castPhotoEnriching: boolean;
+      castLoading: boolean;
+      missingCastPhotoCount: number;
+      castRefreshButtonLabel: string;
+      showCancelRunButton: boolean;
+      castRefreshCanceling: boolean;
+      castRefreshCancelButtonLabel: string;
+      onEnrichCastMedia: () => void;
+      onEnrichMissingCastPhotos: () => void;
+      onRefreshShowCast: () => void;
+      onCancelShowCastWorkflow: () => void;
+      castCreditsRefreshNotice: string | null;
+      castCreditsRefreshError: string | null;
+      castRefreshPhaseRows: ShowCastTabPhaseRow[];
+      castRefreshPipelineRunning: boolean;
+      refreshNotice: string | null;
+      refreshError: string | null;
+      castPhotoEnrichNotice: string | null;
+      castPhotoEnrichError: string | null;
+      castMediaEnrichNotice: string | null;
+      castMediaEnrichError: string | null;
+      castLoadWarning: string | null;
+      castLoadError: string | null;
+      onRetryCast: () => void;
+      showCreditsError: string | null;
+      onRetryCrew: () => void;
+      showCreditsLoading: boolean;
+      showCreditsLoadedOnce: boolean;
+      showCreditsSourceUrl: string | null;
+      castRoleMembersWarningWithSnapshotAge: string | null;
+      onRetryCastRoleMembers: () => void;
+      rolesWarningWithSnapshotAge: string | null;
+      onRetryRoles: () => void;
+      showCastIntelligenceUnavailable: boolean;
+      castRoleMembersError: string | null;
+      rolesError: string | null;
+      castRoleEditorDeepLinkWarning: string | null;
+      castEligibilityWarning: string | null;
+      castRunFailedMembers: Array<{
+        personId: string;
+        name: string;
+        reason: string;
+      }>;
+      castFailedMembersOpen: boolean;
+      onToggleCastFailedMembersOpen: () => void;
+      onRetryFailedCastMediaEnrich: () => void;
+      castMatrixSyncLoading: boolean;
+      castMatrixSyncError: string | null;
+      castMatrixSyncResult: CastMatrixSyncResult | null;
+      castMatrixSyncScopeLabel: string;
+      onSyncCastMatrixRoles: () => void;
+      castSearchQuery: string;
+      onSetCastSearchQuery: (value: string) => void;
+      castSortBy: "episodes" | "season" | "name";
+      onSetCastSortBy: (value: "episodes" | "season" | "name") => void;
+      castSortOrder: "desc" | "asc";
+      onSetCastSortOrder: (value: "desc" | "asc") => void;
+      castHasImageFilter: "all" | "yes" | "no";
+      onSetCastHasImageFilter: (value: "all" | "yes" | "no") => void;
+      onClearCastFilters: () => void;
+      castExactEpisodeCount: number | null;
+      onSetCastExactEpisodeCount: (value: number | null) => void;
+      castMinEpisodeCount: number | null;
+      onSetCastMinEpisodeCount: (value: number | null) => void;
+      castMaxEpisodeCount: number | null;
+      onSetCastMaxEpisodeCount: (value: number | null) => void;
+      availableCastSeasons: number[];
+      castSeasonFilters: number[];
+      onToggleCastSeasonFilter: (seasonNumber: number) => void;
+      castEpisodeScopeLabel: string;
+      shouldShowRoleCreditEmptyState: boolean;
+      castUiTerminalReady: boolean;
+      availableCastRoleAndCreditFilters: ShowCastTabRoleCreditFilterOption[];
+      castRoleAndCreditFilters: string[];
+      onToggleCastRoleAndCreditFilter: (key: string) => void;
+      castRoleMembersLoading: boolean;
+      castLoadedOnce: boolean;
+      castRenderProgressLabel: string | null;
+      castRosterReady: boolean;
+      castViewMode: ShowCreditsCastViewMode;
+      castGalleryColumns: ShowCreditsGalleryColumns;
+      onSetCastViewMode: (viewMode: ShowCreditsCastViewMode) => void;
+      onSetCastGalleryColumns: (columns: ShowCreditsGalleryColumns) => void;
+      castGalleryMembers: TCastMember[];
+      castCount: number;
+      archiveFootageCount: number;
+      visibleCastMembers: TCastMember[];
+      renderCastMember: (member: TCastMember) => ReactNode;
+      crewDisplaySections: ShowCreditsCrewSectionData[];
+      visibleCrewSections: ShowCreditsCrewSectionData[];
+      archiveFootageCast: ShowCastArchiveFootageMember[];
+      getPersonOverviewHref: (person: { personId: string; personName: string | null }) => string;
+    };
+
+const parsePositiveIntegerInputValue = (value: string): number | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+};
+
+const isWrapperProps = <TCastMember extends { id: string | number }>(
+  props: ShowCastTabProps<TCastMember>
+): props is ShowCastTabWrapperProps => "children" in props;
+
+export default function ShowCastTab<TCastMember extends { id: string | number }>(
+  props: ShowCastTabProps<TCastMember>
+) {
+  if (isWrapperProps(props)) {
+    return (
+      <section
+        id="show-tabpanel-cast"
+        role="tabpanel"
+        aria-labelledby="show-tab-cast"
+      >
+        {props.children}
+      </section>
+    );
+  }
+
+  const {
+    renderedCastCount,
+    matchedCastCount,
+    totalCastCount,
+    renderedCrewCount,
+    matchedCrewCount,
+    totalCrewCount,
+    renderedVisibleCount,
+    matchedVisibleCount,
+    totalVisibleCount,
+    castMediaEnriching,
+    isCastRefreshBusy,
+    castPhotoEnriching,
+    castLoading,
+    missingCastPhotoCount,
+    castRefreshButtonLabel,
+    showCancelRunButton,
+    castRefreshCanceling,
+    castRefreshCancelButtonLabel,
+    onEnrichCastMedia,
+    onEnrichMissingCastPhotos,
+    onRefreshShowCast,
+    onCancelShowCastWorkflow,
+    castCreditsRefreshNotice,
+    castCreditsRefreshError,
+    castRefreshPhaseRows,
+    castRefreshPipelineRunning,
+    refreshNotice,
+    refreshError,
+    castPhotoEnrichNotice,
+    castPhotoEnrichError,
+    castMediaEnrichNotice,
+    castMediaEnrichError,
+    castLoadWarning,
+    castLoadError,
+    onRetryCast,
+    showCreditsError,
+    onRetryCrew,
+    showCreditsLoading,
+    showCreditsLoadedOnce,
+    showCreditsSourceUrl,
+    castRoleMembersWarningWithSnapshotAge,
+    onRetryCastRoleMembers,
+    rolesWarningWithSnapshotAge,
+    onRetryRoles,
+    showCastIntelligenceUnavailable,
+    castRoleMembersError,
+    rolesError,
+    castRoleEditorDeepLinkWarning,
+    castEligibilityWarning,
+    castRunFailedMembers,
+    castFailedMembersOpen,
+    onToggleCastFailedMembersOpen,
+    onRetryFailedCastMediaEnrich,
+    castMatrixSyncLoading,
+    castMatrixSyncError,
+    castMatrixSyncResult,
+    castMatrixSyncScopeLabel,
+    onSyncCastMatrixRoles,
+    castSearchQuery,
+    onSetCastSearchQuery,
+    castSortBy,
+    onSetCastSortBy,
+    castSortOrder,
+    onSetCastSortOrder,
+    castHasImageFilter,
+    onSetCastHasImageFilter,
+    onClearCastFilters,
+    castExactEpisodeCount,
+    onSetCastExactEpisodeCount,
+    castMinEpisodeCount,
+    onSetCastMinEpisodeCount,
+    castMaxEpisodeCount,
+    onSetCastMaxEpisodeCount,
+    availableCastSeasons,
+    castSeasonFilters,
+    onToggleCastSeasonFilter,
+    castEpisodeScopeLabel,
+    shouldShowRoleCreditEmptyState,
+    castUiTerminalReady,
+    availableCastRoleAndCreditFilters,
+    castRoleAndCreditFilters,
+    onToggleCastRoleAndCreditFilter,
+    castRoleMembersLoading,
+    castLoadedOnce,
+    castRenderProgressLabel,
+    castRosterReady,
+    castViewMode,
+    castGalleryColumns,
+    onSetCastViewMode,
+    onSetCastGalleryColumns,
+    castGalleryMembers,
+    castCount,
+    archiveFootageCount,
+    visibleCastMembers,
+    renderCastMember,
+    crewDisplaySections,
+    visibleCrewSections,
+    archiveFootageCast,
+    getPersonOverviewHref,
+  } = props;
+
   return (
     <section
       id="show-tabpanel-cast"
       role="tabpanel"
       aria-labelledby="show-tab-cast"
     >
-      {children}
+      <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm">
+        <div className="mb-6 flex items-center justify-between">
+          <div>
+            <h3 className="text-xl font-bold text-zinc-900">Credits</h3>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="rounded-full bg-zinc-100 px-3 py-1 text-xs font-semibold text-zinc-700">
+              {renderedCastCount}/{matchedCastCount}/{totalCastCount} cast ·{" "}
+              {renderedCrewCount}/{matchedCrewCount}/{totalCrewCount} crew ·{" "}
+              {renderedVisibleCount}/{matchedVisibleCount}/{totalVisibleCount} visible
+            </span>
+            <button
+              type="button"
+              onClick={onEnrichCastMedia}
+              disabled={isCastRefreshBusy}
+              title={isCastRefreshBusy ? "Cast sync in progress" : undefined}
+              className="rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs font-semibold text-zinc-700 transition hover:bg-zinc-50 disabled:opacity-50"
+            >
+              {castMediaEnriching ? "Enriching..." : "Enrich Media"}
+            </button>
+            <button
+              type="button"
+              onClick={onEnrichMissingCastPhotos}
+              disabled={isCastRefreshBusy || castPhotoEnriching || castLoading || missingCastPhotoCount <= 0}
+              title={isCastRefreshBusy ? "Cast sync in progress" : undefined}
+              className="rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs font-semibold text-zinc-700 transition hover:bg-zinc-50 disabled:opacity-50"
+            >
+              {castPhotoEnriching
+                ? "Enriching..."
+                : `Enrich Missing Cast Photos${missingCastPhotoCount > 0 ? ` (${missingCastPhotoCount})` : ""}`}
+            </button>
+            <button
+              type="button"
+              onClick={onRefreshShowCast}
+              disabled={isCastRefreshBusy}
+              title={isCastRefreshBusy ? "Cast sync in progress" : undefined}
+              className="rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs font-semibold text-zinc-700 transition hover:bg-zinc-50 disabled:opacity-50"
+            >
+              {castRefreshButtonLabel}
+            </button>
+            {showCancelRunButton && (
+              <button
+                type="button"
+                onClick={onCancelShowCastWorkflow}
+                disabled={castRefreshCanceling}
+                className="rounded-full border border-rose-200 bg-white px-3 py-1 text-xs font-semibold text-rose-700 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {castRefreshCancelButtonLabel}
+              </button>
+            )}
+          </div>
+        </div>
+        {(castCreditsRefreshNotice || castCreditsRefreshError) && (
+          <p
+            className={`mb-4 text-sm ${
+              castCreditsRefreshError ? "text-red-600" : "text-zinc-500"
+            }`}
+          >
+            {castCreditsRefreshError || castCreditsRefreshNotice}
+          </p>
+        )}
+        {(castRefreshPipelineRunning || castRefreshPhaseRows.length > 0) && (
+          <div className="mb-4 rounded-xl border border-zinc-200 bg-zinc-50 p-4">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                Credits Refresh Pipeline
+              </p>
+              {castRefreshPipelineRunning && (
+                <p className="text-[11px] text-zinc-500">Fail-fast timeout policy enabled</p>
+              )}
+            </div>
+            <div className="space-y-2">
+              {castRefreshPhaseRows.map((phase, index) => (
+                <div
+                  key={`cast-refresh-phase-${phase.id}`}
+                  className="flex items-center justify-between gap-3 rounded-lg border border-zinc-200 bg-white px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-zinc-800">
+                      {index + 1}. {phase.label}
+                    </p>
+                    {phase.message && <p className="truncate text-xs text-zinc-500">{phase.message}</p>}
+                  </div>
+                  <span
+                    className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${phase.statusClassName}`}
+                  >
+                    {phase.statusLabel}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+        {(refreshNotice || refreshError) && (
+          <p className={`mb-4 text-sm ${refreshError ? "text-red-600" : "text-zinc-500"}`}>
+            {refreshError || refreshNotice}
+          </p>
+        )}
+        {(castPhotoEnrichNotice || castPhotoEnrichError) && (
+          <p className={`mb-4 text-sm ${castPhotoEnrichError ? "text-red-600" : "text-zinc-500"}`}>
+            {castPhotoEnrichError || castPhotoEnrichNotice}
+          </p>
+        )}
+        {(castMediaEnrichNotice || castMediaEnrichError) && (
+          <p className={`mb-4 text-sm ${castMediaEnrichError ? "text-red-600" : "text-zinc-500"}`}>
+            {castMediaEnrichError || castMediaEnrichNotice}
+          </p>
+        )}
+        {castLoadWarning && (
+          <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+            <span>{castLoadWarning}</span>
+            <button
+              type="button"
+              onClick={onRetryCast}
+              className="rounded-full border border-amber-400 bg-white px-3 py-1 text-xs font-semibold text-amber-900 transition hover:bg-amber-100"
+            >
+              Retry Cast
+            </button>
+          </div>
+        )}
+        {castLoadError && (
+          <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+            <span>{castLoadError}</span>
+            <button
+              type="button"
+              onClick={onRetryCast}
+              className="rounded-full border border-rose-300 bg-white px-3 py-1 text-xs font-semibold text-rose-700 transition hover:bg-rose-100"
+            >
+              Retry Cast
+            </button>
+          </div>
+        )}
+        {showCreditsError && (
+          <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+            <span>{showCreditsError}</span>
+            <button
+              type="button"
+              onClick={onRetryCrew}
+              className="rounded-full border border-rose-300 bg-white px-3 py-1 text-xs font-semibold text-rose-700 transition hover:bg-rose-100"
+            >
+              Retry Crew
+            </button>
+          </div>
+        )}
+        {showCreditsLoading && !showCreditsLoadedOnce && (
+          <p className="mb-4 text-sm text-zinc-500">Loading crew credits...</p>
+        )}
+        {showCreditsSourceUrl && (
+          <p className="mb-4 text-xs text-zinc-500">
+            Crew source:{" "}
+            <a
+              href={showCreditsSourceUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="font-semibold text-zinc-700 underline decoration-zinc-300 underline-offset-2"
+            >
+              IMDb Full Credits
+            </a>
+          </p>
+        )}
+        {castRoleMembersWarningWithSnapshotAge && (
+          <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+            <span>{castRoleMembersWarningWithSnapshotAge}</span>
+            <button
+              type="button"
+              onClick={onRetryCastRoleMembers}
+              className="rounded-full border border-amber-400 bg-white px-3 py-1 text-xs font-semibold text-amber-900 transition hover:bg-amber-100"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+        {rolesWarningWithSnapshotAge && (
+          <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+            <span>{rolesWarningWithSnapshotAge}</span>
+            <button
+              type="button"
+              onClick={onRetryRoles}
+              className="rounded-full border border-amber-400 bg-white px-3 py-1 text-xs font-semibold text-amber-900 transition hover:bg-amber-100"
+            >
+              Retry Roles
+            </button>
+          </div>
+        )}
+        {showCastIntelligenceUnavailable && (
+          <div className="mb-4 rounded-lg border border-amber-300 bg-amber-50 px-3 py-3 text-sm text-amber-900">
+            <p className="font-semibold">
+              Cast intelligence unavailable; showing base cast snapshot.
+            </p>
+            {(castRoleMembersError || rolesError) && (
+              <p className="mt-1 text-xs">
+                {[castRoleMembersError, rolesError].filter(Boolean).join(" · ")}
+              </p>
+            )}
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={onRetryCastRoleMembers}
+                className="rounded-full border border-amber-400 bg-white px-3 py-1 text-xs font-semibold text-amber-900 transition hover:bg-amber-100"
+              >
+                Retry Cast Intelligence
+              </button>
+              <button
+                type="button"
+                onClick={onRetryRoles}
+                className="rounded-full border border-amber-400 bg-white px-3 py-1 text-xs font-semibold text-amber-900 transition hover:bg-amber-100"
+              >
+                Retry Roles
+              </button>
+            </div>
+          </div>
+        )}
+        {castRoleEditorDeepLinkWarning && (
+          <div className="mb-4 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+            {castRoleEditorDeepLinkWarning}
+          </div>
+        )}
+        {castEligibilityWarning && (
+          <div className="mb-4 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+            {castEligibilityWarning}
+          </div>
+        )}
+        {castRunFailedMembers.length > 0 && (
+          <div className="mb-4 rounded-xl border border-amber-200 bg-amber-50 p-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <p className="text-sm font-semibold text-amber-900">
+                Failed Members ({castRunFailedMembers.length})
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={onToggleCastFailedMembersOpen}
+                  className="rounded-full border border-amber-300 bg-white px-3 py-1 text-xs font-semibold text-amber-900 hover:bg-amber-100"
+                >
+                  {castFailedMembersOpen ? "Hide" : "Show"}
+                </button>
+                <button
+                  type="button"
+                  onClick={onRetryFailedCastMediaEnrich}
+                  disabled={isCastRefreshBusy}
+                  className="rounded-full border border-amber-300 bg-white px-3 py-1 text-xs font-semibold text-amber-900 hover:bg-amber-100 disabled:opacity-50"
+                >
+                  Retry failed only
+                </button>
+              </div>
+            </div>
+            {castFailedMembersOpen && (
+              <ul className="mt-3 space-y-2 text-xs text-amber-900">
+                {castRunFailedMembers.map((member) => (
+                  <li
+                    key={`${member.personId}-${member.name}-${member.reason}`}
+                    className="rounded-md border border-amber-200 bg-white px-2 py-1"
+                  >
+                    <span className="font-semibold">{member.name}</span>: {member.reason}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+
+        <CastMatrixSyncPanel
+          loading={castMatrixSyncLoading}
+          error={castMatrixSyncError}
+          result={castMatrixSyncResult}
+          scopeLabel={castMatrixSyncScopeLabel}
+          onSync={onSyncCastMatrixRoles}
+        />
+
+        <div className="mb-4 rounded-xl border border-zinc-200 bg-zinc-50 p-4">
+          <div className="grid gap-3 md:grid-cols-5">
+            <label className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500 md:col-span-2">
+              Search Name
+              <input
+                value={castSearchQuery}
+                onChange={(event) => onSetCastSearchQuery(event.target.value)}
+                placeholder="Search cast or crew..."
+                className="mt-1 block w-full rounded-lg border border-zinc-300 bg-white px-2 py-2 text-sm font-medium normal-case tracking-normal text-zinc-700"
+              />
+            </label>
+            <label className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+              Sort By
+              <select
+                value={castSortBy}
+                onChange={(event) => onSetCastSortBy(event.target.value as "episodes" | "season" | "name")}
+                className="mt-1 block w-full rounded-lg border border-zinc-300 bg-white px-2 py-2 text-sm font-medium normal-case tracking-normal text-zinc-700"
+              >
+                <option value="episodes">Episodes</option>
+                <option value="season">Season Recency</option>
+                <option value="name">Name</option>
+              </select>
+            </label>
+            <label className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+              Order
+              <select
+                value={castSortOrder}
+                onChange={(event) => onSetCastSortOrder(event.target.value as "desc" | "asc")}
+                className="mt-1 block w-full rounded-lg border border-zinc-300 bg-white px-2 py-2 text-sm font-medium normal-case tracking-normal text-zinc-700"
+              >
+                <option value="desc">Desc</option>
+                <option value="asc">Asc</option>
+              </select>
+            </label>
+            <label className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+              Has Image
+              <select
+                value={castHasImageFilter}
+                onChange={(event) => onSetCastHasImageFilter(event.target.value as "all" | "yes" | "no")}
+                className="mt-1 block w-full rounded-lg border border-zinc-300 bg-white px-2 py-2 text-sm font-medium normal-case tracking-normal text-zinc-700"
+              >
+                <option value="all">All</option>
+                <option value="yes">With Image</option>
+                <option value="no">Without Image</option>
+              </select>
+            </label>
+            <button
+              type="button"
+              onClick={onClearCastFilters}
+              className="self-end rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm font-semibold text-zinc-700 hover:bg-zinc-100"
+            >
+              Clear Filters
+            </button>
+          </div>
+          <div className="mt-3 grid gap-3 md:grid-cols-3">
+            <label className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+              Episode Exact
+              <input
+                type="number"
+                min={1}
+                inputMode="numeric"
+                value={castExactEpisodeCount ?? ""}
+                onChange={(event) => onSetCastExactEpisodeCount(parsePositiveIntegerInputValue(event.target.value))}
+                placeholder="Any"
+                className="mt-1 block w-full rounded-lg border border-zinc-300 bg-white px-2 py-2 text-sm font-medium normal-case tracking-normal text-zinc-700"
+              />
+            </label>
+            <label className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+              Episode Min
+              <input
+                type="number"
+                min={1}
+                inputMode="numeric"
+                value={castMinEpisodeCount ?? ""}
+                onChange={(event) => onSetCastMinEpisodeCount(parsePositiveIntegerInputValue(event.target.value))}
+                placeholder="Any"
+                className="mt-1 block w-full rounded-lg border border-zinc-300 bg-white px-2 py-2 text-sm font-medium normal-case tracking-normal text-zinc-700"
+              />
+            </label>
+            <label className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+              Episode Max
+              <input
+                type="number"
+                min={1}
+                inputMode="numeric"
+                value={castMaxEpisodeCount ?? ""}
+                onChange={(event) => onSetCastMaxEpisodeCount(parsePositiveIntegerInputValue(event.target.value))}
+                placeholder="Any"
+                className="mt-1 block w-full rounded-lg border border-zinc-300 bg-white px-2 py-2 text-sm font-medium normal-case tracking-normal text-zinc-700"
+              />
+            </label>
+          </div>
+          <div className="mt-3 space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                Seasons
+              </span>
+              {availableCastSeasons.length === 0 ? (
+                <span className="text-xs text-zinc-500">No season recency data yet.</span>
+              ) : (
+                availableCastSeasons.map((seasonNumber) => {
+                  const active = castSeasonFilters.includes(seasonNumber);
+                  return (
+                    <button
+                      key={`season-filter-${seasonNumber}`}
+                      type="button"
+                      aria-pressed={active}
+                      onClick={() => onToggleCastSeasonFilter(seasonNumber)}
+                      className={`rounded-full border px-2 py-1 text-xs font-semibold ${
+                        active
+                          ? "border-zinc-900 bg-zinc-900 text-white"
+                          : "border-zinc-200 bg-white text-zinc-600"
+                      }`}
+                    >
+                      S{seasonNumber}
+                    </button>
+                  );
+                })
+              )}
+            </div>
+            <p className="text-[11px] text-zinc-500">
+              Season filters use season-scoped role assignments plus global season-0 roles.{" "}
+              {castEpisodeScopeLabel}
+            </p>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                Roles & Credit
+              </span>
+              {shouldShowRoleCreditEmptyState ? (
+                <span className="text-xs text-zinc-500">No role or credit filters available.</span>
+              ) : !castUiTerminalReady ? (
+                <span className="text-xs text-zinc-500">Loading role and credit filters...</span>
+              ) : (
+                availableCastRoleAndCreditFilters.map((option) => {
+                  const active = castRoleAndCreditFilters.includes(option.key);
+                  return (
+                    <button
+                      key={`role-credit-filter-${option.key}`}
+                      type="button"
+                      aria-pressed={active}
+                      onClick={() => onToggleCastRoleAndCreditFilter(option.key)}
+                      className={`rounded-full border px-2 py-1 text-xs font-semibold ${
+                        active
+                          ? "border-zinc-900 bg-zinc-900 text-white"
+                          : "border-zinc-200 bg-white text-zinc-600"
+                      }`}
+                    >
+                      {option.label}
+                    </button>
+                  );
+                })
+              )}
+            </div>
+          </div>
+        </div>
+        {castRoleMembersLoading && (
+          <p className="mb-4 text-sm text-zinc-500" aria-live="polite">
+            Refreshing cast intelligence...
+          </p>
+        )}
+        {castLoading && !castLoadedOnce && (
+          <p className="mb-4 text-sm text-zinc-500" aria-live="polite">
+            Loading cast members...
+          </p>
+        )}
+        {castLoading && castLoadedOnce && castCount === 0 && (
+          <p className="mb-4 text-sm text-zinc-500" aria-live="polite">
+            Cast list unavailable; retrying cast roster...
+          </p>
+        )}
+        {castRenderProgressLabel && (
+          <p className="mb-3 text-xs text-zinc-500" role="status" aria-live="polite">
+            {castRenderProgressLabel}
+          </p>
+        )}
+        <div className="space-y-8">
+          <section>
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-zinc-500">
+                Cast
+              </p>
+              <ShowCreditsCastViewControls
+                viewMode={castViewMode}
+                galleryColumns={castGalleryColumns}
+                onViewModeChange={onSetCastViewMode}
+                onGalleryColumnsChange={onSetCastGalleryColumns}
+              />
+            </div>
+            {castGalleryMembers.length === 0 ? (
+              !castRosterReady ? (
+                <p className="text-sm text-zinc-500">Loading cast roster...</p>
+              ) : castCount === 0 && archiveFootageCount === 0 ? (
+                <p className="text-sm text-zinc-500">No cast members found for this show.</p>
+              ) : (
+                <p className="text-sm text-zinc-500">No cast members match the selected filters.</p>
+              )
+            ) : (
+              <ShowCreditsCastMembers
+                members={visibleCastMembers}
+                viewMode={castViewMode}
+                galleryColumns={castGalleryColumns}
+                renderMember={renderCastMember}
+              />
+            )}
+          </section>
+
+          {crewDisplaySections.length > 0 && (
+            <section>
+              <p className="mb-3 text-xs font-semibold uppercase tracking-[0.3em] text-zinc-500">
+                Crew
+              </p>
+              <ShowCreditsCrewSections
+                sections={visibleCrewSections}
+                renderPersonName={(row) => (
+                  <Link
+                    href={getPersonOverviewHref({
+                      personId: row.personId,
+                      personName: row.personName,
+                    })}
+                    className="hover:underline"
+                  >
+                    {row.personName || "Unknown"}
+                  </Link>
+                )}
+              />
+            </section>
+          )}
+
+          {archiveFootageCast.length > 0 && (
+            <section>
+              <p className="mb-3 text-xs font-semibold uppercase tracking-[0.3em] text-zinc-500">
+                Archive Footage
+              </p>
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {archiveFootageCast.map((member) => {
+                  const thumbnailUrl = member.cover_photo_url || member.photo_url;
+                  const archiveLabel =
+                    typeof member.archive_episode_count === "number"
+                      ? `${member.archive_episode_count} archive footage episodes`
+                      : "Archive footage appearance";
+                  const personName = member.full_name || member.cast_member_name || "Unknown";
+
+                  return (
+                    <Link
+                      key={`archive-${member.id}`}
+                      href={getPersonOverviewHref({
+                        personId: member.person_id,
+                        personName: member.full_name || member.cast_member_name,
+                      })}
+                      className="rounded-xl border border-amber-200 bg-amber-50/40 p-4 transition hover:border-amber-300 hover:bg-amber-100/40"
+                    >
+                      <div className="relative mb-3 aspect-[4/5] overflow-hidden rounded-lg bg-zinc-200">
+                        {thumbnailUrl ? (
+                          <CastPhoto
+                            src={thumbnailUrl}
+                            alt={personName}
+                            thumbnail_focus_x={member.thumbnail_focus_x}
+                            thumbnail_focus_y={member.thumbnail_focus_y}
+                            thumbnail_zoom={member.thumbnail_zoom}
+                            thumbnail_crop_mode={member.thumbnail_crop_mode}
+                          />
+                        ) : (
+                          <div className="flex h-full items-center justify-center text-zinc-400">
+                            <svg width="48" height="48" viewBox="0 0 24 24" fill="none">
+                              <circle cx="12" cy="8" r="4" stroke="currentColor" strokeWidth="2" />
+                              <path d="M4 20c0-4 4-6 8-6s8 2 8 6" stroke="currentColor" strokeWidth="2" />
+                            </svg>
+                          </div>
+                        )}
+                      </div>
+                      <p className="font-semibold text-zinc-900">{personName}</p>
+                      <p className="text-sm text-amber-700">{archiveLabel}</p>
+                    </Link>
+                  );
+                })}
+              </div>
+            </section>
+          )}
+
+        </div>
+      </div>
     </section>
   );
 }

--- a/apps/web/src/components/admin/show-tabs/ShowOverviewTab.tsx
+++ b/apps/web/src/components/admin/show-tabs/ShowOverviewTab.tsx
@@ -1,15 +1,651 @@
 "use client";
 
-import type { ReactNode } from "react";
+import Link from "next/link";
+import { Fragment, type ReactNode } from "react";
 
-export default function ShowOverviewTab({ children }: { children: ReactNode }) {
+import { ExternalLinks } from "@/components/admin/ExternalLinks";
+import type {
+  OverviewRedditCommunityRow,
+  OverviewRedditGroup,
+  OverviewSeasonCoverageRow,
+  OverviewWatchProviderRegionOption,
+  OverviewWatchProviderRegionRow,
+} from "@/lib/admin/show-page/overview-display";
+
+type ShowOverviewRecord = {
+  id: string;
+  name: string;
+  description?: string | null;
+  premiere_date?: string | null;
+  external_ids?: Record<string, unknown> | null;
+  tmdb_id?: number | null;
+  imdb_id?: string | null;
+  derived_external_links?: {
+    justwatch_url?: string | null;
+  } | null;
+  genres?: string[] | null;
+  tags?: string[] | null;
+};
+
+type OverviewExternalIdLink = {
+  id: string;
+  url: string;
+};
+
+type OverviewSocialHandleLink = {
+  id: string;
+};
+
+type OverviewRefreshProgressProps = {
+  show: boolean;
+  stage?: string | null;
+  message?: string | null;
+  current?: number | null;
+  total?: number | null;
+};
+
+export interface ShowOverviewTabProps<
+  TExternalIdLink extends OverviewExternalIdLink = OverviewExternalIdLink,
+  TSocialHandleLink extends OverviewSocialHandleLink = OverviewSocialHandleLink,
+  TSeasonCoverageRow extends OverviewSeasonCoverageRow = OverviewSeasonCoverageRow,
+> {
+  show: ShowOverviewRecord;
+  nickname: string;
+  alternativeNamesText: string;
+  refreshCenterButtonLabel: string;
+  refreshNotice?: string | null;
+  refreshError?: string | null;
+  refreshing: boolean;
+  refreshProgress?: Omit<OverviewRefreshProgressProps, "show"> | null;
+  renderRefreshProgress: (props: OverviewRefreshProgressProps) => ReactNode;
+  detailsNotice: string | null;
+  detailsError: string | null;
+  externalIdLinks: TExternalIdLink[];
+  getExternalIdLinkTitle: (link: TExternalIdLink) => string;
+  renderExternalIdLinkBadge: (link: TExternalIdLink) => ReactNode;
+  socialHandleLinks: TSocialHandleLink[];
+  renderSocialHandlePill: (pill: TSocialHandleLink) => ReactNode;
+  redditLoading: boolean;
+  redditError: string | null;
+  redditGroups: OverviewRedditGroup[];
+  getRedditCommunityHref: (community: OverviewRedditCommunityRow) => string;
+  seasonUrlCoverageRows: TSeasonCoverageRow[];
+  renderSeasonCoverageBadge: (
+    link: TSeasonCoverageRow["links"][number]
+  ) => ReactNode;
+  networks: string[];
+  watchProviderRegions: OverviewWatchProviderRegionRow[];
+  watchProviderRegionOptions: OverviewWatchProviderRegionOption[];
+  selectedAvailabilityRegion: OverviewWatchProviderRegionRow | null;
+  fallbackWatchProviders: string[];
+  isCovered: boolean;
+  coverageLoading: boolean;
+  coverageError: string | null;
+  onOpenSettings: () => void;
+  onOpenRefreshLog: () => void;
+  onSelectAvailabilityRegion: (regionCode: string) => void;
+  onAddToCoveredShows: () => void;
+  onRemoveFromCoveredShows: () => void;
+}
+
+export default function ShowOverviewTab<
+  TExternalIdLink extends OverviewExternalIdLink,
+  TSocialHandleLink extends OverviewSocialHandleLink,
+  TSeasonCoverageRow extends OverviewSeasonCoverageRow,
+>({
+  show,
+  nickname,
+  alternativeNamesText,
+  refreshCenterButtonLabel,
+  refreshNotice,
+  refreshError,
+  refreshing,
+  refreshProgress,
+  renderRefreshProgress,
+  detailsNotice,
+  detailsError,
+  externalIdLinks,
+  getExternalIdLinkTitle,
+  renderExternalIdLinkBadge,
+  socialHandleLinks,
+  renderSocialHandlePill,
+  redditLoading,
+  redditError,
+  redditGroups,
+  getRedditCommunityHref,
+  seasonUrlCoverageRows,
+  renderSeasonCoverageBadge,
+  networks,
+  watchProviderRegions,
+  watchProviderRegionOptions,
+  selectedAvailabilityRegion,
+  fallbackWatchProviders,
+  isCovered,
+  coverageLoading,
+  coverageError,
+  onOpenSettings,
+  onOpenRefreshLog,
+  onSelectAvailabilityRegion,
+  onAddToCoveredShows,
+  onRemoveFromCoveredShows,
+}: ShowOverviewTabProps<
+  TExternalIdLink,
+  TSocialHandleLink,
+  TSeasonCoverageRow
+>) {
   return (
     <section
       id="show-tabpanel-details"
       role="tabpanel"
       aria-labelledby="show-tab-details"
     >
-      {children}
+      <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm">
+        <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-zinc-400">
+              Show Overview
+            </p>
+            <h3 className="text-xl font-bold text-zinc-900">
+              Details and Metadata
+            </h3>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={onOpenSettings}
+              className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-zinc-800"
+            >
+              Open Settings
+            </button>
+            <button
+              type="button"
+              onClick={onOpenRefreshLog}
+              className="rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-50 disabled:opacity-50"
+            >
+              {refreshCenterButtonLabel}
+            </button>
+          </div>
+        </div>
+
+        {(refreshNotice || refreshError) && (
+          <p
+            className={`mb-4 text-sm ${
+              refreshError ? "text-red-600" : "text-zinc-500"
+            }`}
+          >
+            {refreshError || refreshNotice}
+          </p>
+        )}
+        {renderRefreshProgress({
+          show: refreshing,
+          stage: refreshProgress?.stage,
+          message: refreshProgress?.message,
+          current: refreshProgress?.current,
+          total: refreshProgress?.total,
+        })}
+        {(detailsNotice || detailsError) && (
+          <p className={`mb-4 text-sm ${detailsError ? "text-red-600" : "text-zinc-500"}`}>
+            {detailsError || detailsNotice}
+          </p>
+        )}
+
+        <div className="space-y-6">
+          <div>
+            <h4 className="mb-3 text-sm font-semibold text-zinc-700">Show Info</h4>
+            <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="md:col-span-2">
+                  <p className="mb-1 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Display Name
+                  </p>
+                  <p className="text-sm text-zinc-900">{show.name || "Not set"}</p>
+                </div>
+                <div>
+                  <p className="mb-1 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Nickname
+                  </p>
+                  <p className="text-sm text-zinc-900">{nickname || "Not set"}</p>
+                </div>
+                <div>
+                  <p className="mb-1 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Premiere Date
+                  </p>
+                  <p className="text-sm text-zinc-900">
+                    {show.premiere_date
+                      ? new Date(show.premiere_date).toLocaleDateString("en-US", {
+                          year: "numeric",
+                          month: "long",
+                          day: "numeric",
+                        })
+                      : "Not set"}
+                  </p>
+                </div>
+                <div className="md:col-span-2">
+                  <p className="mb-1 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Alt Names
+                  </p>
+                  <p className="text-sm text-zinc-900 whitespace-pre-line">
+                    {alternativeNamesText || "None"}
+                  </p>
+                </div>
+                <div className="md:col-span-2">
+                  <p className="mb-1 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Description
+                  </p>
+                  <p className="text-sm leading-6 text-zinc-900">
+                    {show.description || "No description available."}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <h4 className="mb-3 text-sm font-semibold text-zinc-700">External IDs</h4>
+            <div className="space-y-3 rounded-lg border border-zinc-200 bg-zinc-50 p-4">
+              <ExternalLinks
+                externalIds={(show.external_ids as Record<string, unknown> | null) ?? null}
+                tmdbId={show.tmdb_id}
+                imdbId={show.imdb_id}
+                derivedLinks={show.derived_external_links ?? null}
+                type="show"
+              />
+              {externalIdLinks.length > 0 ? (
+                <div className="space-y-2">
+                  {externalIdLinks.map((link) => (
+                    <a
+                      key={`overview-external-id-link-${link.id}`}
+                      href={link.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex min-w-0 max-w-full items-center gap-2 rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs font-semibold text-zinc-700 hover:bg-zinc-100"
+                    >
+                      {renderExternalIdLinkBadge(link)}
+                      <span className="text-zinc-300">|</span>
+                      <span className="truncate">{getExternalIdLinkTitle(link)}</span>
+                    </a>
+                  ))}
+                </div>
+              ) : (
+                !show.tmdb_id &&
+                !show.imdb_id && (
+                  <p className="text-sm text-zinc-500">No external IDs available for this show.</p>
+                )
+              )}
+            </div>
+          </div>
+
+          <div>
+            <h4 className="mb-3 text-sm font-semibold text-zinc-700">Social Handles</h4>
+            <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
+              {socialHandleLinks.length === 0 ? (
+                <p className="text-sm text-zinc-500">No show-level social handles discovered yet.</p>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {socialHandleLinks.map((pill) => (
+                    <Fragment key={`overview-social-link-${pill.id}`}>
+                      {renderSocialHandlePill(pill)}
+                    </Fragment>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+              <h4 className="text-sm font-semibold text-zinc-700">Reddit</h4>
+              <Link
+                href={"/admin/social/reddit"}
+                className="rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-semibold text-zinc-700 hover:bg-zinc-50"
+              >
+                Open Reddit Admin
+              </Link>
+            </div>
+            <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
+              {redditLoading ? (
+                <p className="text-sm text-zinc-500">Loading Reddit communities...</p>
+              ) : redditError ? (
+                <p className="text-sm text-red-600">{redditError}</p>
+              ) : redditGroups.length === 0 ? (
+                <p className="text-sm text-zinc-500">No relevant Reddit communities configured for this show.</p>
+              ) : (
+                <div className="space-y-4">
+                  {redditGroups.map((group) => (
+                    <div key={`overview-reddit-group-${group.key}`} className="space-y-2">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        {group.label}
+                      </p>
+                      <div className="grid gap-3 md:grid-cols-2">
+                        {group.communities.map((community) => (
+                          <div
+                            key={`overview-reddit-community-${community.id}`}
+                            className="rounded-lg border border-zinc-200 bg-white p-3"
+                          >
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                              <div>
+                                <p className="text-sm font-semibold text-zinc-900">{community.displayName}</p>
+                                <p className="text-xs text-zinc-500">r/{community.subreddit}</p>
+                              </div>
+                              <Link
+                                href={getRedditCommunityHref(community)}
+                                className="rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-1.5 text-xs font-semibold text-zinc-700 hover:bg-zinc-100"
+                              >
+                                Open Community
+                              </Link>
+                            </div>
+                            <div className="mt-3 flex flex-wrap gap-1.5">
+                              {community.assignedFlairs.length > 0 ? (
+                                community.assignedFlairs.map((flair) => (
+                                  <span
+                                    key={`overview-reddit-flair-${community.id}-${flair}`}
+                                    className="rounded-full border border-zinc-200 bg-zinc-50 px-2 py-0.5 text-[11px] font-semibold text-zinc-700"
+                                  >
+                                    {flair}
+                                  </span>
+                                ))
+                              ) : (
+                                <span className="text-xs text-zinc-500">No assigned flairs</span>
+                              )}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <h4 className="mb-3 text-sm font-semibold text-zinc-700">Season URL Coverage</h4>
+            <div className="space-y-2 rounded-lg border border-zinc-200 bg-zinc-50 p-4">
+              {seasonUrlCoverageRows.length === 0 ? (
+                <p className="text-sm text-zinc-500">No seasons available for URL coverage yet.</p>
+              ) : (
+                seasonUrlCoverageRows.map((row) => (
+                  <div
+                    key={`overview-season-url-coverage-${row.seasonNumber}`}
+                    className="rounded-lg border border-zinc-200 bg-white px-3 py-2"
+                  >
+                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                      Season {row.seasonNumber}
+                    </p>
+                    {row.links.length === 0 ? (
+                      <p className="mt-1 text-sm text-zinc-500">No validated season-scoped URLs discovered.</p>
+                    ) : (
+                      <div className="mt-2 flex flex-wrap items-center gap-2">
+                        {row.links.map((link) => (
+                          <a
+                            key={`overview-season-url-pill-${row.seasonNumber}-${link.id}`}
+                            href={link.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center rounded-full border border-zinc-200 bg-zinc-50 px-2 py-1 text-xs font-semibold text-zinc-700 hover:bg-zinc-100"
+                            title={`${link.sourceLabel} | ${link.linkTitle || `Season ${row.seasonNumber}`}`}
+                          >
+                            {renderSeasonCoverageBadge(link)}
+                          </a>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+
+          {/* Genres */}
+          {show.genres && show.genres.length > 0 && (
+            <div>
+              <h4 className="mb-3 text-sm font-semibold text-zinc-700">
+                Genres
+              </h4>
+              <div className="flex flex-wrap gap-2">
+                {show.genres.map((genre) => (
+                  <span
+                    key={genre}
+                    className="rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1 text-sm text-zinc-700"
+                  >
+                    {genre}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div>
+            <h4 className="mb-3 text-sm font-semibold text-zinc-700">
+              Networks & Streaming
+            </h4>
+            <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                Networks
+              </p>
+              <div className="mb-4 flex flex-wrap gap-2">
+                {networks.length > 0 ? (
+                  networks.map((network) => (
+                    <span
+                      key={network}
+                      className="rounded-full border border-zinc-200 bg-white px-3 py-1 text-sm text-zinc-700"
+                    >
+                      {network}
+                    </span>
+                  ))
+                ) : (
+                  <p className="text-sm text-zinc-500">No network metadata.</p>
+                )}
+              </div>
+              <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                Availability
+              </p>
+              {watchProviderRegions.length > 0 ? (
+                <div className="space-y-3">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-500">
+                      Region
+                    </span>
+                    <div className="relative inline-flex">
+                      <select
+                        aria-label="Availability region"
+                        className="appearance-none rounded-full border border-zinc-200 bg-white px-3 py-1 pr-8 text-sm font-medium text-zinc-700 shadow-sm"
+                        value={selectedAvailabilityRegion?.regionCode ?? ""}
+                        onChange={(event) => onSelectAvailabilityRegion(event.target.value)}
+                      >
+                        {watchProviderRegionOptions.map((option) => (
+                          <option key={`availability-region-${option.regionCode}`} value={option.regionCode}>
+                            {option.regionCode} · {option.regionLabel}
+                          </option>
+                        ))}
+                      </select>
+                      <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-xs text-zinc-500">
+                        ▾
+                      </span>
+                    </div>
+                  </div>
+                  {selectedAvailabilityRegion ? (
+                    <div className="rounded-lg border border-zinc-200 bg-white p-3">
+                      <p className="text-sm font-semibold text-zinc-900">
+                        {selectedAvailabilityRegion.regionLabel}
+                      </p>
+                      <div className="mt-3 space-y-3">
+                        <div>
+                          <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-500">
+                            Stream
+                          </p>
+                          <div className="mt-1 flex flex-wrap gap-1.5">
+                            {selectedAvailabilityRegion.stream.length > 0 ? (
+                              selectedAvailabilityRegion.stream.map((provider) => (
+                                <span
+                                  key={`overview-watch-stream-${selectedAvailabilityRegion.regionCode}-${provider}`}
+                                  className="rounded-full border border-zinc-200 bg-zinc-50 px-2 py-0.5 text-[11px] font-semibold text-zinc-700"
+                                >
+                                  {provider}
+                                </span>
+                              ))
+                            ) : (
+                              <span className="text-xs text-zinc-500">None</span>
+                            )}
+                          </div>
+                        </div>
+                        <div>
+                          <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-500">
+                            Free
+                          </p>
+                          <div className="mt-1 flex flex-wrap gap-1.5">
+                            {selectedAvailabilityRegion.free.length > 0 ? (
+                              selectedAvailabilityRegion.free.map((provider) => (
+                                <span
+                                  key={`overview-watch-free-${selectedAvailabilityRegion.regionCode}-${provider}`}
+                                  className="rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700"
+                                >
+                                  {provider}
+                                </span>
+                              ))
+                            ) : (
+                              <span className="text-xs text-zinc-500">None</span>
+                            )}
+                          </div>
+                        </div>
+                        <div>
+                          <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-500">
+                            Rent / Buy
+                          </p>
+                          <div className="mt-1 flex flex-wrap gap-1.5">
+                            {selectedAvailabilityRegion.buyRent.length > 0 ? (
+                              selectedAvailabilityRegion.buyRent.map((provider) => (
+                                <span
+                                  key={`overview-watch-buy-rent-${selectedAvailabilityRegion.regionCode}-${provider}`}
+                                  className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-semibold text-amber-700"
+                                >
+                                  {provider}
+                                </span>
+                              ))
+                            ) : (
+                              <span className="text-xs text-zinc-500">None</span>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  <div className="flex flex-wrap gap-2">
+                    {fallbackWatchProviders.length > 0 ? (
+                      fallbackWatchProviders.map((provider) => (
+                        <span
+                          key={`overview-watch-fallback-${provider}`}
+                          className="rounded-full border border-zinc-200 bg-white px-3 py-1 text-sm text-zinc-700"
+                        >
+                          {provider}
+                        </span>
+                      ))
+                    ) : (
+                      <p className="text-sm text-zinc-500">No streaming providers on this record.</p>
+                    )}
+                  </div>
+                  <p className="text-xs text-zinc-500">
+                    Typed TMDb availability is unavailable for this show.
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Tags */}
+          {show.tags && show.tags.length > 0 && (
+            <div>
+              <h4 className="mb-3 text-sm font-semibold text-zinc-700">
+                Tags
+              </h4>
+              <div className="flex flex-wrap gap-2">
+                {show.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-full bg-blue-50 border border-blue-200 px-3 py-1 text-sm text-blue-700"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Premiere Date */}
+          {show.premiere_date && (
+            <div>
+              <h4 className="mb-3 text-sm font-semibold text-zinc-700">
+                Premiere Date
+              </h4>
+              <p className="text-sm text-zinc-700">
+                {new Date(show.premiere_date).toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })}
+              </p>
+            </div>
+          )}
+
+          <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
+            <p className="text-sm text-zinc-700">
+              Link management and role catalog tools are now on the <span className="font-semibold">Settings</span> tab.
+            </p>
+            <button
+              type="button"
+              onClick={onOpenSettings}
+              className="mt-3 rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-semibold text-zinc-700 hover:bg-zinc-100"
+            >
+              Open Settings
+            </button>
+          </div>
+
+          {/* Internal ID */}
+          <div>
+            <h4 className="mb-3 text-sm font-semibold text-zinc-700">
+              Internal ID
+            </h4>
+            <code className="text-xs bg-zinc-100 rounded px-2 py-1 text-zinc-600 font-mono">
+              {show.id}
+            </code>
+          </div>
+
+          <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
+            <p className="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+              Show Visibility
+            </p>
+            {isCovered ? (
+              <button type="button"
+                onClick={onRemoveFromCoveredShows}
+                disabled={coverageLoading}
+                className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 px-4 py-2 text-sm font-semibold text-green-700 transition hover:bg-green-100 disabled:opacity-50"
+              >
+                <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
+                  <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                </svg>
+                {coverageLoading ? "..." : "Remove from Shows"}
+              </button>
+            ) : (
+              <button type="button"
+                onClick={onAddToCoveredShows}
+                disabled={coverageLoading}
+                className="flex items-center gap-2 rounded-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-zinc-800 disabled:opacity-50"
+              >
+                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+                {coverageLoading ? "..." : "Add to Shows"}
+              </button>
+            )}
+            {coverageError && (
+              <p className="mt-2 text-xs font-medium text-rose-700">{coverageError}</p>
+            )}
+          </div>
+        </div>
+      </div>
     </section>
   );
 }

--- a/apps/web/src/components/admin/show-tabs/ShowSettingsTab.tsx
+++ b/apps/web/src/components/admin/show-tabs/ShowSettingsTab.tsx
@@ -1,15 +1,1306 @@
 "use client";
 
+import Image from "next/image";
+import Link from "next/link";
 import type { ReactNode } from "react";
 
-export default function ShowSettingsTab({ children }: { children: ReactNode }) {
+import {
+  Editable,
+  EditableArea,
+  EditableCancel,
+  EditableInput,
+  EditablePreview,
+  EditableSubmit,
+  EditableToolbar,
+  EditableTrigger,
+} from "@/components/ui/editable";
+import { deriveShowDetailsSlugPreview } from "@/lib/admin/show-page/details-form";
+import type {
+  OverviewRedditCommunityRow,
+  OverviewRedditGroup,
+} from "@/lib/admin/show-page/overview-display";
+import type { ShowDetailsForm } from "@/lib/admin/show-page/types";
+
+type MaybeAsyncResult = void | Promise<void>;
+
+type ShowSettingsRoleBase = {
+  id: string;
+  name: string;
+  is_active: boolean;
+};
+
+type ShowSettingsLinkBase = {
+  id: string;
+  url: string;
+};
+
+export type ShowSettingsSourceBadgeProps<TSourceKind extends string = string> = {
+  kind: TSourceKind;
+  label: string;
+  iconUrl?: string | null;
+  iconOnly?: boolean;
+};
+
+type ShowSettingsSocialLink<
+  TLink extends ShowSettingsLinkBase,
+  TSourceKind extends string,
+> = {
+  id: string;
+  sourceKind: TSourceKind;
+  sourceLabel: string;
+  text: string;
+  url: string;
+  link: TLink;
+};
+
+type ShowSettingsSeasonLink<
+  TLink extends ShowSettingsLinkBase,
+  TSourceKind extends string,
+> = {
+  id: string;
+  url: string;
+  sourceKind: TSourceKind;
+  sourceLabel: string;
+  iconUrl: string | null;
+  linkTitle: string | null;
+  link?: TLink;
+};
+
+type ShowSettingsSeasonCoverageRow<
+  TLink extends ShowSettingsLinkBase,
+  TSourceKind extends string,
+> = {
+  seasonNumber: number;
+  links: ShowSettingsSeasonLink<TLink, TSourceKind>[];
+};
+
+type ShowSettingsApprovedLink<
+  TLink extends ShowSettingsLinkBase,
+  TSourceKind extends string,
+> = {
+  id: string;
+  sourceKind: TSourceKind;
+  sourceLabel: string;
+  text: string;
+  label: string;
+  url: string;
+  iconUrl: string | null;
+  link: TLink;
+};
+
+type ShowSettingsMissingSource<
+  TLink extends ShowSettingsLinkBase,
+  TSourceKind extends string,
+> = {
+  key: TSourceKind;
+  label: string;
+  state: "missing" | "unvalidated";
+  url: string | null;
+  link: TLink | null;
+};
+
+type ShowSettingsCastMemberLinkCoverageCard<
+  TLink extends ShowSettingsLinkBase,
+  TSourceKind extends string,
+> = {
+  personId: string;
+  personName: string;
+  avatarUrl: string | null;
+  seasons: number[];
+  approvedLinkCount: number;
+  approvedLinks: ShowSettingsApprovedLink<TLink, TSourceKind>[];
+  missingSources: ShowSettingsMissingSource<TLink, TSourceKind>[];
+};
+
+type ShowSettingsHeaderProps = {
+  showLogoSyncing: boolean;
+  refreshCenterButtonLabel: string;
+  onSyncShowLogoTargets: () => MaybeAsyncResult;
+  onOpenRefreshLog: () => void;
+};
+
+type ShowSettingsStatusProps = {
+  linksError: string | null;
+  linksNotice: string | null;
+  linksLoadTimedOut: boolean;
+  rolesError: string | null;
+  rolesWarning: string | null;
+  rolesLoadTimedOut: boolean;
+  showLogoSyncError: string | null;
+  showLogoSyncNotice: string | null;
+  onRetryLinks: () => MaybeAsyncResult;
+  onRetryRoles: () => MaybeAsyncResult;
+};
+
+type ShowSettingsMetadataProps = {
+  form: ShowDetailsForm;
+  editing: boolean;
+  saving: boolean;
+  notice: string | null;
+  error: string | null;
+  onChangeField: (field: keyof ShowDetailsForm, value: string) => void;
+  onStartEdit: () => void;
+  onCancelEdit: () => void;
+  onSave: () => MaybeAsyncResult;
+};
+
+type ShowSettingsRolesProps<TRole extends ShowSettingsRoleBase> = {
+  newRoleName: string;
+  loading: boolean;
+  rows: TRole[];
+  onNewRoleNameChange: (value: string) => void;
+  onCreate: () => MaybeAsyncResult;
+  onRename: (role: TRole) => MaybeAsyncResult;
+  onToggleActive: (role: TRole) => MaybeAsyncResult;
+};
+
+type ShowSettingsLinksProps<
+  TLink extends ShowSettingsLinkBase,
+  TSourceKind extends string,
+> = {
+  showIsBravo: boolean;
+  refreshing: boolean;
+  bulkInput: string;
+  bulkSaving: boolean;
+  loading: boolean;
+  totalCount: number;
+  eligibleCastLoading: boolean;
+  eligibleCastLoadedOnce: boolean;
+  savingLinkIds: Readonly<Record<string, boolean>>;
+  socialLinks: ShowSettingsSocialLink<TLink, TSourceKind>[];
+  showPageLinks: TLink[];
+  seasonUrlCoverageRows: ShowSettingsSeasonCoverageRow<TLink, TSourceKind>[];
+  castMemberLinkCoverageCards: ShowSettingsCastMemberLinkCoverageCard<TLink, TSourceKind>[];
+  onRefresh: () => MaybeAsyncResult;
+  onBulkInputChange: (value: string) => void;
+  onAdd: () => MaybeAsyncResult;
+  onUpdateUrl: (linkId: string, nextUrl: string) => Promise<void>;
+  onDelete: (linkId: string) => MaybeAsyncResult;
+};
+
+type ShowSettingsRedditProps = {
+  loading: boolean;
+  error: string | null;
+  groups: OverviewRedditGroup[];
+  getCommunityHref: (community: OverviewRedditCommunityRow) => string;
+};
+
+type ShowSettingsTabWrapperProps = {
+  children: ReactNode;
+};
+
+type ShowSettingsTabPresentationalProps<
+  TRole extends ShowSettingsRoleBase,
+  TLink extends ShowSettingsLinkBase,
+  TSourceKind extends string,
+> = {
+  header: ShowSettingsHeaderProps;
+  status: ShowSettingsStatusProps;
+  metadata: ShowSettingsMetadataProps;
+  roles: ShowSettingsRolesProps<TRole>;
+  links: ShowSettingsLinksProps<TLink, TSourceKind>;
+  reddit: ShowSettingsRedditProps;
+  getShowPageLinkTitle: (link: TLink) => string;
+  renderShowPageLinkBadge: (link: TLink) => ReactNode;
+  renderSourceBadge: (props: ShowSettingsSourceBadgeProps<TSourceKind>) => ReactNode;
+  usesBrandIconOnly: (kind: TSourceKind) => boolean;
+};
+
+export type ShowSettingsTabProps<
+  TRole extends ShowSettingsRoleBase = ShowSettingsRoleBase,
+  TLink extends ShowSettingsLinkBase = ShowSettingsLinkBase,
+  TSourceKind extends string = string,
+> =
+  | ShowSettingsTabWrapperProps
+  | ShowSettingsTabPresentationalProps<TRole, TLink, TSourceKind>;
+
+function InlineEditableLinkUrl({
+  linkId,
+  url,
+  openUrl,
+  label,
+  saving,
+  onSubmit,
+  children,
+  actions,
+  containerClassName,
+  canEdit = true,
+}: {
+  linkId: string;
+  url: string;
+  openUrl?: string | null;
+  label?: string;
+  saving: boolean;
+  onSubmit: (linkId: string, nextUrl: string) => Promise<void>;
+  children?: ReactNode;
+  actions?: ReactNode;
+  containerClassName?: string;
+  canEdit?: boolean;
+}) {
+  const editButton = canEdit ? (
+    <EditableTrigger asChild>
+      <button
+        type="button"
+        disabled={saving}
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-zinc-200 bg-white text-zinc-700 transition hover:bg-zinc-50 disabled:opacity-50"
+        aria-label={label ? `Edit URL for ${label}` : "Edit link URL"}
+        title={label ? `Edit URL for ${label}` : "Edit link URL"}
+      >
+        <EditActionIcon />
+      </button>
+    </EditableTrigger>
+  ) : null;
+  const openButton = openUrl ? (
+    <a
+      href={openUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-zinc-200 bg-white text-zinc-700 transition hover:bg-zinc-50"
+      aria-label={label ? `Open ${label}` : "Open link"}
+      title={label ? `Open ${label}` : "Open link"}
+    >
+      <OpenLinkActionIcon />
+    </a>
+  ) : null;
+
+  return (
+    <Editable value={url} placeholder="https://example.com" onSubmit={(nextUrl) => onSubmit(linkId, nextUrl)}>
+      <div className={containerClassName ? `${containerClassName} space-y-2` : "space-y-2"}>
+        {(children || actions || editButton || openButton) && (
+          <div className="flex flex-wrap items-start justify-between gap-2">
+            <div className="min-w-0 flex-1">{children}</div>
+            <div className="flex shrink-0 items-center gap-2">
+              {editButton}
+              {openButton}
+              {actions}
+            </div>
+          </div>
+        )}
+        {!children && !actions && (editButton || openButton) && (
+          <div className="flex justify-end">
+            <div className="flex items-center gap-2">
+              {editButton}
+              {openButton}
+            </div>
+          </div>
+        )}
+        <EditableArea className="space-y-1">
+          <EditablePreview className="hidden" />
+          <EditableInput
+            type="url"
+            autoCapitalize="off"
+            autoCorrect="off"
+            spellCheck={false}
+            className="min-h-9 rounded-lg text-xs"
+          />
+        </EditableArea>
+        <EditableToolbar className="pt-1">
+          <EditableSubmit asChild>
+            <button
+              type="button"
+              disabled={saving}
+              className="rounded border border-zinc-300 bg-zinc-900 px-2 py-1 text-[11px] font-semibold text-white hover:bg-zinc-800 disabled:opacity-50"
+            >
+              {saving ? "Saving..." : "Save URL"}
+            </button>
+          </EditableSubmit>
+          <EditableCancel asChild>
+            <button
+              type="button"
+              disabled={saving}
+              className="rounded border border-zinc-200 bg-white px-2 py-1 text-[11px] font-semibold text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
+            >
+              Cancel
+            </button>
+          </EditableCancel>
+        </EditableToolbar>
+      </div>
+    </Editable>
+  );
+}
+
+function EditActionIcon() {
+  return (
+    <svg className="h-4 w-4" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M11.8 2.2a1.7 1.7 0 0 1 2.4 2.4l-7.5 7.5-3 .6.6-3z" />
+      <path d="M10.7 3.3l2 2" />
+    </svg>
+  );
+}
+
+function OpenLinkActionIcon() {
+  return (
+    <svg
+      className="h-4 w-4"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M7 3H3v10h10V9" />
+      <path d="M10 3h3v3" />
+      <path d="M6.5 9.5L13 3" />
+    </svg>
+  );
+}
+
+const isWrapperProps = <
+  TRole extends ShowSettingsRoleBase,
+  TLink extends ShowSettingsLinkBase,
+  TSourceKind extends string,
+>(
+  props: ShowSettingsTabProps<TRole, TLink, TSourceKind>
+): props is ShowSettingsTabWrapperProps => "children" in props;
+
+export default function ShowSettingsTab<
+  TRole extends ShowSettingsRoleBase = ShowSettingsRoleBase,
+  TLink extends ShowSettingsLinkBase = ShowSettingsLinkBase,
+  TSourceKind extends string = string,
+>(props: ShowSettingsTabProps<TRole, TLink, TSourceKind>) {
+  if (isWrapperProps(props)) {
+    return (
+      <section
+        id="show-tabpanel-settings"
+        role="tabpanel"
+        aria-labelledby="show-tab-settings"
+      >
+        {props.children}
+      </section>
+    );
+  }
+
+  const {
+    header: {
+      showLogoSyncing,
+      refreshCenterButtonLabel,
+      onSyncShowLogoTargets: syncShowScopedBrandLogos,
+      onOpenRefreshLog,
+    },
+    status: {
+      linksError,
+      linksNotice,
+      linksLoadTimedOut,
+      rolesError,
+      rolesWarning,
+      rolesLoadTimedOut,
+      showLogoSyncError,
+      showLogoSyncNotice,
+      onRetryLinks,
+      onRetryRoles,
+    },
+    metadata: {
+      form: detailsForm,
+      editing: detailsEditing,
+      saving: detailsSaving,
+      notice: detailsNotice,
+      error: detailsError,
+      onChangeField: onChangeDetailsField,
+      onStartEdit: startDetailsEdit,
+      onCancelEdit: cancelDetailsEdit,
+      onSave: saveShowDetails,
+    },
+    roles: {
+      newRoleName,
+      loading: rolesLoading,
+      rows: showRoles,
+      onNewRoleNameChange: setNewRoleName,
+      onCreate: createShowRole,
+      onRename: renameShowRole,
+      onToggleActive: toggleShowRoleActive,
+    },
+    links: {
+      showIsBravo,
+      refreshing: linksRefreshing,
+      bulkInput: linkBulkInput,
+      bulkSaving: linkBulkSaving,
+      loading: linksLoading,
+      totalCount: totalLinkCount,
+      eligibleCastLoading: linksEligibleCastLoading,
+      eligibleCastLoadedOnce: linksEligibleCastLoadedOnce,
+      savingLinkIds,
+      socialLinks: showSocialLinks,
+      showPageLinks,
+      seasonUrlCoverageRows,
+      castMemberLinkCoverageCards,
+      onRefresh: refreshShowLinks,
+      onBulkInputChange: setLinkBulkInput,
+      onAdd: addShowLinks,
+      onUpdateUrl: updateShowLinkUrl,
+      onDelete: deleteShowLink,
+    },
+    reddit: {
+      loading: redditLoading,
+      error: redditError,
+      groups: overviewRedditGroups,
+      getCommunityHref,
+    },
+    getShowPageLinkTitle,
+    renderShowPageLinkBadge,
+    renderSourceBadge,
+    usesBrandIconOnly,
+  } = props;
+
+  const settingsLinkSections = [
+    {
+      key: "social-links",
+      title: "Social Links",
+      description:
+        "Show-level handles routed from submitted Instagram, TikTok, X, YouTube, Threads, Facebook, and Reddit links.",
+    },
+    {
+      key: "show-pages",
+      title: "Show Pages",
+      description:
+        "Validated show-level pages. Fandom community roots stay internal and only page URLs render here.",
+    },
+    {
+      key: "season-pages",
+      title: "Season Pages",
+      description:
+        "Validated season pages only. Cast-announcement, social, and non-page links are excluded.",
+    },
+    {
+      key: "cast-member-pages",
+      title: "Cast Member Pages",
+      description: showIsBravo
+        ? "Cast-member profile links (BravoTV, Fandom, Wikipedia, IMDb, TMDb, and related pages)."
+        : "Cast-member profile links (Fandom, Wikipedia, IMDb, TMDb, and related pages). Bravo appears only when a Bravo profile link exists.",
+    },
+  ] as const;
+  const socialLinksSection = settingsLinkSections[0];
+  const showPagesSection = settingsLinkSections[1];
+  const seasonPagesSection = settingsLinkSections[2];
+  const castMemberPagesSection = settingsLinkSections[3];
+
   return (
     <section
       id="show-tabpanel-settings"
       role="tabpanel"
       aria-labelledby="show-tab-settings"
     >
-      {children}
+      <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm">
+        <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-zinc-400">
+              Show Settings
+            </p>
+            <h3 className="text-xl font-bold text-zinc-900">
+              Settings
+            </h3>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => void syncShowScopedBrandLogos()}
+              disabled={showLogoSyncing}
+              className="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-zinc-800 disabled:opacity-50"
+            >
+              {showLogoSyncing ? "Syncing..." : "Sync Show Logo Targets"}
+            </button>
+            <button
+              type="button"
+              onClick={() => onOpenRefreshLog()}
+              disabled={showLogoSyncing}
+              className="rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-50 disabled:opacity-50"
+            >
+              {refreshCenterButtonLabel}
+            </button>
+          </div>
+        </div>
+
+        {(linksError ||
+          linksNotice ||
+          rolesError ||
+          rolesWarning ||
+          showLogoSyncError ||
+          showLogoSyncNotice) && (
+          <div className="mb-4 text-sm space-y-2">
+            <p
+              className={`${
+                linksError || rolesError || showLogoSyncError
+                  ? linksLoadTimedOut || rolesLoadTimedOut
+                    ? "text-amber-700"
+                    : "text-red-600"
+                  : "text-zinc-500"
+              }`}
+            >
+              {linksError ||
+                rolesError ||
+                showLogoSyncError ||
+                rolesWarning ||
+                linksNotice ||
+                showLogoSyncNotice}
+            </p>
+            {linksError && linksLoadTimedOut && (
+              <button
+                type="button"
+                onClick={() => void onRetryLinks()}
+                className="inline-flex items-center rounded-lg border border-amber-300 bg-amber-50 px-3 py-1.5 text-xs font-semibold text-amber-700 transition hover:bg-amber-100"
+              >
+                Retry links
+              </button>
+            )}
+            {rolesError && rolesLoadTimedOut && (
+              <button
+                type="button"
+                onClick={() => void onRetryRoles()}
+                className="inline-flex items-center rounded-lg border border-amber-300 bg-amber-50 px-3 py-1.5 text-xs font-semibold text-amber-700 transition hover:bg-amber-100"
+              >
+                Retry roles
+              </button>
+            )}
+          </div>
+        )}
+
+        <div className="space-y-6">
+          <section>
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+              <h4 className="text-sm font-semibold text-zinc-700">Editable Metadata</h4>
+              <div className="flex flex-wrap items-center gap-2">
+                {detailsEditing ? (
+                  <>
+                    <button
+                      type="button"
+                      onClick={cancelDetailsEdit}
+                      disabled={detailsSaving}
+                      className="rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-semibold text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      onClick={saveShowDetails}
+                      disabled={detailsSaving}
+                      className="rounded-lg bg-zinc-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-zinc-800 disabled:opacity-50"
+                    >
+                      {detailsSaving ? "Saving..." : "Save"}
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={startDetailsEdit}
+                    className="rounded-lg bg-zinc-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-zinc-800"
+                  >
+                    Edit Metadata
+                  </button>
+                )}
+              </div>
+            </div>
+            {(detailsNotice || detailsError) && (
+              <p className={`mb-3 text-sm ${detailsError ? "text-red-600" : "text-zinc-500"}`}>
+                {detailsError || detailsNotice}
+              </p>
+            )}
+            <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
+              <div className="grid gap-4 md:grid-cols-2">
+                <label className="block md:col-span-2">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Display Name
+                  </span>
+                  <input
+                    type="text"
+                    value={detailsForm.displayName}
+                    onChange={(e) => onChangeDetailsField("displayName", e.target.value)}
+                    disabled={!detailsEditing}
+                    className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
+                  />
+                </label>
+                <label className="block">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Nickname / Slug
+                  </span>
+                  <input
+                    type="text"
+                    value={detailsForm.nickname}
+                    onChange={(e) => onChangeDetailsField("nickname", e.target.value)}
+                    disabled={!detailsEditing}
+                    className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
+                  />
+                  {detailsForm.nickname.trim() && (
+                    <span className="mt-1 block text-xs text-zinc-400">
+                      Canonical slug: <span className="font-mono">{deriveShowDetailsSlugPreview(detailsForm.nickname)}</span>
+                      {" · "}
+                      Hashtag: <span className="font-mono">#{detailsForm.nickname.trim().replace(/\s+/g, "")}</span>
+                    </span>
+                  )}
+                </label>
+                <div className="block">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Premiere Date
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="date"
+                      value={detailsForm.premiereDate}
+                      onChange={(e) => onChangeDetailsField("premiereDate", e.target.value)}
+                      disabled={!detailsEditing}
+                      className="flex-1 rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
+                    />
+                    {detailsEditing && detailsForm.premiereDate && (
+                      <button
+                        type="button"
+                        onClick={() => onChangeDetailsField("premiereDate", "")}
+                        className="rounded-lg border border-zinc-200 bg-white px-2 py-2 text-xs text-zinc-500 hover:bg-zinc-50"
+                        title="Clear premiere date"
+                      >
+                        ✕
+                      </button>
+                    )}
+                  </div>
+                </div>
+                <label className="block md:col-span-2">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Alt Names
+                  </span>
+                  <textarea
+                    value={detailsForm.altNamesText}
+                    onChange={(e) => onChangeDetailsField("altNamesText", e.target.value)}
+                    rows={3}
+                    disabled={!detailsEditing}
+                    className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
+                  />
+                </label>
+                <label className="block md:col-span-2">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Description
+                  </span>
+                  <textarea
+                    value={detailsForm.description}
+                    onChange={(e) => onChangeDetailsField("description", e.target.value)}
+                    rows={4}
+                    disabled={!detailsEditing}
+                    className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
+                  />
+                </label>
+                <label className="block">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    TMDb
+                  </span>
+                  <input
+                    type="text"
+                    value={detailsForm.tmdbId}
+                    onChange={(e) => onChangeDetailsField("tmdbId", e.target.value)}
+                    disabled={!detailsEditing}
+                    className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
+                  />
+                </label>
+                <label className="block">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    IMDb
+                  </span>
+                  <input
+                    type="text"
+                    value={detailsForm.imdbId}
+                    onChange={(e) => onChangeDetailsField("imdbId", e.target.value)}
+                    disabled={!detailsEditing}
+                    className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
+                  />
+                </label>
+                <label className="block">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    TVDb
+                  </span>
+                  <input
+                    type="text"
+                    value={detailsForm.tvdbId}
+                    onChange={(e) => onChangeDetailsField("tvdbId", e.target.value)}
+                    disabled={!detailsEditing}
+                    className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
+                  />
+                </label>
+                <label className="block">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Wikidata
+                  </span>
+                  <input
+                    type="text"
+                    value={detailsForm.wikidataId}
+                    onChange={(e) => onChangeDetailsField("wikidataId", e.target.value)}
+                    disabled={!detailsEditing}
+                    className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
+                  />
+                </label>
+                <label className="block md:col-span-2">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    TV Rage
+                  </span>
+                  <input
+                    type="text"
+                    value={detailsForm.tvRageId}
+                    onChange={(e) => onChangeDetailsField("tvRageId", e.target.value)}
+                    disabled={!detailsEditing}
+                    className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
+                  />
+                </label>
+                <label className="block md:col-span-2">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Genres
+                  </span>
+                  <textarea
+                    value={detailsForm.genresText}
+                    onChange={(e) => onChangeDetailsField("genresText", e.target.value)}
+                    rows={2}
+                    disabled={!detailsEditing}
+                    className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
+                  />
+                </label>
+                <label className="block md:col-span-2">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Networks
+                  </span>
+                  <textarea
+                    value={detailsForm.networksText}
+                    onChange={(e) => onChangeDetailsField("networksText", e.target.value)}
+                    rows={2}
+                    disabled={!detailsEditing}
+                    className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
+                  />
+                </label>
+                <label className="block md:col-span-2">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Streaming
+                  </span>
+                  <textarea
+                    value={detailsForm.streamingProvidersText}
+                    onChange={(e) =>
+                      onChangeDetailsField("streamingProvidersText", e.target.value)
+                    }
+                    rows={2}
+                    disabled={!detailsEditing}
+                    className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
+                  />
+                </label>
+                <label className="block md:col-span-2">
+                  <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Tags
+                  </span>
+                  <textarea
+                    value={detailsForm.tagsText}
+                    onChange={(e) => onChangeDetailsField("tagsText", e.target.value)}
+                    rows={2}
+                    disabled={!detailsEditing}
+                    className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 disabled:bg-zinc-100 disabled:text-zinc-500"
+                  />
+                </label>
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h4 className="mb-3 text-sm font-semibold text-zinc-700">Role Catalog</h4>
+            <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
+              <div className="mb-3 flex flex-wrap gap-2">
+                <input
+                  value={newRoleName}
+                  onChange={(event) => setNewRoleName(event.target.value)}
+                  placeholder="Housewife"
+                  className="min-w-[220px] flex-1 rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-700"
+                />
+                <button
+                  type="button"
+                  onClick={createShowRole}
+                  disabled={rolesLoading}
+                  className="rounded-lg border border-zinc-300 bg-white px-3 py-2 text-xs font-semibold text-zinc-700 hover:bg-zinc-100 disabled:opacity-50"
+                >
+                  Add Role
+                </button>
+              </div>
+              {showRoles.length === 0 ? (
+                <p className="text-sm text-zinc-500">No roles configured yet.</p>
+              ) : (
+                <div className="flex flex-wrap items-center gap-2">
+                  {showRoles.map((role) => (
+                    <div
+                      key={`settings-role-catalog-${role.id}`}
+                      className="flex items-center gap-1 rounded-full border border-zinc-200 bg-white px-2 py-1"
+                    >
+                      <span
+                        className={`text-xs font-semibold ${
+                          role.is_active ? "text-zinc-700" : "text-zinc-400 line-through"
+                        }`}
+                      >
+                        {role.name}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => void renameShowRole(role)}
+                        className="rounded border border-zinc-200 bg-white px-1.5 py-0.5 text-[10px] font-semibold text-zinc-700"
+                      >
+                        Rename
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void toggleShowRoleActive(role)}
+                        className={`rounded px-1.5 py-0.5 text-[10px] font-semibold ${
+                          role.is_active
+                            ? "border border-amber-200 bg-amber-50 text-amber-700"
+                            : "border border-emerald-200 bg-emerald-50 text-emerald-700"
+                        }`}
+                      >
+                        {role.is_active ? "Deactivate" : "Activate"}
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </section>
+
+          <section>
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+              <h4 className="text-sm font-semibold text-zinc-700">Links</h4>
+              <button
+                type="button"
+                onClick={() => void refreshShowLinks()}
+                disabled={linksRefreshing}
+                className="rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-semibold text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
+              >
+                {linksRefreshing ? "Refreshing..." : "Refresh Links"}
+              </button>
+            </div>
+            <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
+              <div className="mb-4 rounded-lg border border-zinc-200 bg-white p-3">
+                <p className="text-xs text-zinc-500">
+                  Paste one or more URLs or handles. The classifier auto-assigns show vs season vs cast-member
+                  links and routes social handles (Instagram/TikTok/X/YouTube/Threads/Facebook/Reddit) into
+                  social links, with show pages, season pages, cast-member pages, and Google News topic URLs
+                  routed into the matching sections below.
+                </p>
+                <textarea
+                  value={linkBulkInput}
+                  onChange={(event) => setLinkBulkInput(event.target.value)}
+                  rows={4}
+                  placeholder={
+                    "https://thetraitors.fandom.com/wiki/The_Traitors_(US)\nhttps://news.google.com/topics/CAAqKAgKIiJDQkFTRXdvTkwyY3ZNVEZvYlhBeGVtUndNQklDWlc0b0FBUAE?ceid=US:en&oc=3\ninstagram:@thetraitorsus"
+                  }
+                  className="mt-2 block w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-700"
+                />
+                <div className="mt-2 flex justify-end">
+                  <button
+                    type="button"
+                    onClick={() => void addShowLinks()}
+                    disabled={linkBulkSaving}
+                    className="rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-semibold text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
+                  >
+                    {linkBulkSaving ? "Adding..." : "Add Link(s)"}
+                  </button>
+                </div>
+              </div>
+              {linksLoading ? (
+                <p className="text-sm text-zinc-500">Loading links...</p>
+              ) : totalLinkCount === 0 ? (
+                <p className="text-sm text-zinc-500">No links yet. Run discovery to populate this list.</p>
+              ) : (
+                <div className="space-y-5">
+                  <div className="space-y-2">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        {socialLinksSection.title}
+                      </p>
+                      <p className="text-xs text-zinc-500">{socialLinksSection.description}</p>
+                    </div>
+                    {showSocialLinks.length === 0 ? (
+                      <p className="text-sm text-zinc-500">No show-level social handles discovered yet.</p>
+                    ) : (
+                      <div className="space-y-1">
+                        {showSocialLinks.map((pill) => (
+                          <InlineEditableLinkUrl
+                            key={`settings-social-link-${pill.id}`}
+                            linkId={pill.link.id}
+                            url={pill.url}
+                            openUrl={pill.url}
+                            label={pill.text}
+                            saving={Boolean(savingLinkIds[pill.link.id])}
+                            onSubmit={updateShowLinkUrl}
+                            containerClassName="rounded-md border border-zinc-200 bg-white px-3 py-2"
+                            actions={
+                              <button
+                                type="button"
+                                onClick={() => void deleteShowLink(pill.link.id)}
+                                className="rounded border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-semibold text-red-700"
+                              >
+                                Delete
+                              </button>
+                            }
+                          >
+                            <div className="inline-flex min-w-0 flex-1 items-center gap-2" title={pill.url}>
+                              {renderSourceBadge({ kind: pill.sourceKind, label: pill.sourceLabel, iconOnly: true })}
+                              <span className="truncate text-zinc-900">{pill.text}</span>
+                            </div>
+                          </InlineEditableLinkUrl>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        {showPagesSection.title}
+                      </p>
+                      <p className="text-xs text-zinc-500">{showPagesSection.description}</p>
+                    </div>
+                    {showPageLinks.length === 0 ? (
+                      <p className="text-sm text-zinc-500">No links in this category yet.</p>
+                    ) : (
+                      <div className="space-y-1">
+                        {showPageLinks.map((link) => {
+                          const linkTitle = getShowPageLinkTitle(link);
+                          return (
+                            <InlineEditableLinkUrl
+                              key={`settings-link-show-pages-${link.id}`}
+                              linkId={link.id}
+                              url={link.url}
+                              openUrl={link.url}
+                              label={linkTitle}
+                              saving={Boolean(savingLinkIds[link.id])}
+                              onSubmit={updateShowLinkUrl}
+                              containerClassName="rounded-md border border-zinc-200 bg-white px-3 py-2"
+                              actions={
+                                <button
+                                  type="button"
+                                  onClick={() => void deleteShowLink(link.id)}
+                                  className="rounded border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-semibold text-red-700"
+                                >
+                                  Delete
+                                </button>
+                              }
+                            >
+                              <div className="inline-flex min-w-0 flex-1 items-center gap-2">
+                                {renderShowPageLinkBadge(link)}
+                                <span className="shrink-0 text-zinc-300">|</span>
+                                <span className="truncate text-zinc-900">{linkTitle}</span>
+                              </div>
+                            </InlineEditableLinkUrl>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        {seasonPagesSection.title}
+                      </p>
+                      <p className="text-xs text-zinc-500">{seasonPagesSection.description}</p>
+                    </div>
+                    {seasonUrlCoverageRows.length === 0 ? (
+                      <p className="text-sm text-zinc-500">No season-scoped validated links yet.</p>
+                    ) : (
+                      <div className="space-y-2">
+                        {seasonUrlCoverageRows.map((row) => (
+                          <div
+                            key={`settings-season-pages-${row.seasonNumber}`}
+                            className="rounded-lg border border-zinc-200 bg-white px-3 py-2"
+                          >
+                            <div className="flex flex-wrap items-center gap-2">
+                              <p className="text-sm font-semibold text-zinc-900">Season {row.seasonNumber}</p>
+                              <div className="flex flex-wrap items-center gap-2">
+                                {row.links.map((link) => (
+                                  <a
+                                    key={`settings-season-link-pill-${row.seasonNumber}-${link.id}`}
+                                    href={link.url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="inline-flex items-center rounded-full border border-zinc-200 bg-zinc-50 px-2 py-1 text-xs font-semibold text-zinc-700 hover:bg-zinc-100"
+                                    title={`${link.sourceLabel} | ${link.linkTitle || `Season ${row.seasonNumber}`}`}
+                                  >
+                                    {renderSourceBadge({
+                                      kind: link.sourceKind,
+                                      label: link.sourceLabel,
+                                      iconUrl: link.iconUrl,
+                                      iconOnly: true,
+                                    })}
+                                  </a>
+                                ))}
+                              </div>
+                            </div>
+                            <div className="mt-3 grid gap-2">
+                              {row.links.filter((link) => link.link).map((link) => (
+                                <InlineEditableLinkUrl
+                                  key={`settings-season-link-editor-${row.seasonNumber}-${link.id}`}
+                                  linkId={link.link!.id}
+                                  url={link.url}
+                                  openUrl={link.url}
+                                  label={`${link.sourceLabel} season page`}
+                                  saving={Boolean(savingLinkIds[link.link!.id])}
+                                  onSubmit={updateShowLinkUrl}
+                                  containerClassName="rounded-md border border-zinc-200 bg-zinc-50 px-3 py-2"
+                                  actions={
+                                    <button
+                                      type="button"
+                                      onClick={() => void deleteShowLink(link.link!.id)}
+                                      className="rounded border border-red-200 bg-red-50 px-1.5 py-0.5 text-[10px] font-semibold text-red-700"
+                                    >
+                                      Delete
+                                    </button>
+                                  }
+                                  >
+                                    <div className="flex items-center gap-2 text-xs font-semibold text-zinc-700">
+                                      {renderSourceBadge({
+                                        kind: link.sourceKind,
+                                        label: link.sourceLabel,
+                                        iconUrl: link.iconUrl,
+                                        iconOnly: usesBrandIconOnly(link.sourceKind),
+                                      })}
+                                    <span>{link.sourceLabel}</span>
+                                  </div>
+                                </InlineEditableLinkUrl>
+                              ))}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        {castMemberPagesSection.title}
+                      </p>
+                      <p className="text-xs text-zinc-500">{castMemberPagesSection.description}</p>
+                    </div>
+                    {castMemberLinkCoverageCards.length === 0 ? (
+                      linksEligibleCastLoading && !linksEligibleCastLoadedOnce ? (
+                        <p className="text-sm text-zinc-500">Loading eligible cast roster...</p>
+                      ) : (
+                        <p className="text-sm text-zinc-500">No cast-member links in this category yet.</p>
+                      )
+                    ) : (
+                      <div className="space-y-3">
+                        {castMemberLinkCoverageCards.map((card) => (
+                          <div
+                            key={`person-link-coverage-${card.personId}`}
+                            className="rounded-lg border border-zinc-200 bg-white p-3"
+                          >
+                            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                              <div className="flex min-w-0 items-center gap-2">
+                                {card.avatarUrl ? (
+                                  <Image
+                                    src={card.avatarUrl}
+                                    alt={card.personName}
+                                    width={32}
+                                    height={32}
+                                    className="h-8 w-8 rounded-full border border-zinc-200 object-cover"
+                                    unoptimized
+                                  />
+                                ) : (
+                                  <div className="flex h-8 w-8 items-center justify-center rounded-full border border-zinc-200 bg-zinc-100 text-[10px] font-semibold uppercase text-zinc-500">
+                                    {card.personName.slice(0, 1) || "?"}
+                                  </div>
+                                )}
+                                <p className="truncate text-sm font-semibold text-zinc-900">{card.personName}</p>
+                              </div>
+                              <div className="flex flex-wrap items-center gap-1">
+                                <span className="rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-[11px] font-semibold text-blue-700">
+                                  {card.approvedLinkCount} approved
+                                </span>
+                                {card.seasons.length > 0 && (
+                                  <span className="rounded-full border border-zinc-200 bg-zinc-50 px-2 py-0.5 text-[11px] font-semibold text-zinc-600">
+                                    Seasons {card.seasons.map((season) => `S${season}`).join(", ")}
+                                  </span>
+                                )}
+                              </div>
+                            </div>
+
+                            {card.approvedLinks.length === 0 ? (
+                              <p className="text-sm text-zinc-500">No validated links for this person yet.</p>
+                            ) : (
+                              <div className="flex flex-wrap gap-2">
+                                {card.approvedLinks.map((approvedLink) => (
+                                  <InlineEditableLinkUrl
+                                    key={`person-approved-link-${card.personId}-${approvedLink.id}`}
+                                    linkId={approvedLink.link.id}
+                                    url={approvedLink.url}
+                                    openUrl={approvedLink.url}
+                                    label={approvedLink.text}
+                                    saving={Boolean(savingLinkIds[approvedLink.link.id])}
+                                    onSubmit={updateShowLinkUrl}
+                                    containerClassName="rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2"
+                                    actions={
+                                      <button
+                                        type="button"
+                                        onClick={() => void deleteShowLink(approvedLink.link.id)}
+                                        className="rounded border border-red-200 bg-red-50 px-1.5 py-0.5 text-[10px] font-semibold text-red-700"
+                                      >
+                                        Delete
+                                      </button>
+                                    }
+                                  >
+                                    <div
+                                      className="inline-flex min-w-0 max-w-full items-center gap-2 text-xs font-semibold text-zinc-700"
+                                      title={approvedLink.url}
+                                    >
+                                      {renderSourceBadge({
+                                        kind: approvedLink.sourceKind,
+                                        label: approvedLink.sourceLabel,
+                                        iconUrl: approvedLink.iconUrl,
+                                        iconOnly: usesBrandIconOnly(approvedLink.sourceKind),
+                                      })}
+                                      <span className="truncate">{approvedLink.text}</span>
+                                    </div>
+                                  </InlineEditableLinkUrl>
+                                ))}
+                              </div>
+                            )}
+
+                            {card.missingSources.length > 0 && (
+                              <details className="mt-3 rounded-lg border border-zinc-200 bg-zinc-50 p-3">
+                                <summary className="cursor-pointer text-xs font-semibold uppercase tracking-[0.16em] text-zinc-500">
+                                  Missing / Unvalidated Sources
+                                </summary>
+                                <div className="mt-3 space-y-2">
+                                  {card.missingSources.map((source) => (
+                                    <InlineEditableLinkUrl
+                                      key={`person-link-source-${card.personId}-${source.key}`}
+                                      linkId={source.link?.id ?? `missing-${card.personId}-${source.key}`}
+                                      url={source.link?.url ?? source.url ?? ""}
+                                      openUrl={source.link?.url ?? source.url ?? null}
+                                      label={source.label}
+                                      saving={source.link ? Boolean(savingLinkIds[source.link.id]) : false}
+                                      onSubmit={updateShowLinkUrl}
+                                      containerClassName="rounded-md border border-amber-200 bg-white px-3 py-2"
+                                      canEdit={Boolean(source.link)}
+                                      actions={
+                                        source.link ? (
+                                          <button
+                                            type="button"
+                                            onClick={() => source.link && void deleteShowLink(source.link.id)}
+                                            className="rounded border border-red-200 bg-red-50 px-2 py-0.5 text-[10px] font-semibold text-red-700"
+                                          >
+                                            Delete
+                                          </button>
+                                        ) : null
+                                      }
+                                    >
+                                      <div className="space-y-2">
+                                        <div className="flex flex-wrap items-center gap-2">
+                                          {renderSourceBadge({ kind: source.key, label: source.label, iconOnly: true })}
+                                          <span className="text-xs font-semibold text-zinc-800">
+                                            {source.label}
+                                          </span>
+                                          <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
+                                            {source.state === "unvalidated" ? "Unvalidated" : "Missing"}
+                                          </span>
+                                        </div>
+                                        <p className="text-xs text-zinc-600">No validated source URL found</p>
+                                        {source.url ? (
+                                          <p className="max-w-full truncate text-xs font-medium text-zinc-700" title={source.url}>
+                                            {source.url}
+                                          </p>
+                                        ) : null}
+                                      </div>
+                                    </InlineEditableLinkUrl>
+                                  ))}
+                                </div>
+                              </details>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          </section>
+
+          <section>
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+              <h4 className="text-sm font-semibold text-zinc-700">Reddit</h4>
+              <Link
+                href={"/admin/social/reddit"}
+                className="rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-semibold text-zinc-700 hover:bg-zinc-50"
+              >
+                Open Reddit Admin
+              </Link>
+            </div>
+            <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4">
+              {redditLoading ? (
+                <p className="text-sm text-zinc-500">Loading Reddit communities...</p>
+              ) : redditError ? (
+                <p className="text-sm text-red-600">{redditError}</p>
+              ) : overviewRedditGroups.length === 0 ? (
+                <p className="text-sm text-zinc-500">No relevant Reddit communities configured for this show.</p>
+              ) : (
+                <div className="space-y-4">
+                  {overviewRedditGroups.map((group) => (
+                    <div key={`settings-reddit-group-${group.key}`} className="space-y-2">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        {group.label}
+                      </p>
+                      <div className="space-y-2">
+                        {group.communities.map((community) => (
+                          <div
+                            key={`settings-reddit-community-${community.id}`}
+                            className="rounded-lg border border-zinc-200 bg-white p-3"
+                          >
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                              <div>
+                                <p className="text-sm font-semibold text-zinc-900">{community.displayName}</p>
+                                <p className="text-xs text-zinc-500">r/{community.subreddit}</p>
+                              </div>
+                              <Link
+                                href={getCommunityHref(community)}
+                                className="rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-1.5 text-xs font-semibold text-zinc-700 hover:bg-zinc-100"
+                              >
+                                Open Community
+                              </Link>
+                            </div>
+                            <div className="mt-3 space-y-2">
+                              <div>
+                                <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-500">
+                                  Assigned Flairs
+                                </p>
+                                <div className="mt-1 flex flex-wrap gap-1.5">
+                                  {community.assignedFlairs.length > 0 ? (
+                                    community.assignedFlairs.map((flair) => (
+                                      <span
+                                        key={`settings-reddit-flair-${community.id}-${flair}`}
+                                        className="rounded-full border border-zinc-200 bg-zinc-50 px-2 py-0.5 text-[11px] font-semibold text-zinc-700"
+                                      >
+                                        {flair}
+                                      </span>
+                                    ))
+                                  ) : (
+                                    <span className="text-xs text-zinc-500">No assigned flairs</span>
+                                  )}
+                                </div>
+                              </div>
+                              {community.postFlairs.length > 0 && (
+                                <div>
+                                  <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-500">
+                                    Post Flairs
+                                  </p>
+                                  <div className="mt-1 flex flex-wrap gap-1.5">
+                                    {community.postFlairs.map((flair) => (
+                                      <span
+                                        key={`settings-reddit-post-flair-${community.id}-${flair}`}
+                                        className="rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700"
+                                      >
+                                        {flair}
+                                      </span>
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </section>
+        </div>
+      </div>
     </section>
   );
 }

--- a/apps/web/src/components/admin/show-tabs/show-logo-types.ts
+++ b/apps/web/src/components/admin/show-tabs/show-logo-types.ts
@@ -1,0 +1,1 @@
+export type ShowLogoVariant = "color" | "black" | "white";

--- a/apps/web/src/lib/admin/api-references/generated/inventory.ts
+++ b/apps/web/src/lib/admin/api-references/generated/inventory.ts
@@ -3,8 +3,8 @@ import type { AdminApiReferenceInventory } from "@/lib/admin/api-references/type
 export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
   "inventorySchemaVersion": "1.0.0",
   "generatorVersion": "1.0.0",
-  "generatedAt": "2026-07-14T00:08:26.713Z",
-  "sourceCommitSha": "a7846a58a407629f6554f186ffe89fa2a4c5a870",
+  "generatedAt": "2026-08-04T18:38:12.940Z",
+  "sourceCommitSha": "d5d7ff9accaa394d61c53487afa1d862b8147455",
   "overrideDigest": "cd85a76fd2fc977cbc691ccab80ce844f9ea783e118af35eb3d9766e5d61fd36",
   "nodes": [
     {
@@ -20707,7 +20707,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/[showId]/page.tsx",
       "sourceLocator": {
-        "line": 10536,
+        "line": 8951,
         "matchedText": "`/api/admin/trr-api/shows/settings/show-core-auto-refresh`"
       },
       "provenance": "static_scan",
@@ -20725,7 +20725,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/[showId]/page.tsx",
       "sourceLocator": {
-        "line": 3704,
+        "line": 2155,
         "matchedText": "`/api/admin/trr-api/people/${personId}/refresh-images`"
       },
       "provenance": "static_scan",
@@ -20743,7 +20743,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/[showId]/page.tsx",
       "sourceLocator": {
-        "line": 3618,
+        "line": 2069,
         "matchedText": "`/api/admin/trr-api/people/${personId}/refresh-images/stream`"
       },
       "provenance": "static_scan",
@@ -20761,7 +20761,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/[showId]/page.tsx",
       "sourceLocator": {
-        "line": 3411,
+        "line": 1862,
         "matchedText": "`/api/admin/trr-api/people/${personId}/refresh-profile/stream`"
       },
       "provenance": "static_scan",
@@ -20779,7 +20779,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/[showId]/page.tsx",
       "sourceLocator": {
-        "line": 3788,
+        "line": 2239,
         "matchedText": "`/api/admin/trr-api/people/${personId}/reprocess-images/stream`"
       },
       "provenance": "static_scan",
@@ -20797,7 +20797,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/[showId]/page.tsx",
       "sourceLocator": {
-        "line": 9676,
+        "line": 8091,
         "matchedText": "`/api/admin/trr-api/shows/${showId}/assets/batch-jobs/stream`"
       },
       "provenance": "static_scan",
@@ -20815,7 +20815,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/[showId]/page.tsx",
       "sourceLocator": {
-        "line": 6638,
+        "line": 5089,
         "matchedText": "`/api/admin/trr-api/shows/${showId}/import-bravo/preview/stream`"
       },
       "provenance": "static_scan",
@@ -20833,7 +20833,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/[showId]/page.tsx",
       "sourceLocator": {
-        "line": 10745,
+        "line": 9160,
         "matchedText": "`/api/admin/trr-api/shows/${showId}/refresh/stream`"
       },
       "provenance": "static_scan",
@@ -20851,7 +20851,7 @@ export const GENERATED_ADMIN_API_REFERENCE_INVENTORY = {
       "title": null,
       "sourceFile": "src/app/admin/trr-shows/[showId]/page.tsx",
       "sourceLocator": {
-        "line": 10572,
+        "line": 8987,
         "matchedText": "`/api/admin/trr-api/shows/settings/show-core-auto-refresh`"
       },
       "provenance": "static_scan",

--- a/apps/web/src/lib/admin/show-page/show-detail-utilities.ts
+++ b/apps/web/src/lib/admin/show-page/show-detail-utilities.ts
@@ -1,0 +1,408 @@
+import type { CastRefreshPhaseId, CastRefreshPhaseState } from "@/lib/admin/cast-refresh-orchestration";
+import { firstImageUrlCandidate, getSeasonAssetCardUrlCandidates } from "@/lib/admin/image-url-candidates";
+import { isRefreshLogTerminalSuccess } from "@/lib/admin/refresh-log-pipeline";
+import { extractSocialHandleFromUrl } from "@/lib/admin/show-page/show-link-display-model";
+import {
+  GalleryAssetSourceError,
+  type BravoImportImageKind,
+  type GalleryAssetSourceFailure,
+  type GalleryAssetSourceRequest,
+  type RefreshLogEntry,
+  type ShowRefreshTarget,
+} from "@/lib/admin/show-page/workspace-model";
+import type { SeasonAsset } from "@/lib/server/trr-api/trr-shows-repository";
+import { THUMBNAIL_DEFAULTS, parseThumbnailCrop } from "@/lib/thumbnail-crop";
+
+const SHOW_REFRESH_TARGET_LABELS: Record<ShowRefreshTarget, string> = {
+  details: "Show Info",
+  seasons_episodes: "Seasons & Episodes",
+  photos: "Gallery Media",
+  cast_credits: "Credits",
+  videos: "Bravo Videos",
+  news: "Google News",
+  social_setup: "Social Setup",
+  show_core: "Show Core",
+  links: "Links",
+  bravo: "Bravo",
+  cast_profiles: "Cast Profiles",
+  cast_media: "Cast Media",
+  get_images: "Getty/NBCUMV Images",
+};
+
+export const CAST_REFRESH_PHASE_ORDER: CastRefreshPhaseId[] = [
+  "credits_sync",
+  "profile_links_sync",
+  "bio_sync",
+  "network_augmentation",
+  "media_ingest",
+];
+
+export const SEASON_PAGE_TABS = [
+  { tab: "overview", label: "Home" },
+  { tab: "episodes", label: "Episodes" },
+  { tab: "assets", label: "Assets" },
+  { tab: "news", label: "News" },
+  { tab: "fandom", label: "Fandom" },
+  { tab: "cast", label: "Credits" },
+  { tab: "surveys", label: "Surveys" },
+  { tab: "social", label: "Social Media" },
+] as const;
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const UUID_LIKE_RE =
+  /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+
+export const readTrimmedToken = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+export const formatIsoAgeLabel = (value: string | null | undefined): string | null => {
+  const trimmed = readTrimmedToken(value);
+  if (!trimmed) return null;
+  const timestamp = Date.parse(trimmed);
+  if (!Number.isFinite(timestamp)) return null;
+  const diffSeconds = Math.max(0, Math.round((Date.now() - timestamp) / 1000));
+  return `${diffSeconds}s ago`;
+};
+
+export const isCastRefreshPhaseId = (value: unknown): value is CastRefreshPhaseId =>
+  typeof value === "string" && CAST_REFRESH_PHASE_ORDER.includes(value as CastRefreshPhaseId);
+
+export const toIsoNow = (): string => new Date().toISOString();
+
+export const updateCastRefreshPhaseStates = (
+  states: CastRefreshPhaseState[],
+  phaseId: CastRefreshPhaseId,
+  updater: (state: CastRefreshPhaseState) => CastRefreshPhaseState
+): CastRefreshPhaseState[] => states.map((state) => (state.id === phaseId ? updater(state) : state));
+
+export const looksLikeUuid = (value: string): boolean => UUID_RE.test(value);
+
+export const toFiniteNumber = (value: unknown): number | null => {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+export const formatFixed1 = (value: unknown): string | null => {
+  const parsed = toFiniteNumber(value);
+  return parsed === null ? null : parsed.toFixed(1);
+};
+
+export const parseProgressNumber = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+export const isAbortError = (error: unknown): boolean =>
+  error instanceof Error && error.name === "AbortError";
+
+export const isRetryableGalleryStatus = (status: number): boolean =>
+  status === 408 || status === 409 || status === 425 || status === 429 || status >= 500;
+
+const readGalleryErrorString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+
+const readGalleryErrorBoolean = (value: unknown): boolean | undefined =>
+  typeof value === "boolean" ? value : undefined;
+
+export const parseGalleryAssetErrorPayload = async (
+  response: Response,
+): Promise<{
+  message: string;
+  code?: string;
+  reason?: string;
+  retryable: boolean;
+  detail?: Record<string, unknown>;
+}> => {
+  let payload: Record<string, unknown> | null = null;
+  try {
+    const parsed = (await response.clone().json()) as unknown;
+    payload = parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    payload = null;
+  }
+
+  const detail =
+    payload?.detail && typeof payload.detail === "object" && !Array.isArray(payload.detail)
+      ? (payload.detail as Record<string, unknown>)
+      : null;
+  const code = readGalleryErrorString(payload?.code) ?? readGalleryErrorString(detail?.code);
+  const reason = readGalleryErrorString(payload?.reason) ?? readGalleryErrorString(detail?.reason);
+  return {
+    message:
+      readGalleryErrorString(payload?.error) ??
+      readGalleryErrorString(payload?.detail) ??
+      readGalleryErrorString(detail?.message) ??
+      `${response.status} ${response.statusText || "Failed to load gallery assets"}`,
+    ...(code ? { code } : {}),
+    ...(reason ? { reason } : {}),
+    retryable:
+      readGalleryErrorBoolean(payload?.retryable) ??
+      readGalleryErrorBoolean(detail?.retryable) ??
+      isRetryableGalleryStatus(response.status),
+    ...(detail ? { detail } : {}),
+  };
+};
+
+export const normalizeGallerySourceFailure = (
+  source: GalleryAssetSourceRequest,
+  reason: unknown,
+): GalleryAssetSourceFailure => {
+  if (reason instanceof GalleryAssetSourceError) {
+    return {
+      sourceId: source.id,
+      label: source.label,
+      message: reason.message,
+      status: reason.status,
+      retryable: reason.retryable,
+      ...(reason.code ? { code: reason.code } : {}),
+      ...(reason.reason ? { reason: reason.reason } : {}),
+      ...(reason.detail ? { detail: reason.detail } : {}),
+    };
+  }
+  return {
+    sourceId: source.id,
+    label: source.label,
+    message: reason instanceof Error ? reason.message : "Failed to load gallery assets",
+    status: 500,
+    retryable: false,
+  };
+};
+
+export const formatGallerySourceFailure = (failure: GalleryAssetSourceFailure): string => {
+  const retryLabel = failure.retryable ? "retryable" : "not retryable";
+  const codeLabel = failure.code ? ` (${failure.code})` : "";
+  return `${failure.label}: ${failure.message}${codeLabel}, ${retryLabel}`;
+};
+
+export const formatSnapshotAgeLabel = (timestampMs: number): string => {
+  const diffMs = Math.max(0, Date.now() - timestampMs);
+  const diffMinutes = Math.floor(diffMs / 60_000);
+  if (diffMinutes < 1) return "just now";
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  return `${diffDays}d ago`;
+};
+
+export const isHttpUrlValue = (value: string): boolean => {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+export const withSnapshotAgeSuffix = (
+  warning: string | null,
+  timestampMs: number | null
+): string | null => {
+  if (!warning) return null;
+  if (!timestampMs) return warning;
+  return `${warning} Last successful snapshot: ${formatSnapshotAgeLabel(timestampMs)}.`;
+};
+
+export const inferBravoShowUrl = (showName: string | null | undefined): string | null => {
+  if (typeof showName !== "string") return null;
+  const slug = showName
+    .trim()
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+  if (!slug) return null;
+  return `https://www.bravotv.com/${slug}`;
+};
+
+export const inferBravoPersonUrl = (personName: string | null | undefined): string | null => {
+  if (typeof personName !== "string") return null;
+  const slug = personName
+    .trim()
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+  if (!slug) return null;
+  return `https://www.bravotv.com/people/${slug}`;
+};
+
+export const isBravoNetworkName = (value: unknown): boolean => {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "");
+  if (!normalized) return false;
+  return normalized === "bravo" || normalized === "bravotv" || normalized.includes("bravo");
+};
+
+export const normalizeBravoSocialKey = (value: string): string => {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return "link";
+  if (normalized.includes("instagram")) return "instagram";
+  if (normalized === "x" || normalized.includes("twitter")) return "x";
+  if (normalized.includes("facebook")) return "facebook";
+  if (normalized.includes("tiktok")) return "tiktok";
+  if (normalized.includes("youtube")) return "youtube";
+  return normalized;
+};
+
+export const formatBravoSocialLabel = (key: string): string => {
+  if (key === "x") return "X";
+  if (key === "instagram") return "Instagram";
+  if (key === "facebook") return "Facebook";
+  if (key === "tiktok") return "TikTok";
+  if (key === "youtube") return "YouTube";
+  return key.replace(/[_-]+/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+};
+
+export const extractBravoSocialHandle = (url: string): string | null =>
+  extractSocialHandleFromUrl(url);
+
+export const inferBravoImportImageKind = (
+  image: { url: string; alt?: string | null }
+): BravoImportImageKind => {
+  const haystack = `${image.alt ?? ""} ${image.url}`.toLowerCase();
+  if (haystack.includes("logo")) return "logo";
+  if (haystack.includes("key art") || haystack.includes("poster")) return "poster";
+  if (haystack.includes("backdrop") || haystack.includes("background")) return "backdrop";
+  if (haystack.includes("cast")) return "cast";
+  if (haystack.includes("still")) return "episode_still";
+  if (haystack.includes("intro")) return "intro";
+  if (haystack.includes("reunion")) return "reunion";
+  return "promo";
+};
+
+export const humanizeStage = (value: string): string => {
+  const normalized = value.replace(/[_-]+/g, " ").trim();
+  if (!normalized) return "Working";
+  return normalized
+    .split(" ")
+    .map((token) =>
+      token.length > 0 ? token.charAt(0).toUpperCase() + token.slice(1) : token
+    )
+    .join(" ");
+};
+
+export const resolveStageLabel = (
+  stageValue: unknown,
+  stageLabels: Record<string, string>
+): string | null => {
+  if (typeof stageValue !== "string") return null;
+  const normalized = stageValue.trim().toLowerCase();
+  if (!normalized) return null;
+  return stageLabels[normalized] ?? humanizeStage(normalized);
+};
+
+export const getShowRefreshTargetLabel = (target: ShowRefreshTarget): string =>
+  SHOW_REFRESH_TARGET_LABELS[target] ?? target;
+
+export const buildProgressMessage = (
+  stageLabel: string | null,
+  rawMessage: unknown,
+  fallback: string
+): string => {
+  const message = typeof rawMessage === "string" ? rawMessage.trim() : "";
+  if (!message) return stageLabel ? `Working on ${stageLabel}...` : fallback;
+  if (stageLabel) return `${stageLabel}: ${message}`;
+  return message;
+};
+
+export const normalizeRefreshLogMessage = (value: string): string =>
+  value
+    .replace(UUID_LIKE_RE, "person")
+    .replace(/\s+/g, " ")
+    .trim();
+
+export const isRefreshTopicDone = (entry: RefreshLogEntry | null): boolean =>
+  isRefreshLogTerminalSuccess(entry);
+
+export const isRefreshTopicFailed = (entry: RefreshLogEntry | null): boolean => {
+  if (!entry) return false;
+  const message = entry.message.toLowerCase();
+  return message.includes("failed") || message.includes("error");
+};
+
+export const getAssetDisplayUrl = (asset: SeasonAsset): string =>
+  firstImageUrlCandidate(getSeasonAssetCardUrlCandidates(asset)) ?? asset.hosted_url;
+
+export const getFeaturedShowImageKind = (
+  asset: SeasonAsset
+): "poster" | "backdrop" | null => {
+  const normalizedKind = String(asset.kind ?? "").trim().toLowerCase();
+  if (normalizedKind === "poster") return "poster";
+  if (normalizedKind === "backdrop") return "backdrop";
+  return null;
+};
+
+export const buildAssetAutoCropPayload = (
+  asset: SeasonAsset
+): Record<string, unknown> | null => {
+  const directCrop = parseThumbnailCrop(
+    {
+      x: asset.thumbnail_focus_x,
+      y: asset.thumbnail_focus_y,
+      zoom: asset.thumbnail_zoom,
+      mode: asset.thumbnail_crop_mode,
+    },
+    { clamp: true }
+  );
+  const metadataCrop = parseThumbnailCrop(
+    (asset.metadata as Record<string, unknown> | null)?.thumbnail_crop,
+    { clamp: true }
+  );
+  const crop = directCrop ?? metadataCrop;
+  if (!crop) return null;
+  return {
+    x: crop.x,
+    y: crop.y,
+    zoom: crop.zoom,
+    mode: crop.mode,
+  };
+};
+
+export const buildAssetAutoCropPayloadWithFallback = (
+  asset: SeasonAsset
+): Record<string, unknown> =>
+  buildAssetAutoCropPayload(asset) ?? {
+    x: THUMBNAIL_DEFAULTS.x,
+    y: THUMBNAIL_DEFAULTS.y,
+    zoom: THUMBNAIL_DEFAULTS.zoom,
+    mode: "auto",
+    strategy: "resize_center_fallback_v1",
+  };
+
+export const areStringArraysEqual = (a: string[], b: string[]): boolean => {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let index = 0; index < a.length; index += 1) {
+    if (a[index] !== b[index]) return false;
+  }
+  return true;
+};
+
+export const areNumberArraysEqual = (a: number[], b: number[]): boolean => {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let index = 0; index < a.length; index += 1) {
+    if (a[index] !== b[index]) return false;
+  }
+  return true;
+};

--- a/apps/web/src/lib/admin/show-page/show-link-display-model.ts
+++ b/apps/web/src/lib/admin/show-page/show-link-display-model.ts
@@ -1,0 +1,331 @@
+import {
+  getHostnameFromUrl,
+  isFandomSeedUrl,
+  isLikelyPageUrl,
+  isSocialLinkKind,
+  normalizeLinkKind,
+  parsePersonNameFromLink,
+  resolveLinkPageTitle,
+  resolveLinkSiteTitle,
+  resolveShowPageDisplayTitle,
+} from "@/lib/admin/show-page/link-display";
+import type {
+  EntityLink,
+  EntityLinkStatus,
+  LinkSourceBadgeKind,
+  PersonLinkSourceKey,
+} from "@/lib/admin/show-page/workspace-model";
+
+export type ShowLinkSocialIconKey =
+  | "instagram"
+  | "tiktok"
+  | "twitter"
+  | "youtube"
+  | "threads"
+  | "facebook"
+  | "reddit";
+
+export const normalizeEntityLinkStatus = (value: unknown): EntityLinkStatus => {
+  const normalized = String(value ?? "").trim().toLowerCase();
+  if (normalized === "approved") return "approved";
+  if (normalized === "rejected") return "rejected";
+  return "pending";
+};
+
+export const classifyPersonLinkSource = (linkKind: string): PersonLinkSourceKey | null => {
+  const kind = linkKind.trim().toLowerCase();
+  if (!kind) return null;
+  if (kind === "bravo_profile" || kind.includes("bravo")) return "bravo";
+  if (kind.includes("imdb")) return "imdb";
+  if (kind.includes("tmdb")) return "tmdb";
+  if (kind === "wikipedia") return "wikipedia";
+  if (kind === "wikidata") return "wikidata";
+  if (kind === "fandom" || kind === "wikia") return "fandom";
+  return null;
+};
+
+const getPersonSourceKindPriority = (
+  sourceKey: PersonLinkSourceKey,
+  linkKind: string
+): number => {
+  const kind = linkKind.trim().toLowerCase();
+  if (sourceKey === "wikidata") return kind === "wikidata" ? 0 : 99;
+  if (sourceKey === "wikipedia") return kind === "wikipedia" ? 0 : 99;
+  return 99;
+};
+
+export const pickPreferredPersonSourceLink = (
+  sourceKey: PersonLinkSourceKey,
+  links: EntityLink[]
+): EntityLink | null => {
+  if (links.length === 0) return null;
+  const rankByStatus = (status: EntityLinkStatus): number => {
+    if (status === "approved") return 0;
+    if (status === "pending") return 1;
+    return 2;
+  };
+  const sorted = [...links].sort((a, b) => {
+    const statusDiff =
+      rankByStatus(normalizeEntityLinkStatus(a.status)) -
+      rankByStatus(normalizeEntityLinkStatus(b.status));
+    if (statusDiff !== 0) return statusDiff;
+    const kindDiff =
+      getPersonSourceKindPriority(sourceKey, a.link_kind) -
+      getPersonSourceKindPriority(sourceKey, b.link_kind);
+    if (kindDiff !== 0) return kindDiff;
+    return (a.label || a.url).localeCompare(b.label || b.url);
+  });
+  return sorted[0] ?? null;
+};
+
+export const PAGE_LINK_SOURCE_ORDER: LinkSourceBadgeKind[] = [
+  "official",
+  "bravo",
+  "fandom",
+  "wikipedia",
+  "wikidata",
+  "imdb",
+  "tmdb",
+  "tvdb",
+  "tvmaze",
+  "trakt",
+  "ratinggraph",
+  "freebase",
+  "google_kg",
+  "x_topic",
+  "google_news",
+  "instagram",
+  "tiktok",
+  "x",
+  "youtube",
+  "threads",
+  "facebook",
+  "reddit",
+  "other",
+];
+
+const PAGE_LINK_SOURCE_LABELS: Record<LinkSourceBadgeKind, string> = {
+  official: "Official",
+  google_news: "Google News",
+  bravo: "Bravo TV",
+  fandom: "Fandom",
+  wikipedia: "Wikipedia",
+  wikidata: "Wikidata",
+  imdb: "IMDb",
+  tmdb: "TMDb",
+  instagram: "Instagram",
+  tiktok: "TikTok",
+  x: "X",
+  youtube: "YouTube",
+  threads: "Threads",
+  facebook: "Facebook",
+  reddit: "Reddit",
+  tvdb: "TVDB",
+  tvmaze: "TVmaze",
+  trakt: "Trakt",
+  freebase: "Freebase",
+  google_kg: "Google KG",
+  ratinggraph: "RatingGraph",
+  x_topic: "X Topic",
+  other: "Link",
+};
+
+export const getLinkSourceBadgeKind = (link: EntityLink): LinkSourceBadgeKind => {
+  const normalizedKind = normalizeLinkKind(link.link_kind);
+  const sourceKey = classifyPersonLinkSource(normalizedKind);
+  if (sourceKey) return sourceKey;
+  if (isSocialLinkKind(normalizedKind)) {
+    if (normalizedKind === "x") return "x";
+    return normalizedKind as LinkSourceBadgeKind;
+  }
+  if (
+    normalizedKind === "official_page" ||
+    normalizedKind === "network_blog" ||
+    normalizedKind === "cast_announcement"
+  ) {
+    const host = getHostnameFromUrl(link.url)?.toLowerCase() ?? "";
+    if (host.includes("bravotv.com")) return "bravo";
+    return "official";
+  }
+  if (normalizedKind === "tvdb") return "tvdb";
+  if (normalizedKind === "tvmaze") return "tvmaze";
+  if (normalizedKind === "trakt") return "trakt";
+  if (normalizedKind === "freebase") return "freebase";
+  if (normalizedKind === "google_kg") return "google_kg";
+  if (normalizedKind === "ratinggraph") return "ratinggraph";
+  if (normalizedKind === "x_topic") return "x_topic";
+  if (normalizedKind === "google_news_url") return "google_news";
+  return "other";
+};
+
+export const getSourceBadgeOrder = (kind: LinkSourceBadgeKind): number => {
+  const index = PAGE_LINK_SOURCE_ORDER.indexOf(kind);
+  return index === -1 ? PAGE_LINK_SOURCE_ORDER.length : index;
+};
+
+export const getLinkSourceLabel = (link: EntityLink): string => {
+  const badgeKind = getLinkSourceBadgeKind(link);
+  if (badgeKind === "fandom") {
+    return resolveLinkSiteTitle(link) || PAGE_LINK_SOURCE_LABELS.fandom;
+  }
+  if (badgeKind === "official" || badgeKind === "bravo") {
+    const host = getHostnameFromUrl(link.url)?.toLowerCase() ?? "";
+    if (host.includes("bravotv.com")) return "Bravo TV";
+  }
+  return (
+    PAGE_LINK_SOURCE_LABELS[badgeKind] ||
+    String(link.label || link.link_kind || "Link").trim() ||
+    "Link"
+  );
+};
+
+export const getShowPageLinkTitle = (link: EntityLink, showName: string): string =>
+  resolveShowPageDisplayTitle(link, showName);
+
+const decodeHandleToken = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+export const normalizeSocialHandleValue = (value: string): string | null => {
+  const decoded = decodeHandleToken(value).trim();
+  if (!decoded) return null;
+  const handleMatch = decoded.match(/@[\w.]+/);
+  if (handleMatch) {
+    return `@${handleMatch[0].replace(/^@+/, "")}`;
+  }
+  const normalized = decoded.replace(/^@+/, "").trim();
+  if (!normalized) return null;
+  return `@${normalized}`;
+};
+
+export const extractSocialHandleFromUrl = (url: string): string | null => {
+  try {
+    const parsed = new URL(url);
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    const handle = segments.at(-1) ?? "";
+    return normalizeSocialHandleValue(handle);
+  } catch {
+    return null;
+  }
+};
+
+export const getApprovedLinkText = (link: EntityLink, fallbackTitle: string): string => {
+  const badgeKind = getLinkSourceBadgeKind(link);
+  if (isSocialLinkKind(badgeKind)) {
+    const normalizedUrlHandle = extractSocialHandleFromUrl(link.url);
+    if (normalizedUrlHandle) return normalizedUrlHandle;
+    const rawLabel = String(link.label || "").trim();
+    const normalizedLabelHandle = normalizeSocialHandleValue(rawLabel);
+    if (normalizedLabelHandle) return normalizedLabelHandle;
+    return rawLabel.startsWith("@") ? rawLabel : link.url;
+  }
+  return resolveLinkPageTitle(link) || String(link.label || "").trim() || fallbackTitle;
+};
+
+export const getCastMemberLinkText = (link: EntityLink, personName: string): string => {
+  const badgeKind = getLinkSourceBadgeKind(link);
+  if (isSocialLinkKind(badgeKind)) {
+    return getApprovedLinkText(link, personName);
+  }
+  if (badgeKind === "fandom") {
+    return resolveLinkPageTitle(link) || personName;
+  }
+  return personName;
+};
+
+const getCastMemberNameSourcePriority = (link: EntityLink): number => {
+  const normalizedKind = normalizeLinkKind(link.link_kind);
+  if (normalizedKind === "bravo_profile") return 0;
+  if (normalizedKind === "wikipedia") return 1;
+  if (normalizedKind === "fandom") return 2;
+  if (normalizedKind === "wikidata") return 3;
+  if (normalizedKind === "imdb") return 4;
+  if (normalizedKind === "tmdb") return 5;
+  if (isSocialLinkKind(normalizedKind)) return 99;
+  if (normalizedKind === "freebase" || normalizedKind === "google_kg") return 98;
+  return 50;
+};
+
+export const resolveCastMemberNameFromLinks = (
+  links: EntityLink[],
+  rosterName: string | null | undefined
+): string => {
+  const normalizedRosterName = String(rosterName || "").trim();
+  if (normalizedRosterName) return normalizedRosterName;
+
+  const rankedCandidates = links
+    .map((link) => ({
+      link,
+      name: parsePersonNameFromLink(link),
+      statusPriority: normalizeEntityLinkStatus(link.status) === "approved" ? 0 : 1,
+      sourcePriority: getCastMemberNameSourcePriority(link),
+    }))
+    .filter((candidate): candidate is typeof candidate & { name: string } => Boolean(candidate.name))
+    .sort((a, b) => {
+      const statusDiff = a.statusPriority - b.statusPriority;
+      if (statusDiff !== 0) return statusDiff;
+      const sourceDiff = a.sourcePriority - b.sourcePriority;
+      if (sourceDiff !== 0) return sourceDiff;
+      const shorterDiff = a.name.length - b.name.length;
+      if (shorterDiff !== 0) return shorterDiff;
+      return a.name.localeCompare(b.name);
+    });
+
+  return rankedCandidates[0]?.name || "Unknown Person";
+};
+
+export const isRenderableSeasonPageLink = (link: EntityLink): boolean => {
+  if (normalizeEntityLinkStatus(link.status) !== "approved") return false;
+  if (
+    link.entity_type !== "season" &&
+    !(typeof link.season_number === "number" && link.season_number > 0)
+  ) {
+    return false;
+  }
+  const normalizedKind = normalizeLinkKind(link.link_kind);
+  if (isSocialLinkKind(normalizedKind)) return false;
+  if (normalizedKind === "cast_announcement" || normalizedKind === "network_blog") return false;
+  if (isFandomSeedUrl(link.url)) return false;
+  return isLikelyPageUrl(link.url);
+};
+
+export const isRenderableShowPageLink = (link: EntityLink): boolean => {
+  if (normalizeEntityLinkStatus(link.status) !== "approved") return false;
+  if (link.entity_type !== "show" || Number(link.season_number || 0) > 0) return false;
+  const normalizedKind = normalizeLinkKind(link.link_kind);
+  if (link.link_group === "social" || isSocialLinkKind(normalizedKind)) return false;
+  if (normalizedKind === "cast_announcement") return false;
+  if (isFandomSeedUrl(link.url)) return false;
+  return isLikelyPageUrl(link.url);
+};
+
+export const toSocialPlatformIconKey = (
+  kind: LinkSourceBadgeKind
+): ShowLinkSocialIconKey | null => {
+  if (
+    kind === "instagram" ||
+    kind === "tiktok" ||
+    kind === "youtube" ||
+    kind === "threads" ||
+    kind === "facebook" ||
+    kind === "reddit"
+  ) {
+    return kind;
+  }
+  if (kind === "x") return "twitter";
+  return null;
+};
+
+export const usesBrandIconOnly = (kind: LinkSourceBadgeKind): boolean =>
+  Boolean(
+    toSocialPlatformIconKey(kind) ||
+      kind === "imdb" ||
+      kind === "tmdb" ||
+      kind === "bravo" ||
+      kind === "wikipedia" ||
+      kind === "wikidata"
+  );

--- a/apps/web/src/lib/admin/show-page/workspace-model.ts
+++ b/apps/web/src/lib/admin/show-page/workspace-model.ts
@@ -1,0 +1,712 @@
+import type { AssetSectionKey } from "@/lib/admin/asset-sectioning";
+import type { CastRefreshPhaseProgress } from "@/lib/admin/cast-refresh-orchestration";
+import type { RefreshLogTopicKey } from "@/lib/admin/refresh-log-pipeline";
+
+export type ShowSyncWarningSample = {
+  season_number?: number | null;
+  episode_number?: number | null;
+  title?: string | null;
+  air_date?: string | null;
+  tmdb_episode_id?: number | null;
+};
+
+export type ShowSyncWarning = {
+  code: string;
+  severity?: "info" | "warning" | "error" | string;
+  message: string;
+  count?: number | null;
+  ignored_season_zero_count?: number | null;
+  samples?: ShowSyncWarningSample[] | null;
+};
+
+export interface TrrShow {
+  id: string;
+  name: string;
+  slug: string;
+  canonical_slug: string;
+  alternative_names: string[];
+  overview_alternative_names?: string[] | null;
+  imdb_id: string | null;
+  tmdb_id: number | null;
+  external_ids?: Record<string, unknown> | null;
+  derived_external_links?: {
+    justwatch_url?: string | null;
+  } | null;
+  overview_watch_availability?: Array<{
+    region: "US" | "GB" | "CA" | "AU";
+    stream: string[];
+    buy: string[];
+  }> | null;
+  watch_provider_regions?: Array<{
+    region: string;
+    stream: string[];
+    free: string[];
+    buy_rent: string[];
+  }> | null;
+  show_total_seasons: number | null;
+  show_total_episodes: number | null;
+  description: string | null;
+  premiere_date: string | null;
+  networks: string[];
+  overview_networks?: string[] | null;
+  genres: string[];
+  tags: string[];
+  tmdb_status: string | null;
+  tmdb_vote_average: number | null;
+  imdb_rating_value: number | null;
+  primary_poster_image_id?: string | null;
+  primary_backdrop_image_id?: string | null;
+  primary_logo_image_id?: string | null;
+  logo_url?: string | null;
+  streaming_providers?: string[] | null;
+  overview_streaming_providers?: string[] | null;
+  watch_providers?: string[] | null;
+  sync_warnings?: ShowSyncWarning[] | null;
+}
+
+export interface ShowRedditCommunity {
+  id: string;
+  subreddit: string;
+  display_name: string | null;
+  post_flairs: string[];
+  analysis_flairs: string[];
+  analysis_all_flairs: string[];
+  is_show_focused: boolean;
+  network_focus_targets: string[];
+  franchise_focus_targets: string[];
+}
+
+export interface TrrSeason {
+  id: string;
+  show_id: string;
+  season_number: number;
+  name: string | null;
+  title: string | null;
+  overview: string | null;
+  air_date: string | null;
+  premiere_date?: string | null;
+  url_original_poster: string | null;
+  tmdb_season_id: number | null;
+  episode_count?: number | null;
+  episode_airdate_count?: number | null;
+  first_episode_air_date?: string | null;
+  last_episode_air_date?: string | null;
+  fandom_source_url?: string | null;
+  fandom_page_title?: string | null;
+}
+
+export type SeasonEpisodeSummary = {
+  count: number;
+  premiereDate: string | null;
+  finaleDate: string | null;
+};
+
+export interface TrrCastMember {
+  id: string;
+  person_id: string;
+  full_name: string | null;
+  cast_member_name: string | null;
+  role: string | null;
+  roles?: string[] | null;
+  billing_order: number | null;
+  credit_category: string;
+  photo_url: string | null;
+  cover_photo_url: string | null;
+  thumbnail_focus_x?: number | null;
+  thumbnail_focus_y?: number | null;
+  thumbnail_zoom?: number | null;
+  thumbnail_crop_mode?: "manual" | "auto" | null;
+  total_episodes?: number | null;
+  archive_episode_count?: number | null;
+  latest_season?: number | null;
+  seasons_appeared?: number[] | null;
+}
+
+export type ShowCastEligibilityMode = "default" | "links";
+
+export type EntityLinkType = "show" | "season" | "person";
+export type EntityLinkGroup =
+  | "official"
+  | "social"
+  | "knowledge"
+  | "cast_announcements"
+  | "other";
+export type EntityLinkStatus = "pending" | "approved" | "rejected";
+
+export interface EntityLink {
+  id: string;
+  show_id: string;
+  entity_type: EntityLinkType;
+  entity_id: string;
+  season_number: number;
+  link_group: EntityLinkGroup;
+  link_kind: string;
+  label: string | null;
+  url: string;
+  status: EntityLinkStatus;
+  confidence: number | null;
+  source: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface ShowRole {
+  id: string;
+  show_id: string;
+  name: string;
+  normalized_name: string;
+  sort_order: number;
+  is_active: boolean;
+}
+
+export interface CastRoleMember {
+  person_id: string;
+  person_name: string | null;
+  total_episodes: number | null;
+  seasons_appeared: number | null;
+  latest_season: number | null;
+  roles: string[];
+  photo_url: string | null;
+}
+
+export interface ShowCrewCreditRow {
+  credit_id: string;
+  person_id: string;
+  person_name: string | null;
+  role: string | null;
+  billing_order: number | null;
+  source_type: string | null;
+  episode_count: number | null;
+  episodes_label: string | null;
+  years_label: string | null;
+  imdb_name_id: string | null;
+  display_order: number | null;
+}
+
+export interface ShowCrewGroupedRow {
+  person_id: string;
+  person_name: string | null;
+  role_lines: ShowCrewCreditRow[];
+}
+
+export interface ShowCrewSection {
+  title: string;
+  rows: ShowCrewCreditRow[];
+  grouped_rows?: ShowCrewGroupedRow[];
+}
+
+export interface ShowCreditsPayload {
+  cast_roster: Array<Record<string, unknown>>;
+  crew_sections: ShowCrewSection[];
+  source_metadata?: {
+    source_page_url?: string | null;
+    show_imdb_id?: string | null;
+    last_synced_at?: string | null;
+  } | null;
+}
+
+export interface BravoPersonTag {
+  person_id?: string | null;
+  person_name?: string | null;
+  person_url?: string | null;
+}
+
+export interface BravoVideoItem {
+  title?: string | null;
+  runtime?: string | null;
+  kicker?: string | null;
+  image_url?: string | null;
+  hosted_image_url?: string | null;
+  original_image_url?: string | null;
+  media_asset_id?: string | null;
+  thumbnail_sync_status?: string | null;
+  thumbnail_sync_error?: string | null;
+  clip_url: string;
+  season_number?: number | null;
+  published_at?: string | null;
+  person_tags?: BravoPersonTag[];
+}
+
+export interface BravoNewsItem {
+  headline?: string | null;
+  image_url?: string | null;
+  article_url: string;
+  published_at?: string | null;
+  person_tags?: BravoPersonTag[];
+}
+
+export interface UnifiedNewsSeasonMatch {
+  season_number?: number | null;
+  match_types?: string[] | null;
+}
+
+export interface UnifiedNewsItem {
+  source_id?: string | null;
+  headline?: string | null;
+  article_url: string;
+  canonical_article_url?: string | null;
+  image_url?: string | null;
+  hosted_image_url?: string | null;
+  original_image_url?: string | null;
+  mirror_status?: string | null;
+  mirror_attempt_count?: number | null;
+  last_mirror_attempt_at?: string | null;
+  last_mirror_success_at?: string | null;
+  last_mirror_error?: string | null;
+  mirror_retry_after?: string | null;
+  published_at?: string | null;
+  publisher_name?: string | null;
+  publisher_domain?: string | null;
+  person_tags?: BravoPersonTag[];
+  topic_tags?: string[] | null;
+  season_matches?: UnifiedNewsSeasonMatch[] | null;
+  feed_rank?: number | null;
+  trending_rank?: number | null;
+  quality_score?: number | null;
+}
+
+export interface UnifiedNewsFacetSource {
+  token: string;
+  label: string;
+  count: number;
+}
+
+export interface UnifiedNewsFacetPerson {
+  person_id: string;
+  person_name: string;
+  count: number;
+}
+
+export interface UnifiedNewsFacetTopic {
+  topic: string;
+  count: number;
+}
+
+export interface UnifiedNewsFacetSeason {
+  season_number: number;
+  count: number;
+}
+
+export interface UnifiedNewsFacets {
+  sources: UnifiedNewsFacetSource[];
+  people: UnifiedNewsFacetPerson[];
+  topics: UnifiedNewsFacetTopic[];
+  seasons: UnifiedNewsFacetSeason[];
+}
+
+export interface BravoPreviewPerson {
+  name?: string | null;
+  canonical_url?: string | null;
+  bio?: string | null;
+  hero_image_url?: string | null;
+  social_links?: Record<string, string> | null;
+}
+
+export interface BravoPersonCandidateResult {
+  url: string;
+  source?: "bravo" | "fandom";
+  name?: string | null;
+  status?: "pending" | "in_progress" | "ok" | "missing" | "error" | string;
+  error?: string | null;
+  person?: BravoPreviewPerson | null;
+}
+
+export type BravoCandidateSummary = {
+  tested: number;
+  valid: number;
+  missing: number;
+  errors: number;
+};
+
+export type BravoImportImageKind =
+  | "poster"
+  | "backdrop"
+  | "logo"
+  | "episode_still"
+  | "cast"
+  | "promo"
+  | "intro"
+  | "reunion"
+  | "other";
+
+export type SyncBravoRunMode = "full" | "cast-only";
+export type TabId =
+  | "seasons"
+  | "assets"
+  | "news"
+  | "cast"
+  | "surveys"
+  | "social"
+  | "details"
+  | "settings";
+export type ShowCastSource = "episode_evidence" | "show_fallback" | "imdb_show_membership";
+export type ShowCastRosterMode = "episode_evidence" | "imdb_show_membership";
+export type CastPhotoFallbackMode = "none" | "bravo";
+export type ShowRefreshTarget =
+  | "details"
+  | "seasons_episodes"
+  | "photos"
+  | "cast_credits"
+  | "videos"
+  | "news"
+  | "social_setup"
+  | "show_core"
+  | "links"
+  | "bravo"
+  | "cast_profiles"
+  | "cast_media"
+  | "get_images";
+export type ShowTab = { id: TabId; label: string; icon?: "home" };
+export type RefreshProgressState = {
+  stage?: string | null;
+  message?: string | null;
+  current: number | null;
+  total: number | null;
+};
+
+export type RefreshLogEntry = {
+  id: string;
+  at: string;
+  category: string;
+  message: string;
+  current: number | null;
+  total: number | null;
+  stageKey?: string | null;
+  topic?: RefreshLogTopicKey | null;
+  provider?: string | null;
+  subOperationId?: string | null;
+  executionOwner?: string | null;
+  parentOperationId?: string | null;
+};
+
+export type RoleRenameDraft = {
+  roleId: string;
+  originalName: string;
+  nextName: string;
+};
+
+export type CastRoleEditDraft = {
+  personId: string;
+  personName: string;
+  roleCsv: string;
+};
+
+export type CastRunFailedMember = {
+  personId: string;
+  name: string;
+  reason: string;
+};
+
+export type CastBatchRunSummary = {
+  attempted: number;
+  succeeded: number;
+  skipped: number;
+  failed: number;
+  failedMembers: CastRunFailedMember[];
+};
+
+export type ShowRefreshRunOptions = {
+  photoMode?: "fast" | "full";
+  skipCastPhotos?: boolean;
+  includeCastProfiles?: boolean;
+  suppressSuccessNotice?: boolean;
+  onProgress?: (progress: Partial<CastRefreshPhaseProgress>) => void;
+};
+
+export type PersonRefreshMode = "full" | "ingest_only" | "profile_only";
+export type HealthStatus = "ready" | "missing" | "stale";
+export type PersonLinkSourceKey = "bravo" | "imdb" | "tmdb" | "wikipedia" | "wikidata" | "fandom";
+export type PersonLinkSourceState = "missing" | "unvalidated";
+export type LinkSourceBadgeKind =
+  | PersonLinkSourceKey
+  | "official"
+  | "google_news"
+  | "instagram"
+  | "tiktok"
+  | "x"
+  | "youtube"
+  | "threads"
+  | "facebook"
+  | "reddit"
+  | "tvdb"
+  | "tvmaze"
+  | "trakt"
+  | "freebase"
+  | "google_kg"
+  | "ratinggraph"
+  | "x_topic"
+  | "other";
+
+export type PersonLinkSourceSummary = {
+  key: PersonLinkSourceKey;
+  label: string;
+  state: PersonLinkSourceState;
+  url: string | null;
+  link: EntityLink | null;
+};
+
+export type ShowSocialLinkPill = {
+  id: string;
+  sourceKind: LinkSourceBadgeKind;
+  sourceLabel: string;
+  text: string;
+  url: string;
+  link: EntityLink;
+};
+
+export type PersonApprovedLinkPill = {
+  id: string;
+  sourceKind: LinkSourceBadgeKind;
+  sourceLabel: string;
+  text: string;
+  label: string;
+  url: string;
+  iconUrl: string | null;
+  link: EntityLink;
+};
+
+export type PersonLinkCoverageCard = {
+  personId: string;
+  personName: string;
+  avatarUrl: string | null;
+  seasons: number[];
+  approvedLinkCount: number;
+  approvedLinks: PersonApprovedLinkPill[];
+  missingSources: PersonLinkSourceSummary[];
+};
+
+export type SeasonCoverageLinkPill = {
+  id: string;
+  seasonNumber: number;
+  url: string;
+  sourceKind: LinkSourceBadgeKind;
+  sourceLabel: string;
+  iconUrl: string | null;
+  linkTitle: string | null;
+  link?: EntityLink;
+};
+
+export type SeasonUrlCoverageRow = {
+  seasonNumber: number;
+  links: SeasonCoverageLinkPill[];
+};
+
+export type ShowGalleryVisibleBySection = Partial<Record<AssetSectionKey, number>>;
+
+export type GalleryAssetSourceRequest = {
+  id: string;
+  label: string;
+  baseUrl: string;
+};
+
+export type GalleryAssetSourceFailure = {
+  sourceId: string;
+  label: string;
+  message: string;
+  status: number;
+  retryable: boolean;
+  code?: string;
+  reason?: string;
+  detail?: Record<string, unknown>;
+};
+
+export class GalleryAssetSourceError extends Error {
+  status: number;
+  retryable: boolean;
+  code?: string;
+  reason?: string;
+  detail?: Record<string, unknown>;
+
+  constructor({
+    message,
+    status,
+    retryable,
+    code,
+    reason,
+    detail,
+  }: {
+    message: string;
+    status: number;
+    retryable: boolean;
+    code?: string;
+    reason?: string;
+    detail?: Record<string, unknown>;
+  }) {
+    super(message);
+    this.name = "GalleryAssetSourceError";
+    this.status = status;
+    this.retryable = retryable;
+    this.code = code;
+    this.reason = reason;
+    this.detail = detail;
+  }
+}
+
+export const buildSeasonEpisodeSummary = (season: TrrSeason): SeasonEpisodeSummary | null => {
+  const count =
+    typeof season.episode_count === "number"
+      ? season.episode_count
+      : typeof season.episode_airdate_count === "number"
+        ? season.episode_airdate_count
+        : null;
+  const premiereDate =
+    season.first_episode_air_date ?? season.premiere_date ?? season.air_date ?? null;
+  const finaleDate =
+    season.last_episode_air_date ?? season.air_date ?? season.premiere_date ?? premiereDate;
+
+  if (count === null && !premiereDate && !finaleDate) return null;
+
+  return {
+    count: count ?? 0,
+    premiereDate,
+    finaleDate,
+  };
+};
+
+export const buildSeasonEpisodeSummaryMap = (
+  seasonList: TrrSeason[]
+): Record<string, SeasonEpisodeSummary> => {
+  const summaries: Record<string, SeasonEpisodeSummary> = {};
+  for (const season of seasonList) {
+    const summary = buildSeasonEpisodeSummary(season);
+    if (!summary) continue;
+    summaries[season.id] = summary;
+  }
+  return summaries;
+};
+
+export const normalizeErrorMessage = (value: unknown): string | null => {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (Array.isArray(value)) {
+    const messages = value
+      .map((entry) => normalizeErrorMessage(entry))
+      .filter((entry): entry is string => Boolean(entry));
+    return messages.length > 0 ? messages.join("; ") : null;
+  }
+
+  if (value && typeof value === "object") {
+    const candidate = value as {
+      detail?: unknown;
+      error?: unknown;
+      msg?: unknown;
+      message?: unknown;
+    };
+    return (
+      normalizeErrorMessage(candidate.error) ??
+      normalizeErrorMessage(candidate.detail) ??
+      normalizeErrorMessage(candidate.msg) ??
+      normalizeErrorMessage(candidate.message) ??
+      JSON.stringify(value)
+    );
+  }
+
+  return null;
+};
+
+export const normalizeShowCreditsCastRoster = (value: unknown): TrrCastMember[] => {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((row) => {
+      if (!row || typeof row !== "object") return null;
+      const candidate = row as Record<string, unknown>;
+      const personId =
+        typeof candidate.person_id === "string" ? candidate.person_id.trim() : "";
+      if (!personId) return null;
+      const roles = Array.isArray(candidate.roles)
+        ? candidate.roles.filter(
+            (item): item is string => typeof item === "string" && item.trim().length > 0
+          )
+        : [];
+      const seasonNumbers = Array.isArray(candidate.season_numbers)
+        ? candidate.season_numbers.filter(
+            (item): item is number => typeof item === "number" && Number.isFinite(item)
+          )
+        : [];
+      return {
+        id:
+          typeof candidate.person_id === "string" && candidate.person_id.trim()
+            ? candidate.person_id.trim()
+            : typeof candidate.show_id === "string"
+              ? `${candidate.show_id}:${personId}`
+              : personId,
+        person_id: personId,
+        full_name:
+          typeof candidate.person_name === "string" && candidate.person_name.trim()
+            ? candidate.person_name
+            : null,
+        cast_member_name:
+          typeof candidate.person_name === "string" && candidate.person_name.trim()
+            ? candidate.person_name
+            : null,
+        role: roles[0] ?? null,
+        roles,
+        billing_order: null,
+        credit_category: "Self",
+        photo_url:
+          typeof candidate.photo_url === "string" && candidate.photo_url.trim()
+            ? candidate.photo_url
+            : null,
+        cover_photo_url: null,
+        total_episodes:
+          typeof candidate.total_episodes === "number" ? candidate.total_episodes : null,
+        archive_episode_count:
+          typeof candidate.archive_episodes === "number" ? candidate.archive_episodes : null,
+        latest_season:
+          typeof candidate.latest_season === "number" ? candidate.latest_season : null,
+        seasons_appeared: seasonNumbers,
+      } as TrrCastMember;
+    })
+    .filter((row): row is TrrCastMember => row !== null);
+};
+
+const shouldHideShowCreditsRoleChip = (role: string): boolean => {
+  const normalized = role.trim().toLowerCase();
+  return (
+    normalized === "cast" ||
+    normalized === "self" ||
+    normalized.startsWith("self ") ||
+    normalized.startsWith("self-") ||
+    normalized.startsWith("self/")
+  );
+};
+
+export const getMeaningfulShowCreditsRoles = (
+  roles: string[] | null | undefined
+): string[] => {
+  if (!Array.isArray(roles)) return [];
+  return roles
+    .map((role) => role.trim())
+    .filter((role) => role.length > 0 && !shouldHideShowCreditsRoleChip(role));
+};
+
+export const groupShowCrewRows = (rows: ShowCrewCreditRow[]): ShowCrewGroupedRow[] => {
+  const grouped = new Map<string, ShowCrewGroupedRow>();
+  const orderedKeys: string[] = [];
+
+  for (const row of rows) {
+    const personId =
+      typeof row.person_id === "string" && row.person_id.trim()
+        ? row.person_id.trim()
+        : row.credit_id;
+    const existing = grouped.get(personId);
+    if (existing) {
+      existing.role_lines.push(row);
+      continue;
+    }
+    grouped.set(personId, {
+      person_id: personId,
+      person_name: row.person_name,
+      role_lines: [row],
+    });
+    orderedKeys.push(personId);
+  }
+
+  return orderedKeys
+    .map((key) => grouped.get(key))
+    .filter((row): row is ShowCrewGroupedRow => Boolean(row));
+};

--- a/apps/web/tests/brands-logo-sync-wiring.test.ts
+++ b/apps/web/tests/brands-logo-sync-wiring.test.ts
@@ -60,7 +60,11 @@ describe("brands logo sync wiring", () => {
 
   it("wires show settings scoped sync on the show page", () => {
     const filePath = path.resolve(__dirname, "../src/app/admin/trr-shows/[showId]/page.tsx");
-    const contents = fs.readFileSync(filePath, "utf8");
+    const settingsPath = path.resolve(
+      __dirname,
+      "../src/components/admin/show-tabs/ShowSettingsTab.tsx"
+    );
+    const contents = `${fs.readFileSync(filePath, "utf8")}\n${fs.readFileSync(settingsPath, "utf8")}`;
 
     expect(contents).toMatch(/syncShowScopedBrandLogos/);
     expect(contents).toMatch(/scope:\s*"show"/);

--- a/apps/web/tests/bravotv-image-run-panel-wiring.test.ts
+++ b/apps/web/tests/bravotv-image-run-panel-wiring.test.ts
@@ -16,13 +16,17 @@ describe("bravotv image run panel wiring", () => {
   });
 
   it("renders the shared panel on the show assets page", () => {
-    const contents = read("../src/app/admin/trr-shows/[showId]/page.tsx");
+    const routeContents = read("../src/app/admin/trr-shows/[showId]/page.tsx");
+    const tabContents = read("../src/components/admin/show-tabs/ShowAssetsTab.tsx");
 
-    expect(contents).toContain('import { BravotvImageRunPanel } from "@/components/admin/BravotvImageRunPanel"');
-    expect(contents).toContain("<BravotvImageRunPanel");
-    expect(contents).toContain('mode="show"');
-    expect(contents).toContain("loadGalleryAssets(selectedGallerySeason)");
-    expect(contents).toContain("gallerySeasonInitialized");
-    expect(contents).toContain("newestVisibleSeason");
+    expect(tabContents).toContain(
+      'import { BravotvImageRunPanel } from "@/components/admin/BravotvImageRunPanel"',
+    );
+    expect(tabContents).toContain("<BravotvImageRunPanel");
+    expect(tabContents).toContain('mode="show"');
+    expect(routeContents).toContain("onRunCompleted: async () => {");
+    expect(routeContents).toContain("loadGalleryAssets(selectedGallerySeason)");
+    expect(routeContents).toContain("gallerySeasonInitialized");
+    expect(routeContents).toContain("newestVisibleSeason");
   });
 });

--- a/apps/web/tests/cast-incremental-render.test.tsx
+++ b/apps/web/tests/cast-incremental-render.test.tsx
@@ -8,7 +8,11 @@ describe("cast incremental render wiring", () => {
     __dirname,
     "../src/app/admin/trr-shows/[showId]/seasons/[seasonNumber]/page.tsx"
   );
-  const showContents = fs.readFileSync(showPath, "utf8");
+  const showCastPath = path.resolve(
+    __dirname,
+    "../src/components/admin/show-tabs/ShowCastTab.tsx"
+  );
+  const showContents = `${fs.readFileSync(showPath, "utf8")}\n${fs.readFileSync(showCastPath, "utf8")}`;
   const seasonContents = fs.readFileSync(seasonPath, "utf8");
 
   it("limits show cast render and appends in batches", () => {

--- a/apps/web/tests/gallery-fallback-telemetry.test.ts
+++ b/apps/web/tests/gallery-fallback-telemetry.test.ts
@@ -8,6 +8,7 @@ const read = (relativePath: string): string =>
 describe("gallery fallback telemetry wiring", () => {
   it("tracks recovered/failed/attempted telemetry on show, season, and person pages", () => {
     const showContents = read("../src/app/admin/trr-shows/[showId]/page.tsx");
+    const showAssetsContents = read("../src/components/admin/show-tabs/ShowAssetsTab.tsx");
     const seasonContents = read("../src/app/admin/trr-shows/[showId]/seasons/[seasonNumber]/page.tsx");
     const personContents = read("../src/app/admin/trr-shows/people/[personId]/PersonPageClient.tsx");
 
@@ -17,7 +18,7 @@ describe("gallery fallback telemetry wiring", () => {
       expect(contents).toContain("totalImageAttempts");
     }
 
-    expect(showContents).toContain("Fallback diagnostics:");
+    expect(`${showContents}\n${showAssetsContents}`).toContain("Fallback diagnostics:");
     expect(seasonContents).toContain("Fallback diagnostics:");
     expect(personContents).toContain("Fallback diagnostics:");
   });

--- a/apps/web/tests/show-assets-tab-wiring.test.ts
+++ b/apps/web/tests/show-assets-tab-wiring.test.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("show detail assets tab extraction wiring", () => {
+  const routePath = path.resolve(__dirname, "../src/app/admin/trr-shows/[showId]/page.tsx");
+  const tabPath = path.resolve(
+    __dirname,
+    "../src/components/admin/show-tabs/ShowAssetsTab.tsx",
+  );
+  const routeContents = fs.readFileSync(routePath, "utf8");
+  const tabContents = fs.readFileSync(tabPath, "utf8");
+
+  it("keeps the complete assets UI in the lazy tab module", () => {
+    expect(routeContents).toMatch(
+      /dynamic\(\(\) => import\("@\/components\/admin\/show-tabs\/ShowAssetsTab"\)/,
+    );
+    expect(routeContents).toMatch(/<ShowAssetsTab[\s\S]*images=\{\{/);
+    expect(routeContents).toMatch(/videos=\{\{/);
+    expect(routeContents).toMatch(/branding=\{\{/);
+    expect(tabContents).toContain("Fallback diagnostics:");
+    expect(tabContents).toContain("No persisted Bravo videos found for this show.");
+    expect(tabContents).toContain("Featured Images");
+    expect(routeContents).not.toContain("No images found for this selection.");
+    expect(routeContents).not.toContain("No persisted Bravo videos found for this show.");
+    expect(routeContents).not.toMatch(/<ShowBrandEditor/);
+  });
+
+  it("keeps state, derivation, telemetry, and async orchestration route-owned", () => {
+    expect(routeContents).toContain("const [assetsView, setAssetsView] = useState");
+    expect(routeContents).toContain("const filteredGalleryAssets = useMemo");
+    expect(routeContents).toContain("const gallerySectionAssets = useMemo");
+    expect(routeContents).toContain("const loadGalleryAssets = useCallback");
+    expect(routeContents).toContain("trackGalleryFallbackEvent");
+    expect(routeContents).toContain("onOpenImport: () => {");
+    expect(routeContents).toContain("setScrapeDrawerContext");
+    expect(routeContents).toContain("setScrapeDrawerOpen(true)");
+    expect(tabContents).not.toMatch(/\buse(?:State|Effect|Memo|Callback|Ref)\b/);
+    expect(tabContents).not.toMatch(/fetch\(|\/api\/admin/);
+  });
+
+  it("preserves the assets tabpanel accessibility contract", () => {
+    expect(tabContents).toContain('id="show-tabpanel-assets"');
+    expect(tabContents).toContain('role="tabpanel"');
+    expect(tabContents).toContain('aria-labelledby="show-tab-assets"');
+  });
+});

--- a/apps/web/tests/show-assets-tab.test.tsx
+++ b/apps/web/tests/show-assets-tab.test.tsx
@@ -1,0 +1,311 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import ShowAssetsTab, {
+  type ShowAssetsTabProps,
+} from "@/components/admin/show-tabs/ShowAssetsTab";
+import type { SeasonAsset } from "@/lib/server/trr-api/trr-shows-repository";
+
+vi.mock("@/components/admin/BravotvImageRunPanel", () => ({
+  BravotvImageRunPanel: ({
+    title,
+    onCompleted,
+  }: {
+    title: string;
+    onCompleted: () => void | Promise<void>;
+  }) => (
+    <div>
+      <span>{title}</span>
+      <button type="button" onClick={() => void onCompleted()}>
+        Run image panel
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/admin/show-tabs/ShowAssetsImageSections", () => ({
+  ShowAssetsImageSections: ({
+    onLoadMoreBackdrops,
+  }: {
+    onLoadMoreBackdrops: () => void;
+  }) => (
+    <button type="button" onClick={onLoadMoreBackdrops}>
+      Load mocked backdrops
+    </button>
+  ),
+}));
+
+vi.mock("@/components/admin/show-tabs/ShowFeaturedMediaSelectors", () => ({
+  ShowFeaturedMediaSelectors: ({
+    onSetFeaturedPoster,
+  }: {
+    onSetFeaturedPoster: (id: string) => void;
+  }) => (
+    <button type="button" onClick={() => onSetFeaturedPoster("poster-2")}>
+      Set mocked poster
+    </button>
+  ),
+}));
+
+vi.mock("@/components/admin/show-tabs/ShowBrandLogosSection", () => ({
+  ShowBrandLogosSection: ({
+    onSetFeaturedLogo,
+    logoAssets,
+  }: {
+    onSetFeaturedLogo: (asset: SeasonAsset) => void;
+    logoAssets: SeasonAsset[];
+  }) => (
+    <button type="button" onClick={() => onSetFeaturedLogo(logoAssets[0])}>
+      Set mocked logo
+    </button>
+  ),
+}));
+
+vi.mock("@/components/admin/ShowBrandEditor", () => ({
+  default: ({ trrShowName }: { trrShowName: string }) => (
+    <div>{`Brand editor for ${trrShowName}`}</div>
+  ),
+}));
+
+const createAsset = (id: string, personName?: string): SeasonAsset => ({
+  id,
+  type: "show",
+  origin_table: "show_images",
+  source: "bravotv",
+  kind: "photo",
+  hosted_url: `https://cdn.example.com/${id}.jpg`,
+  width: 1200,
+  height: 1800,
+  caption: `${id} caption`,
+  person_name: personName,
+});
+
+const profileAsset = createAsset("profile-1", "Jane Doe");
+const promoAsset = createAsset("promo-1", "Alex Roe");
+const logoAsset = createAsset("logo-1");
+
+const createProps = (): ShowAssetsTabProps => ({
+  assetsView: "images",
+  showId: "show-1",
+  showName: "Test Show",
+  featuredPosterImageId: "poster-1",
+  featuredBackdropImageId: "backdrop-1",
+  images: {
+    selectedSeason: "all",
+    seasonOptions: [{ id: "season-2", season_number: 2 }],
+    refreshCenterButtonLabel: "Open Refresh Center",
+    autoAdvanceMode: "manual",
+    hasActiveAdvancedFilters: true,
+    activeAdvancedFilterCount: 2,
+    refreshingGetImages: false,
+    photosNotice: "Photos refreshed",
+    photosError: null,
+    getImagesNotice: "Images ready",
+    getImagesError: null,
+    getImagesProgress: { stage: "download", current: 1, total: 2 },
+    batchJobsNotice: "Batch complete",
+    batchJobsError: null,
+    batchJobsRunning: true,
+    batchJobsProgress: { stage: "batch", current: 3, total: 4 },
+    truncatedWarning: "Showing the first page.",
+    fallbackTelemetry: {
+      fallbackRecoveredCount: 2,
+      allCandidatesFailedCount: 1,
+      totalImageAttempts: 5,
+    },
+    mirrorTelemetry: { mirroredCount: 4, totalCount: 5, mirroredRatio: 0.8 },
+    sourceFailures: [
+      {
+        sourceId: "show",
+        label: "Show assets",
+        message: "Unavailable",
+        status: 503,
+        retryable: true,
+      },
+    ],
+    loading: false,
+    filteredAssetCount: 2,
+    sections: {
+      backdrops: [],
+      banners: [],
+      posters: [],
+      profile_pictures: [profileAsset],
+      hasMoreBySection: {
+        backdrops: true,
+        profile_pictures: true,
+        cast_photos: true,
+      },
+    },
+    castPromoAssets: [promoAsset],
+    onRunCompleted: vi.fn(),
+    onSelectSeason: vi.fn(),
+    onOpenRefreshCenter: vi.fn(),
+    onOpenFilters: vi.fn(),
+    onToggleAutoAdvance: vi.fn(),
+    onClearFilters: vi.fn(),
+    onOpenBatchJobs: vi.fn(),
+    onGetImages: vi.fn(),
+    onOpenImport: vi.fn(),
+    onLoadMoreBackdrops: vi.fn(),
+    onLoadMoreBanners: vi.fn(),
+    onLoadMorePosters: vi.fn(),
+    onLoadMoreProfilePictures: vi.fn(),
+    onLoadMoreCastPromos: vi.fn(),
+    onOpenAssetLightbox: vi.fn(),
+    formatSourceFailure: (failure) => `${failure.label}: ${failure.message}`,
+  },
+  videos: {
+    error: null,
+    loading: false,
+    thumbnailSyncing: false,
+    thumbnailSyncWarning: null,
+    rows: [],
+    getThumbnailUrl: () => null,
+    formatPublishedDate: () => null,
+  },
+  branding: {
+    posterAssets: [createAsset("poster-1")],
+    backdropAssets: [createAsset("backdrop-1")],
+    featuredPosterImageId: "poster-1",
+    featuredBackdropImageId: "backdrop-1",
+    logoAssets: [logoAsset],
+    featuredLogoAssetId: "logo-1",
+    featuredLogoSavingAssetId: null,
+    featuredLogoVariant: "color",
+    seasons: [{ id: "season-2", season_number: 2, name: "Season 2", title: null }],
+    cast: [
+      {
+        person_id: "person-1",
+        full_name: "Jane Doe",
+        cast_member_name: "Jane Doe",
+        role: "Self",
+        credit_category: "Self",
+        photo_url: null,
+        cover_photo_url: null,
+      },
+    ],
+    getAssetDisplayUrl: (asset) => asset.hosted_url,
+    onSetFeaturedPoster: vi.fn(),
+    onSetFeaturedBackdrop: vi.fn(),
+    onSelectFeaturedLogoVariant: vi.fn(),
+    onSetFeaturedLogo: vi.fn(),
+  },
+  renderProgress: ({ show, stage }) => (show ? <span>{`progress:${stage}`}</span> : null),
+  renderAssetImage: ({ asset, useResolvedUrl }) => (
+    <span>{`${useResolvedUrl ? "resolved" : "default"}:${asset.id}`}</span>
+  ),
+  renderVideoThumbnail: ({ src }) => <span>{`thumbnail:${src}`}</span>,
+});
+
+describe("ShowAssetsTab", () => {
+  it("renders image diagnostics and dispatches route-owned image actions", () => {
+    const props = createProps();
+    render(<ShowAssetsTab {...props} />);
+
+    const tabpanel = screen.getByRole("tabpanel");
+    expect(tabpanel).toHaveAttribute("id", "show-tabpanel-assets");
+    expect(tabpanel).toHaveAttribute("aria-labelledby", "show-tab-assets");
+    expect(screen.getByLabelText("Filter by season:")).toHaveValue("all");
+    expect(screen.getByText("BRAVOTV Get Images for Test Show")).toBeInTheDocument();
+    expect(screen.getByText(/Fallback diagnostics: 2 recovered/)).toBeInTheDocument();
+    expect(screen.getByText(/Mirrored URL usage: 4\/5 \(80%\)/)).toBeInTheDocument();
+    expect(screen.getByText("default:profile-1")).toBeInTheDocument();
+    expect(screen.getByText("resolved:promo-1")).toBeInTheDocument();
+    expect(screen.getByText("progress:batch")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "2" } });
+    fireEvent.click(screen.getByRole("button", { name: "Open Refresh Center" }));
+    fireEvent.click(screen.getByRole("button", { name: "Filters" }));
+    fireEvent.click(screen.getByRole("button", { name: "Auto-Load: Off" }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear Filters (2)" }));
+    fireEvent.click(screen.getByRole("button", { name: "Batch Jobs" }));
+    fireEvent.click(screen.getByRole("button", { name: "Get Images" }));
+    fireEvent.click(screen.getByRole("button", { name: "Import Images" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run image panel" }));
+    fireEvent.click(screen.getByRole("button", { name: "Load mocked backdrops" }));
+    fireEvent.click(screen.getByRole("button", { name: "Load More Profile Pictures" }));
+    fireEvent.click(screen.getByRole("button", { name: "Load More Cast Promos" }));
+    fireEvent.click(screen.getByRole("button", { name: /default:profile-1 Jane Doe/i }));
+
+    expect(props.images.onSelectSeason).toHaveBeenCalledWith("2");
+    expect(props.images.onOpenRefreshCenter).toHaveBeenCalledOnce();
+    expect(props.images.onOpenFilters).toHaveBeenCalledOnce();
+    expect(props.images.onToggleAutoAdvance).toHaveBeenCalledOnce();
+    expect(props.images.onClearFilters).toHaveBeenCalledOnce();
+    expect(props.images.onOpenBatchJobs).toHaveBeenCalledOnce();
+    expect(props.images.onGetImages).toHaveBeenCalledOnce();
+    expect(props.images.onOpenImport).toHaveBeenCalledOnce();
+    expect(props.images.onRunCompleted).toHaveBeenCalledOnce();
+    expect(props.images.onLoadMoreBackdrops).toHaveBeenCalledOnce();
+    expect(props.images.onLoadMoreProfilePictures).toHaveBeenCalledOnce();
+    expect(props.images.onLoadMoreCastPromos).toHaveBeenCalledOnce();
+    expect(props.images.onOpenAssetLightbox).toHaveBeenCalledWith(
+      profileAsset,
+      0,
+      [profileAsset],
+      expect.any(HTMLButtonElement),
+    );
+  });
+
+  it("preserves video loading, metadata, empty, and thumbnail behavior", () => {
+    const props = createProps();
+    const videoProps: ShowAssetsTabProps = {
+      ...props,
+      assetsView: "videos",
+      videos: {
+        ...props.videos,
+        thumbnailSyncing: true,
+        thumbnailSyncWarning: "Thumbnail fallback used.",
+        rows: [
+          {
+            title: "First Look",
+            runtime: "2:30",
+            kicker: "Preview",
+            clip_url: "https://example.com/video",
+            season_number: 2,
+            published_at: "2026-07-15",
+          },
+        ],
+        getThumbnailUrl: () => "https://cdn.example.com/video.jpg",
+        formatPublishedDate: () => "Jul 15, 2026",
+      },
+    };
+    const { rerender } = render(<ShowAssetsTab {...videoProps} />);
+
+    expect(screen.getByText("Syncing high-quality video thumbnails...")).toBeInTheDocument();
+    expect(screen.getByText("Thumbnail fallback used.")).toBeInTheDocument();
+    expect(screen.getByText("First Look")).toBeInTheDocument();
+    expect(screen.getByText("2:30")).toBeInTheDocument();
+    expect(screen.getByText("Season 2")).toBeInTheDocument();
+    expect(screen.getByText("Preview")).toBeInTheDocument();
+    expect(screen.getByText("Posted Jul 15, 2026")).toBeInTheDocument();
+    expect(screen.getByText("thumbnail:https://cdn.example.com/video.jpg")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /First Look/ })).toHaveAttribute(
+      "href",
+      "https://example.com/video",
+    );
+
+    rerender(
+      <ShowAssetsTab
+        {...videoProps}
+        videos={{ ...videoProps.videos, rows: [], thumbnailSyncing: false }}
+      />,
+    );
+    expect(screen.getByText("No persisted Bravo videos found for this show.")).toBeInTheDocument();
+  });
+
+  it("renders branding and dispatches featured media changes", () => {
+    const props = createProps();
+    render(<ShowAssetsTab {...props} assetsView="branding" />);
+
+    expect(screen.getByText("Featured Images")).toBeInTheDocument();
+    expect(screen.getByText("Logos")).toBeInTheDocument();
+    expect(screen.getByText("Brand editor for Test Show")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Set mocked poster" }));
+    fireEvent.click(screen.getByRole("button", { name: "Set mocked logo" }));
+
+    expect(props.branding.onSetFeaturedPoster).toHaveBeenCalledWith("poster-2");
+    expect(props.branding.onSetFeaturedLogo).toHaveBeenCalledWith(logoAsset);
+  });
+});

--- a/apps/web/tests/show-autocrop-wiring.test.ts
+++ b/apps/web/tests/show-autocrop-wiring.test.ts
@@ -8,12 +8,17 @@ describe("show auto-crop wiring", () => {
       __dirname,
       "../src/app/admin/trr-shows/[showId]/page.tsx",
     );
+    const utilitiesPath = path.resolve(
+      __dirname,
+      "../src/lib/admin/show-page/show-detail-utilities.ts",
+    );
     const contents = fs.readFileSync(filePath, "utf8");
+    const utilities = fs.readFileSync(utilitiesPath, "utf8");
 
     expect(contents).toMatch(/resize:\s*"Auto-Crop"/);
     expect(contents).toMatch(/Variants \(Auto-Crop\)/);
     expect(contents).toMatch(/buildAssetAutoCropPayloadWithFallback/);
-    expect(contents).toMatch(/strategy:\s*"resize_center_fallback_v1"/);
+    expect(utilities).toMatch(/strategy:\s*"resize_center_fallback_v1"/);
   });
 
   it("rebuilds preview auto-crop variants when star is toggled on", () => {

--- a/apps/web/tests/show-batch-role-modals-wiring.test.ts
+++ b/apps/web/tests/show-batch-role-modals-wiring.test.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) =>
+  fs.readFileSync(path.resolve(__dirname, relativePath), "utf8");
+
+describe("show batch and role modal wiring", () => {
+  const route = readSource("../src/app/admin/trr-shows/[showId]/page.tsx");
+  const modals = readSource("../src/components/admin/ShowBatchRoleModals.tsx");
+
+  it("keeps state, validation, mutations, and option semantics in the route", () => {
+    expect(route).toMatch(/<ShowBatchRoleModals/);
+    expect(route).toMatch(/const BATCH_JOB_OPERATION_LABELS/);
+    expect(route).toMatch(/const SHOW_GALLERY_ALLOWED_SECTIONS/);
+    expect(route).toMatch(/const runBatchJobs = useCallback/);
+    expect(route).toMatch(/const saveRenamedShowRole = useCallback/);
+    expect(route).toMatch(/const saveCastRoleAssignments = useCallback/);
+    expect(route).toMatch(/setRoleRenameDraft/);
+    expect(route).toMatch(/setCastRoleEditDraft/);
+    expect(route).toMatch(/toggleBatchJobOperation/);
+    expect(route).toMatch(/toggleBatchJobContentSection/);
+    expect(route).toMatch(/if \(!batchJobsRunning\) setBatchJobsOpen\(false\)/);
+    expect(route).toMatch(/<AdvancedFilterDrawer/);
+  });
+
+  it("moves only the three modal views into a presentational component", () => {
+    expect(route).not.toMatch(/ariaLabel="Run image batch jobs"/);
+    expect(route).not.toMatch(/ariaLabel="Rename role"/);
+    expect(route).not.toMatch(/ariaLabel="Assign cast roles"/);
+    expect(modals).toMatch(/ariaLabel="Run image batch jobs"/);
+    expect(modals).toMatch(/ariaLabel="Rename role"/);
+    expect(modals).toMatch(/ariaLabel="Assign cast roles"/);
+    expect(modals).not.toMatch(/useEffect|useLayoutEffect|useState|useReducer|useMemo/);
+    expect(modals).not.toMatch(/\bfetch\s*\(|adminStream|patchShowRole|assignRolesToCastMember/);
+    expect(modals).not.toMatch(/["'`]\/api\//);
+  });
+});

--- a/apps/web/tests/show-batch-role-modals.test.tsx
+++ b/apps/web/tests/show-batch-role-modals.test.tsx
@@ -1,0 +1,154 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import ShowBatchRoleModals, {
+  type ShowBatchRoleModalsProps,
+} from "@/components/admin/ShowBatchRoleModals";
+
+vi.mock("@/components/admin/AdminModal", () => ({
+  default: ({
+    ariaLabel,
+    children,
+    closeLabel,
+    disableClose,
+    isOpen,
+    onClose,
+  }: {
+    ariaLabel?: string;
+    children: ReactNode;
+    closeLabel?: string;
+    disableClose?: boolean;
+    isOpen: boolean;
+    onClose: () => void;
+  }) =>
+    isOpen ? (
+      <div role="dialog" aria-label={ariaLabel} data-disable-close={String(Boolean(disableClose))}>
+        <button type="button" aria-label={closeLabel} onClick={onClose} disabled={disableClose} />
+        {children}
+      </div>
+    ) : null,
+}));
+
+const createProps = (): ShowBatchRoleModalsProps => ({
+  batchJobs: {
+    open: true,
+    running: false,
+    operationOptions: [
+      { key: "count", label: "Count", checked: true, onToggle: vi.fn() },
+      { key: "crop", label: "Crop", checked: false, onToggle: vi.fn() },
+    ],
+    contentSectionOptions: [
+      { key: "posters", label: "Posters", checked: true, onToggle: vi.fn() },
+    ],
+    preflightSummary: "Will process 3 assets across Posters with Count.",
+    onClose: vi.fn(),
+    onRun: vi.fn(),
+  },
+  roleRename: {
+    draft: null,
+    saving: false,
+    onClose: vi.fn(),
+    onNameChange: vi.fn(),
+    onSave: vi.fn(),
+  },
+  castRoles: {
+    draft: null,
+    saving: false,
+    onClose: vi.fn(),
+    onRoleCsvChange: vi.fn(),
+    onSave: vi.fn(),
+  },
+});
+
+describe("ShowBatchRoleModals", () => {
+  it("renders batch options and relays route-owned controls", () => {
+    const props = createProps();
+    render(<ShowBatchRoleModals {...props} />);
+
+    const dialog = screen.getByRole("dialog", { name: "Run image batch jobs" });
+    expect(dialog).toHaveAttribute("data-disable-close", "false");
+    expect(within(dialog).getByRole("checkbox", { name: "Count" })).toBeChecked();
+    expect(within(dialog).getByRole("checkbox", { name: "Crop" })).not.toBeChecked();
+    expect(within(dialog).getByRole("checkbox", { name: "Posters" })).toBeChecked();
+    expect(within(dialog).getByText(props.batchJobs.preflightSummary)).toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getByRole("checkbox", { name: "Crop" }));
+    fireEvent.click(within(dialog).getByRole("button", { name: "Run Batch Jobs" }));
+    fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+    fireEvent.click(within(dialog).getByRole("button", { name: "Close" }));
+    fireEvent.click(within(dialog).getByRole("button", { name: "Close batch jobs dialog" }));
+
+    expect(props.batchJobs.operationOptions[1].onToggle).toHaveBeenCalledOnce();
+    expect(props.batchJobs.onRun).toHaveBeenCalledOnce();
+    expect(props.batchJobs.onClose).toHaveBeenCalledTimes(3);
+  });
+
+  it("preserves the batch running lock across shell and visible controls", () => {
+    const props = createProps();
+    props.batchJobs.running = true;
+    render(<ShowBatchRoleModals {...props} />);
+
+    const dialog = screen.getByRole("dialog", { name: "Run image batch jobs" });
+    expect(dialog).toHaveAttribute("data-disable-close", "true");
+    expect(within(dialog).getByRole("button", { name: "Close batch jobs dialog" })).toBeDisabled();
+    expect(within(dialog).getByRole("button", { name: "Close" })).toBeDisabled();
+    expect(within(dialog).getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(within(dialog).getByRole("button", { name: "Running..." })).toBeDisabled();
+    for (const checkbox of within(dialog).getAllByRole("checkbox")) {
+      expect(checkbox).toBeDisabled();
+    }
+  });
+
+  it("renders the rename draft and relays edit, cancel, and save callbacks", () => {
+    const props = createProps();
+    props.batchJobs.open = false;
+    props.roleRename.draft = { originalName: "Friend", nextName: "Housewife" };
+    const { rerender } = render(<ShowBatchRoleModals {...props} />);
+
+    const dialog = screen.getByRole("dialog", { name: "Rename role" });
+    expect(within(dialog).getByText("Current: Friend")).toBeInTheDocument();
+    fireEvent.change(within(dialog).getByRole("textbox", { name: "New Name" }), {
+      target: { value: "Guest" },
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Save Role" }));
+    fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+
+    expect(props.roleRename.onNameChange).toHaveBeenCalledWith("Guest");
+    expect(props.roleRename.onSave).toHaveBeenCalledOnce();
+    expect(props.roleRename.onClose).toHaveBeenCalledOnce();
+
+    props.roleRename.saving = true;
+    rerender(<ShowBatchRoleModals {...props} />);
+    expect(within(dialog).getByRole("button", { name: "Close role rename dialog" })).toBeDisabled();
+    expect(within(dialog).getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(within(dialog).getByRole("button", { name: "Saving..." })).toBeDisabled();
+    expect(within(dialog).getByRole("textbox", { name: "New Name" })).toBeEnabled();
+  });
+
+  it("renders the cast-role draft and preserves its saving lock", () => {
+    const props = createProps();
+    props.batchJobs.open = false;
+    props.castRoles.draft = { personName: "Lisa Vanderpump", roleCsv: "Housewife" };
+    const { rerender } = render(<ShowBatchRoleModals {...props} />);
+
+    const dialog = screen.getByRole("dialog", { name: "Assign cast roles" });
+    expect(within(dialog).getByText("Assign Roles for Lisa Vanderpump")).toBeInTheDocument();
+    fireEvent.change(within(dialog).getByRole("textbox", { name: "Roles" }), {
+      target: { value: "Housewife, Friend Of" },
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Save Roles" }));
+    fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+
+    expect(props.castRoles.onRoleCsvChange).toHaveBeenCalledWith("Housewife, Friend Of");
+    expect(props.castRoles.onSave).toHaveBeenCalledOnce();
+    expect(props.castRoles.onClose).toHaveBeenCalledOnce();
+
+    props.castRoles.saving = true;
+    rerender(<ShowBatchRoleModals {...props} />);
+    expect(within(dialog).getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(within(dialog).getByRole("button", { name: "Saving..." })).toBeDisabled();
+    expect(within(dialog).getByRole("button", { name: "Close cast role editor" })).toBeDisabled();
+    expect(within(dialog).getByRole("textbox", { name: "Roles" })).toBeEnabled();
+  });
+});

--- a/apps/web/tests/show-bravo-cast-only-preview-details.test.ts
+++ b/apps/web/tests/show-bravo-cast-only-preview-details.test.ts
@@ -4,12 +4,15 @@ import path from "node:path";
 
 describe("show bravo cast-only preview details", () => {
   it("renders progressive cast-only probe details with queue + rich profile cards", () => {
-    const filePath = path.resolve(__dirname, "../src/app/admin/trr-shows/[showId]/page.tsx");
-    const contents = fs.readFileSync(filePath, "utf8");
+    const routePath = path.resolve(__dirname, "../src/app/admin/trr-shows/[showId]/page.tsx");
+    const previewPath = path.resolve(__dirname, "../src/components/admin/ShowBravoSyncPreviewStep.tsx");
+    const modelPath = path.resolve(__dirname, "../src/lib/admin/show-page/workspace-model.ts");
+    const routeContents = fs.readFileSync(routePath, "utf8");
+    const contents = `${routeContents}\n${fs.readFileSync(previewPath, "utf8")}\n${fs.readFileSync(modelPath, "utf8")}`;
 
-    expect(contents).toMatch(/import-bravo\/preview\/stream/);
+    expect(routeContents).toMatch(/import-bravo\/preview\/stream/);
     expect(contents).toMatch(/Probe Queue/);
-    expect(contents).toMatch(/setSyncBravoProbeStatusMessage/);
+    expect(routeContents).toMatch(/setSyncBravoProbeStatusMessage/);
     expect(contents).toMatch(/status === "in_progress"/);
     expect(contents).toMatch(/hero_image_url\?: string \| null/);
     expect(contents).toMatch(/social_links\?: Record<string, string> \| null/);
@@ -21,8 +24,10 @@ describe("show bravo cast-only preview details", () => {
   });
 
   it("allows cast-only confirm step with candidate probe results", () => {
-    const filePath = path.resolve(__dirname, "../src/app/admin/trr-shows/[showId]/page.tsx");
-    const contents = fs.readFileSync(filePath, "utf8");
+    const routePath = path.resolve(__dirname, "../src/app/admin/trr-shows/[showId]/page.tsx");
+    const modalPath = path.resolve(__dirname, "../src/components/admin/ShowBravoSyncModal.tsx");
+    const routeContents = fs.readFileSync(routePath, "utf8");
+    const contents = `${routeContents}\n${fs.readFileSync(modalPath, "utf8")}`;
 
     expect(contents).toMatch(/syncBravoPersonCandidateResults\.length > 0/);
     expect(contents).toMatch(/syncFandomPersonCandidateResults\.length > 0/);

--- a/apps/web/tests/show-bravo-cast-only-wiring.test.ts
+++ b/apps/web/tests/show-bravo-cast-only-wiring.test.ts
@@ -4,8 +4,10 @@ import path from "node:path";
 
 describe("show bravo cast-only wiring", () => {
   it("offers cast-only vs rerun mode choices for existing Bravo sync data", () => {
-    const filePath = path.resolve(__dirname, "../src/app/admin/trr-shows/[showId]/page.tsx");
-    const contents = fs.readFileSync(filePath, "utf8");
+    const routePath = path.resolve(__dirname, "../src/app/admin/trr-shows/[showId]/page.tsx");
+    const modalPath = path.resolve(__dirname, "../src/components/admin/ShowBravoSyncModal.tsx");
+    const routeContents = fs.readFileSync(routePath, "utf8");
+    const contents = `${routeContents}\n${fs.readFileSync(modalPath, "utf8")}`;
 
     expect(contents).toMatch(/Sync All Info/);
     expect(contents).toMatch(/Cast Info only/);
@@ -13,26 +15,33 @@ describe("show bravo cast-only wiring", () => {
   });
 
   it("sends canonical cast candidate urls and uses stream preview for cast-only mode", () => {
-    const filePath = path.resolve(__dirname, "../src/app/admin/trr-shows/[showId]/page.tsx");
-    const contents = fs.readFileSync(filePath, "utf8");
+    const routePath = path.resolve(__dirname, "../src/app/admin/trr-shows/[showId]/page.tsx");
+    const modalPath = path.resolve(__dirname, "../src/components/admin/ShowBravoSyncModal.tsx");
+    const utilitiesPath = path.resolve(
+      __dirname,
+      "../src/lib/admin/show-page/show-detail-utilities.ts"
+    );
+    const routeContents = fs.readFileSync(routePath, "utf8");
+    const utilitiesContents = fs.readFileSync(utilitiesPath, "utf8");
+    const contents = `${routeContents}\n${fs.readFileSync(modalPath, "utf8")}\n${utilitiesContents}`;
 
-    expect(contents).toMatch(/person_url_candidates:\s*syncBravoCastUrlCandidates/);
-    expect(contents).toMatch(/import-bravo\/preview\/stream/);
-    expect(contents).toMatch(/cast_only:\s*true/);
-    expect(contents).toMatch(/cast_only:\s*syncBravoRunMode === "cast-only"/);
-    expect(contents).toMatch(/preview_result:/);
-    expect(contents).toMatch(/preview_signature:/);
-    expect(contents).toMatch(/syncBravoPreviewResult/);
-    expect(contents).toMatch(/syncBravoPreviewSignature/);
-    expect(contents).toMatch(/syncBravoRunMode === "cast-only" && !syncBravoPreviewSignature/);
-    expect(contents).toMatch(/Preview stale\. Re-run preview before committing cast-only sync\./);
-    expect(contents).toMatch(/fetchCastRoleMembers\(\{\s*force:\s*true\s*\}\)/);
-    expect(contents).toMatch(/status:\s*"pending"/);
-    expect(contents).toMatch(/https:\/\/www\.bravotv\.com\/people\/\$\{slug\}/);
-    expect(contents).toMatch(/payload\.source === "fandom" \? "fandom" : "bravo"/);
-    expect(contents).toMatch(/setSyncFandomPersonCandidateResults/);
-    expect(contents).toMatch(/fandom_candidate_results/);
-    expect(contents).toMatch(/fandom_domains_used/);
+    expect(routeContents).toMatch(/person_url_candidates:\s*syncBravoCastUrlCandidates/);
+    expect(routeContents).toMatch(/import-bravo\/preview\/stream/);
+    expect(routeContents).toMatch(/cast_only:\s*true/);
+    expect(routeContents).toMatch(/cast_only:\s*syncBravoRunMode === "cast-only"/);
+    expect(routeContents).toMatch(/preview_result:/);
+    expect(routeContents).toMatch(/preview_signature:/);
+    expect(routeContents).toMatch(/syncBravoPreviewResult/);
+    expect(routeContents).toMatch(/syncBravoPreviewSignature/);
+    expect(routeContents).toMatch(/syncBravoRunMode === "cast-only" && !syncBravoPreviewSignature/);
+    expect(routeContents).toMatch(/Preview stale\. Re-run preview before committing cast-only sync\./);
+    expect(routeContents).toMatch(/fetchCastRoleMembers\(\{\s*force:\s*true\s*\}\)/);
+    expect(routeContents).toMatch(/status:\s*"pending"/);
+    expect(utilitiesContents).toMatch(/https:\/\/www\.bravotv\.com\/people\/\$\{slug\}/);
+    expect(routeContents).toMatch(/payload\.source === "fandom" \? "fandom" : "bravo"/);
+    expect(routeContents).toMatch(/setSyncFandomPersonCandidateResults/);
+    expect(routeContents).toMatch(/fandom_candidate_results/);
+    expect(routeContents).toMatch(/fandom_domains_used/);
     expect(contents).toMatch(/Selected Mode:/);
   });
 });

--- a/apps/web/tests/show-bravo-fandom-integration-wiring.test.ts
+++ b/apps/web/tests/show-bravo-fandom-integration-wiring.test.ts
@@ -4,15 +4,17 @@ import path from "node:path";
 
 describe("show bravo fandom integration wiring", () => {
   it("maps full preview fandom fields and renders fandom coverage section", () => {
-    const filePath = path.resolve(__dirname, "../src/app/admin/trr-shows/[showId]/page.tsx");
-    const contents = fs.readFileSync(filePath, "utf8");
+    const routePath = path.resolve(__dirname, "../src/app/admin/trr-shows/[showId]/page.tsx");
+    const previewPath = path.resolve(__dirname, "../src/components/admin/ShowBravoSyncPreviewStep.tsx");
+    const routeContents = fs.readFileSync(routePath, "utf8");
+    const contents = `${routeContents}\n${fs.readFileSync(previewPath, "utf8")}`;
 
-    expect(contents).toMatch(/fandom_people\?: BravoPreviewPerson\[]/);
-    expect(contents).toMatch(/fandom_candidate_results\?: BravoPersonCandidateResult\[]/);
-    expect(contents).toMatch(/fandom_domains_used\?: string\[]/);
+    expect(routeContents).toMatch(/fandom_people\?: BravoPreviewPerson\[]/);
+    expect(routeContents).toMatch(/fandom_candidate_results\?: BravoPersonCandidateResult\[]/);
+    expect(routeContents).toMatch(/fandom_domains_used\?: string\[]/);
     expect(contents).toMatch(/Fandom Cast Coverage/);
-    expect(contents).toMatch(/setSyncFandomPreviewPeople/);
-    expect(contents).toMatch(/setSyncFandomCandidateSummary/);
+    expect(routeContents).toMatch(/setSyncFandomPreviewPeople/);
+    expect(routeContents).toMatch(/setSyncFandomCandidateSummary/);
   });
 
   it("includes fandom sync outcomes in commit notice and log messaging", () => {

--- a/apps/web/tests/show-bravo-sync-modal-wiring.test.ts
+++ b/apps/web/tests/show-bravo-sync-modal-wiring.test.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) =>
+  fs.readFileSync(path.resolve(__dirname, relativePath), "utf8");
+
+describe("show bravo sync modal wiring", () => {
+  it("keeps orchestration in the route and delegates the modal workspace", () => {
+    const route = readSource("../src/app/admin/trr-shows/[showId]/page.tsx");
+    const modal = readSource("../src/components/admin/ShowBravoSyncModal.tsx");
+    const preview = readSource("../src/components/admin/ShowBravoSyncPreviewStep.tsx");
+
+    expect(route).toMatch(/<ShowBravoSyncModal/);
+    expect(route).toMatch(/previewSyncByBravo/);
+    expect(route).toMatch(/commitSyncByBravo/);
+    expect(route).toMatch(/openSyncBravoConfirmStep/);
+    expect(route).toMatch(/startSyncBravoFlow/);
+    expect(route).toMatch(/syncBravoPreviewAbortControllerRef/);
+    expect(route).toMatch(/import-bravo\/preview\/stream/);
+
+    expect(route).not.toMatch(/ariaLabel="Sync by Bravo mode picker"/);
+    expect(route).not.toMatch(/ariaLabel="Import by Bravo"/);
+    expect(route).not.toMatch(/Probe Queue/);
+    expect(modal).toMatch(/ariaLabel="Sync by Bravo mode picker"/);
+    expect(modal).toMatch(/ariaLabel="Import by Bravo"/);
+    expect(preview).toMatch(/Probe Queue/);
+    expect(preview).toMatch(/Fandom Cast Coverage/);
+    expect(preview).toMatch(/BRAVO_IMPORT_IMAGE_KIND_OPTIONS/);
+  });
+
+  it("keeps both extracted components presentational", () => {
+    const contents = [
+      readSource("../src/components/admin/ShowBravoSyncModal.tsx"),
+      readSource("../src/components/admin/ShowBravoSyncPreviewStep.tsx"),
+    ].join("\n");
+
+    expect(contents).not.toMatch(/\bfetch\s*\(/);
+    expect(contents).not.toMatch(/useEffect|useLayoutEffect|useState|useReducer/);
+    expect(contents).not.toMatch(/["'`]\/api\//);
+    expect(contents).not.toMatch(/FeaturedLogoDrawer|ShowBrandLogosSection/);
+  });
+});

--- a/apps/web/tests/show-bravo-sync-modal.test.tsx
+++ b/apps/web/tests/show-bravo-sync-modal.test.tsx
@@ -1,0 +1,281 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import ShowBravoSyncModal, {
+  type ShowBravoSyncModalProps,
+} from "@/components/admin/ShowBravoSyncModal";
+
+vi.mock("@/components/admin/AdminModal", () => ({
+  default: ({
+    ariaLabel,
+    children,
+    isOpen,
+  }: {
+    ariaLabel?: string;
+    children: ReactNode;
+    isOpen: boolean;
+  }) => (isOpen ? <div role="dialog" aria-label={ariaLabel}>{children}</div> : null),
+}));
+
+vi.mock("@/app/admin/trr-shows/[showId]/ShowPageMedia", () => ({
+  GalleryImage: ({ alt, src }: { alt: string; src: string }) => (
+    <span role="img" aria-label={alt} data-src={src} />
+  ),
+}));
+
+const summary = { tested: 3, valid: 1, missing: 1, errors: 1 };
+const profile = {
+  url: "https://www.bravotv.com/people/jane-doe",
+  name: "Jane Doe",
+  bio: "Cast member bio",
+  heroImageUrl: "https://images.example/jane.jpg",
+  socialLinks: [
+    {
+      key: "instagram",
+      label: "Instagram",
+      url: "https://instagram.com/janedoe",
+      handle: "@janedoe",
+    },
+  ],
+};
+
+type ShowBravoSyncModalOverrides = {
+  modePicker?: Partial<ShowBravoSyncModalProps["modePicker"]>;
+  dialog?: Partial<ShowBravoSyncModalProps["dialog"]>;
+  season?: Partial<ShowBravoSyncModalProps["season"]>;
+  preview?: Partial<ShowBravoSyncModalProps["preview"]>;
+  confirm?: Partial<ShowBravoSyncModalProps["confirm"]>;
+};
+
+const createProps = (overrides: ShowBravoSyncModalOverrides = {}): ShowBravoSyncModalProps => {
+  const props: ShowBravoSyncModalProps = {
+    modePicker: {
+      open: false,
+      onClose: vi.fn(),
+      onStart: vi.fn(),
+    },
+    dialog: {
+      open: true,
+      step: "preview",
+      modeSummaryLabel: "Sync All Info",
+      previewSignature: "1234567890abcdef",
+      commitLoading: false,
+      onClose: vi.fn(),
+      onBack: vi.fn(),
+      onCancel: vi.fn(),
+      onNext: vi.fn(),
+      onCommit: vi.fn(),
+    },
+    season: {
+      targetSeasonNumber: 2,
+      defaultSeasonNumber: 2,
+      options: [3, 2],
+      onChange: vi.fn(),
+    },
+    preview: {
+      runMode: "full",
+      loading: false,
+      previewLoading: false,
+      showName: "Test Show",
+      bravoUrl: "https://www.bravotv.com/test-show",
+      error: null,
+      notice: "Preview ready",
+      description: "Bravo description",
+      airs: "Thursdays at 9",
+      applyDescriptionToShow: false,
+      images: [{ url: "https://images.example/show.jpg", alt: "Show key art" }],
+      selectedImages: new Set(["https://images.example/show.jpg"]),
+      imageKinds: { "https://images.example/show.jpg": "poster" },
+      personCandidateResults: [
+        {
+          url: profile.url,
+          name: profile.name,
+          status: "ok",
+        },
+      ],
+      fandomPersonCandidateResults: [
+        {
+          url: "https://example.fandom.com/wiki/Jane_Doe",
+          name: profile.name,
+          status: "missing",
+        },
+      ],
+      probeSummary: summary,
+      fandomProbeSummary: summary,
+      probeStatusMessage: "Probing candidate 1 of 3",
+      probeActive: true,
+      probeTotal: 31,
+      validProfileCards: [profile],
+      fandomValidProfileCards: [
+        { ...profile, url: "https://example.fandom.com/wiki/Jane_Doe" },
+      ],
+      candidateIssues: [
+        { url: "https://www.bravotv.com/people/missing", status: "missing", reason: null },
+      ],
+      fandomCandidateIssues: [
+        {
+          url: "https://example.fandom.com/wiki/Missing",
+          status: "error",
+          reason: "Probe failed",
+        },
+      ],
+      fandomDomainsUsed: ["example.fandom.com"],
+      castLinks: [{ name: "Jane Doe", url: profile.url }],
+      newsItems: [
+        {
+          headline: "Test Show News",
+          image_url: "https://images.example/news.jpg",
+          article_url: "https://www.bravotv.com/news/test-show-news",
+          published_at: "2026-07-15T00:00:00Z",
+        },
+      ],
+      videos: [
+        {
+          title: "Test Show Preview",
+          runtime: "2:00",
+          image_url: "https://images.example/video.jpg",
+          clip_url: "https://www.bravotv.com/videos/test-show-preview",
+          season_number: 2,
+          published_at: "2026-07-15T00:00:00Z",
+        },
+      ],
+      videoSeasonFilter: "all",
+      videoSeasonOptions: [2],
+      onRefreshPreview: vi.fn(),
+      onDescriptionChange: vi.fn(),
+      onAirsChange: vi.fn(),
+      onApplyDescriptionChange: vi.fn(),
+      onImageSelectionChange: vi.fn(),
+      onImageKindChange: vi.fn(),
+      onVideoSeasonFilterChange: vi.fn(),
+      inferImageKind: vi.fn(() => "other"),
+      formatPublishedDate: vi.fn(() => "Jul 15, 2026"),
+    },
+    confirm: {
+      castSyncCount: 1,
+      selectedImageSummaries: [
+        { url: "https://images.example/show.jpg", alt: "Show key art", kind: "poster" },
+      ],
+    },
+  };
+
+  return {
+    ...props,
+    ...overrides,
+    modePicker: { ...props.modePicker, ...overrides.modePicker },
+    dialog: { ...props.dialog, ...overrides.dialog },
+    season: { ...props.season, ...overrides.season },
+    preview: { ...props.preview, ...overrides.preview },
+    confirm: { ...props.confirm, ...overrides.confirm },
+  };
+};
+
+describe("ShowBravoSyncModal", () => {
+  it("renders the mode picker first and starts either sync mode", () => {
+    const props = createProps({
+      modePicker: { open: true },
+    });
+
+    render(<ShowBravoSyncModal {...props} />);
+
+    const dialogs = screen.getAllByRole("dialog");
+    expect(dialogs[0]).toHaveAccessibleName("Sync by Bravo mode picker");
+    expect(dialogs[1]).toHaveAccessibleName("Import by Bravo");
+    fireEvent.click(within(dialogs[0]).getByRole("button", { name: "Sync All Info" }));
+    fireEvent.click(within(dialogs[0]).getByRole("button", { name: "Cast Info only" }));
+    fireEvent.click(within(dialogs[0]).getByRole("button", { name: "Cancel" }));
+
+    expect(props.modePicker.onStart).toHaveBeenNthCalledWith(1, "full");
+    expect(props.modePicker.onStart).toHaveBeenNthCalledWith(2, "cast-only");
+    expect(props.modePicker.onClose).toHaveBeenCalledOnce();
+  });
+
+  it("renders and dispatches the full preview controls", () => {
+    const props = createProps();
+
+    render(<ShowBravoSyncModal {...props} />);
+
+    expect(screen.getByRole("dialog", { name: "Import by Bravo" })).toBeInTheDocument();
+    expect(screen.getByText("Step 1 of 2")).toBeInTheDocument();
+    expect(screen.getByText("Selected Mode: Sync All Info")).toBeInTheDocument();
+    expect(screen.getByText("Test Show News")).toBeInTheDocument();
+    expect(screen.getByText("Test Show Preview")).toBeInTheDocument();
+    expect(screen.getByText("Fandom Cast Coverage")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Sync Season"), { target: { value: "3" } });
+    fireEvent.change(screen.getByLabelText("Description"), {
+      target: { value: "Updated description" },
+    });
+    fireEvent.click(screen.getByLabelText(/Apply Bravo description/));
+    fireEvent.click(screen.getAllByRole("checkbox")[1]);
+    fireEvent.change(screen.getByDisplayValue("Poster"), { target: { value: "promo" } });
+    fireEvent.click(screen.getByRole("button", { name: "Refresh Preview" }));
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    expect(props.season.onChange).toHaveBeenCalledWith(3);
+    expect(props.preview.onDescriptionChange).toHaveBeenCalledWith("Updated description");
+    expect(props.preview.onApplyDescriptionChange).toHaveBeenCalledWith(true);
+    expect(props.preview.onImageSelectionChange).toHaveBeenCalledWith(
+      "https://images.example/show.jpg",
+      false
+    );
+    expect(props.preview.onImageKindChange).toHaveBeenCalledWith(
+      "https://images.example/show.jpg",
+      "promo"
+    );
+    expect(props.preview.onRefreshPreview).toHaveBeenCalledOnce();
+    expect(props.dialog.onClose).toHaveBeenCalledOnce();
+    expect(props.dialog.onCancel).toHaveBeenCalledOnce();
+    expect(props.dialog.onNext).toHaveBeenCalledOnce();
+  });
+
+  it("preserves Bravo and Fandom cast-only probe details", () => {
+    render(
+      <ShowBravoSyncModal
+        {...createProps({
+          preview: { runMode: "cast-only" },
+          dialog: { modeSummaryLabel: "Cast Info only" },
+        })}
+      />
+    );
+
+    expect(screen.getByText("Probe Queue")).toBeInTheDocument();
+    expect(screen.getByText("Fandom Probe Queue")).toBeInTheDocument();
+    expect(screen.getByText("Missing / Error Profiles")).toBeInTheDocument();
+    expect(screen.getByText("Fandom Missing / Error Profiles")).toBeInTheDocument();
+    expect(screen.getByText(/This may take several minutes/)).toBeInTheDocument();
+  });
+
+  it("renders confirmation details and dispatches back and commit", () => {
+    const props = createProps({ dialog: { step: "confirm" } });
+
+    render(<ShowBravoSyncModal {...props} />);
+
+    expect(screen.getByText("Step 2 of 2")).toBeInTheDocument();
+    expect(screen.getByText("Cast Members Being Synced (1)")).toBeInTheDocument();
+    expect(screen.getByText("Show Images Being Synced (1)")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    fireEvent.click(screen.getByRole("button", { name: "Sync All Info" }));
+
+    expect(props.dialog.onBack).toHaveBeenCalledOnce();
+    expect(props.dialog.onCommit).toHaveBeenCalledOnce();
+  });
+
+  it("disables closing, navigation, and commit while sync is loading", () => {
+    render(
+      <ShowBravoSyncModal
+        {...createProps({
+          dialog: { step: "confirm", commitLoading: true },
+          preview: { loading: true },
+        })}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Close" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Back" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Syncing..." })).toBeDisabled();
+  });
+});

--- a/apps/web/tests/show-cast-lazy-loading-wiring.test.ts
+++ b/apps/web/tests/show-cast-lazy-loading-wiring.test.ts
@@ -6,9 +6,12 @@ describe("show detail cast lazy-loading wiring", () => {
   const filePath = path.resolve(__dirname, "../src/app/admin/trr-shows/[showId]/page.tsx");
   const castRouteStatePath = path.resolve(__dirname, "../src/lib/admin/cast-route-state.ts");
   const creditsViewsPath = path.resolve(__dirname, "../src/components/admin/show-tabs/ShowCreditsViews.tsx");
+  const showCastTabPath = path.resolve(__dirname, "../src/components/admin/show-tabs/ShowCastTab.tsx");
   const contents = fs.readFileSync(filePath, "utf8");
   const castRouteStateContents = fs.readFileSync(castRouteStatePath, "utf8");
   const creditsViewsContents = fs.readFileSync(creditsViewsPath, "utf8");
+  const showCastTabContents = fs.readFileSync(showCastTabPath, "utf8");
+  const combinedContents = `${contents}\n${showCastTabContents}`;
 
   it("keeps initial page load Promise.all free of fetchCast", () => {
     expect(contents).toMatch(/useShowIdentityLoad/);
@@ -23,7 +26,7 @@ describe("show detail cast lazy-loading wiring", () => {
     expect(contents).toMatch(/if \(castAutoLoadAttemptedRef\.current === autoLoadKey\) return;/);
     expect(contents).toMatch(/void fetchCast\(\{ force: true, includePhotos: false \}\);/);
     expect(contents).toMatch(/castAutoRecoveryAttemptedRef/);
-    expect(contents).toMatch(/Cast list unavailable; retrying cast roster\.\.\./);
+    expect(showCastTabContents).toMatch(/Cast list unavailable; retrying cast roster\.\.\./);
   });
 
   it("hardens cast loading with longer timeout, retry, and zero-episode exclusion", () => {
@@ -37,7 +40,7 @@ describe("show detail cast lazy-loading wiring", () => {
   });
 
   it("provides explicit enrich missing cast photos action with bravo fallback", () => {
-    expect(contents).toMatch(/Enrich Missing Cast Photos/);
+    expect(showCastTabContents).toMatch(/Enrich Missing Cast Photos/);
     expect(contents).toMatch(/photoFallbackMode: "bravo"/);
     expect(contents).toMatch(/includePhotos: true/);
     expect(contents).toMatch(/mergeMissingPhotosOnly: true/);
@@ -94,7 +97,7 @@ describe("show detail cast lazy-loading wiring", () => {
     expect(castRouteStateContents).toMatch(/cast_episode_max/);
     expect(castRouteStateContents).toMatch(/cast_view/);
     expect(castRouteStateContents).toMatch(/cast_cols/);
-    expect(contents).toMatch(/Search Name/);
+    expect(showCastTabContents).toMatch(/Search Name/);
   });
 
   it("keeps cast job state tracking even after removing per-card credits actions", () => {
@@ -106,32 +109,33 @@ describe("show detail cast lazy-loading wiring", () => {
 
   it("tracks and renders failed cast members with retry-failed control", () => {
     expect(contents).toMatch(/const \[castRunFailedMembers, setCastRunFailedMembers\] = useState<CastRunFailedMember\[]>\(\[\]\)/);
-    expect(contents).toMatch(/Retry failed only/);
+    expect(showCastTabContents).toMatch(/Retry failed only/);
     expect(contents).toMatch(/retryFailedCastMediaEnrich/);
-    expect(contents).toMatch(/Failed Members \(\{castRunFailedMembers\.length\}\)/);
+    expect(showCastTabContents).toMatch(/Failed Members \(\{castRunFailedMembers\.length\}\)/);
   });
 
   it("shows rendered\\/matched\\/total cast counters and exposes cancel for running cast jobs", () => {
     expect(contents).toMatch(/const castDisplayTotals = useMemo/);
-    expect(contents).toMatch(/renderedCastCount}\/\{matchedCastCount}\/\{totalCastCount} cast/);
-    expect(contents).toMatch(/renderedCrewCount}\/\{matchedCrewCount}\/\{totalCrewCount} crew/);
-    expect(contents).toMatch(/renderedVisibleCount}\/\{matchedVisibleCount}\/\{totalVisibleCount} visible/);
+    expect(showCastTabContents).toMatch(/renderedCastCount}\/\{matchedCastCount}\/\{totalCastCount} cast/);
+    expect(showCastTabContents).toMatch(/renderedCrewCount}\/\{matchedCrewCount}\/\{totalCrewCount} crew/);
+    expect(showCastTabContents).toMatch(/renderedVisibleCount}\/\{matchedVisibleCount}\/\{totalVisibleCount} visible/);
     expect(contents).toMatch(/const cancelShowCastWorkflow = useCallback/);
     expect(contents).toMatch(/castRefreshAbortControllerRef\.current\?\.abort\(\)/);
     expect(contents).toMatch(/castMediaEnrichAbortControllerRef\.current\?\.abort\(\)/);
-    expect(contents).toMatch(/\(castRefreshPipelineRunning \|\|\s*castMediaEnriching \|\|\s*hasPersonRefreshInFlight \|\|\s*hasReconnectableCreditsRun\) &&/s);
+    expect(contents).toMatch(/showCancelRunButton=\{/);
     expect(contents).toMatch(
       /castRefreshAbortControllerRef\.current\?\.abort\(\);\s*castMediaEnrichAbortControllerRef\.current\?\.abort\(\);/s
     );
     expect(contents).toMatch(/\/api\/admin\/trr-api\/operations\/\$\{operationId\}\/cancel/);
-    expect(contents).toMatch(/Cancel Run/);
+    expect(showCastTabContents).toMatch(/castRefreshCancelButtonLabel/);
     expect(contents).toMatch(/personRefreshAbortControllersRef/);
   });
 
   it("renders cast members through the dedicated credits view components", () => {
     expect(contents).toMatch(/const renderShowCreditsCastMember =/);
-    expect(contents).toMatch(/ShowCreditsCastMembers/);
-    expect(contents).toMatch(/ShowCreditsCastViewControls/);
+    expect(contents).toMatch(/<ShowCastTab/);
+    expect(showCastTabContents).toMatch(/ShowCreditsCastMembers/);
+    expect(showCastTabContents).toMatch(/ShowCreditsCastViewControls/);
     expect(contents).not.toMatch(/event\.preventDefault\(\);\s*event\.stopPropagation\(\);\s*handleRefreshCastMember/s);
   });
 
@@ -164,13 +168,13 @@ describe("show detail cast lazy-loading wiring", () => {
   });
 
   it("renders the credits header and cast view controls without per-card edit actions", () => {
-    expect(contents).toMatch(/<h3 className="text-xl font-bold text-zinc-900">\s*Credits\s*<\/h3>/);
-    expect(contents).not.toMatch(/The Real Housewives of Salt Lake City/);
-    expect(contents).toMatch(/ShowCreditsCastViewControls/);
-    expect(contents).toMatch(/ShowCreditsCastMembers/);
-    expect(contents).toMatch(/ShowCreditsCrewSections/);
-    expect(contents).not.toMatch(/Refresh Person/);
-    expect(contents).not.toMatch(/Edit Roles/);
+    expect(showCastTabContents).toMatch(/<h3 className="text-xl font-bold text-zinc-900">\s*Credits\s*<\/h3>/);
+    expect(showCastTabContents).not.toMatch(/The Real Housewives of Salt Lake City/);
+    expect(showCastTabContents).toMatch(/ShowCreditsCastViewControls/);
+    expect(showCastTabContents).toMatch(/ShowCreditsCastMembers/);
+    expect(showCastTabContents).toMatch(/ShowCreditsCrewSections/);
+    expect(combinedContents).not.toMatch(/Refresh Person/);
+    expect(combinedContents).not.toMatch(/Edit Roles/);
     expect(creditsViewsContents).toMatch(/<th[^>]*>\s*Name\s*<\/th>/);
     expect(creditsViewsContents).toMatch(/<th[^>]*>\s*Role\s*<\/th>/);
     expect(creditsViewsContents).toMatch(/<th[^>]*>\s*Episodes\s*<\/th>/);
@@ -186,18 +190,18 @@ describe("show detail cast lazy-loading wiring", () => {
   it("keeps cast tab usable when cast-role-members refresh fails", () => {
     expect(contents).toMatch(/Showing last successful cast intelligence snapshot/);
     expect(contents).toMatch(/setCastRoleMembersWarning/);
-    expect(contents).toMatch(/onClick=\{\(\) => void fetchCastRoleMembers\(\{ force: true \}\)\}/);
-    expect(contents).toMatch(/rolesWarningWithSnapshotAge && \(/);
-    expect(contents).toMatch(/Retry Roles/);
-    expect(contents).toMatch(/onClick=\{\(\) => void fetchShowRoles\(\{ force: true \}\)\}/);
-    expect(contents).toMatch(/Cast intelligence unavailable; showing base cast snapshot\./);
-    expect(contents).toMatch(/Retry Cast Intelligence/);
-    expect(contents).toMatch(/Refreshing cast intelligence\.\.\./);
+    expect(showCastTabContents).toMatch(/onClick=\{onRetryCastRoleMembers\}/);
+    expect(showCastTabContents).toMatch(/rolesWarningWithSnapshotAge && \(/);
+    expect(showCastTabContents).toMatch(/Retry Roles/);
+    expect(showCastTabContents).toMatch(/onClick=\{onRetryRoles\}/);
+    expect(showCastTabContents).toMatch(/Cast intelligence unavailable; showing base cast snapshot\./);
+    expect(showCastTabContents).toMatch(/Retry Cast Intelligence/);
+    expect(showCastTabContents).toMatch(/Refreshing cast intelligence\.\.\./);
     expect(contents).toMatch(/castUiTerminalReady/);
     expect(contents).toMatch(/const castRosterReady =/);
-    expect(contents).toMatch(/Loading role and credit filters\.\.\./);
-    expect(contents).toMatch(/Loading cast roster\.\.\./);
-    expect(contents).toMatch(/No cast members found for this show\./);
+    expect(showCastTabContents).toMatch(/Loading role and credit filters\.\.\./);
+    expect(showCastTabContents).toMatch(/Loading cast roster\.\.\./);
+    expect(showCastTabContents).toMatch(/No cast members found for this show\./);
     expect(contents).toMatch(
       /showCastIntelligenceUnavailable =\s*activeTab === "cast" &&\s*castSource === "show_fallback" &&\s*!castRoleMembersLoading &&\s*!rolesLoading &&\s*\(Boolean\(castRoleMembersError\) \|\| Boolean\(rolesError\)\)/
     );

--- a/apps/web/tests/show-cast-tab.test.tsx
+++ b/apps/web/tests/show-cast-tab.test.tsx
@@ -1,0 +1,357 @@
+/* eslint-disable @next/next/no-img-element */
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import ShowCastTab, { type ShowCastTabProps } from "@/components/admin/show-tabs/ShowCastTab";
+
+vi.mock("@/app/admin/trr-shows/[showId]/ShowPageMedia", () => ({
+  CastPhoto: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />,
+}));
+
+type TestCastMember = {
+  id: string;
+  name: string;
+};
+
+type PresentationalProps = Exclude<ShowCastTabProps<TestCastMember>, { children: ReactNode }>;
+
+const createProps = (overrides: Partial<PresentationalProps> = {}): PresentationalProps => ({
+  renderedCastCount: 2,
+  matchedCastCount: 3,
+  totalCastCount: 4,
+  renderedCrewCount: 1,
+  matchedCrewCount: 2,
+  totalCrewCount: 3,
+  renderedVisibleCount: 3,
+  matchedVisibleCount: 5,
+  totalVisibleCount: 7,
+  castMediaEnriching: false,
+  isCastRefreshBusy: false,
+  castPhotoEnriching: false,
+  castLoading: false,
+  missingCastPhotoCount: 2,
+  castRefreshButtonLabel: "Refresh Credits",
+  showCancelRunButton: true,
+  castRefreshCanceling: false,
+  castRefreshCancelButtonLabel: "Cancel Run",
+  onEnrichCastMedia: vi.fn(),
+  onEnrichMissingCastPhotos: vi.fn(),
+  onRefreshShowCast: vi.fn(),
+  onCancelShowCastWorkflow: vi.fn(),
+  castCreditsRefreshNotice: null,
+  castCreditsRefreshError: null,
+  castRefreshPhaseRows: [
+    {
+      id: "credits",
+      label: "Syncing Credits...",
+      message: "IMDb credits in progress",
+      statusClassName: "border-sky-200 bg-sky-50 text-sky-700",
+      statusLabel: "Running",
+    },
+  ],
+  castRefreshPipelineRunning: true,
+  refreshNotice: null,
+  refreshError: null,
+  castPhotoEnrichNotice: null,
+  castPhotoEnrichError: null,
+  castMediaEnrichNotice: null,
+  castMediaEnrichError: null,
+  castLoadWarning: null,
+  castLoadError: null,
+  onRetryCast: vi.fn(),
+  showCreditsError: null,
+  onRetryCrew: vi.fn(),
+  showCreditsLoading: false,
+  showCreditsLoadedOnce: true,
+  showCreditsSourceUrl: "https://www.imdb.com/title/tt123/credits",
+  castRoleMembersWarningWithSnapshotAge: null,
+  onRetryCastRoleMembers: vi.fn(),
+  rolesWarningWithSnapshotAge: null,
+  onRetryRoles: vi.fn(),
+  showCastIntelligenceUnavailable: false,
+  castRoleMembersError: null,
+  rolesError: null,
+  castRoleEditorDeepLinkWarning: null,
+  castEligibilityWarning: null,
+  castRunFailedMembers: [{ personId: "p-1", name: "Jane Doe", reason: "Bravo image failed" }],
+  castFailedMembersOpen: false,
+  onToggleCastFailedMembersOpen: vi.fn(),
+  onRetryFailedCastMediaEnrich: vi.fn(),
+  castMatrixSyncLoading: false,
+  castMatrixSyncError: null,
+  castMatrixSyncResult: null,
+  castMatrixSyncScopeLabel: "Season scope: all show seasons (plus global season 0 roles).",
+  onSyncCastMatrixRoles: vi.fn(),
+  castSearchQuery: "",
+  onSetCastSearchQuery: vi.fn(),
+  castSortBy: "episodes",
+  onSetCastSortBy: vi.fn(),
+  castSortOrder: "desc",
+  onSetCastSortOrder: vi.fn(),
+  castHasImageFilter: "all",
+  onSetCastHasImageFilter: vi.fn(),
+  onClearCastFilters: vi.fn(),
+  castExactEpisodeCount: null,
+  onSetCastExactEpisodeCount: vi.fn(),
+  castMinEpisodeCount: null,
+  onSetCastMinEpisodeCount: vi.fn(),
+  castMaxEpisodeCount: null,
+  onSetCastMaxEpisodeCount: vi.fn(),
+  availableCastSeasons: [6, 5],
+  castSeasonFilters: [6],
+  onToggleCastSeasonFilter: vi.fn(),
+  castEpisodeScopeLabel: "Episode scope hint",
+  shouldShowRoleCreditEmptyState: false,
+  castUiTerminalReady: true,
+  availableCastRoleAndCreditFilters: [
+    { key: "role:housewife", label: "Housewife" },
+    { key: "credit:main", label: "Main" },
+  ],
+  castRoleAndCreditFilters: ["role:housewife"],
+  onToggleCastRoleAndCreditFilter: vi.fn(),
+  castRoleMembersLoading: false,
+  castLoadedOnce: true,
+  castRenderProgressLabel: "Rendering 2 of 3 cast members",
+  castRosterReady: true,
+  castViewMode: "gallery",
+  castGalleryColumns: 5,
+  onSetCastViewMode: vi.fn(),
+  onSetCastGalleryColumns: vi.fn(),
+  castGalleryMembers: [
+    { id: "cast-1", name: "Heather Gay" },
+    { id: "cast-2", name: "Meredith Marks" },
+    { id: "cast-3", name: "Lisa Barlow" },
+  ],
+  castCount: 3,
+  archiveFootageCount: 1,
+  visibleCastMembers: [
+    { id: "cast-1", name: "Heather Gay" },
+    { id: "cast-2", name: "Meredith Marks" },
+  ],
+  renderCastMember: (member) => <div>{member.name}</div>,
+  crewDisplaySections: [
+    {
+      title: "Producers",
+      groupedRows: [
+        {
+          personId: "crew-1",
+          personName: "Casey Allan",
+          roleLines: [{ creditId: "line-1", role: "producer", episodesLabel: "12 episodes", yearsLabel: null }],
+        },
+      ],
+    },
+  ],
+  visibleCrewSections: [
+    {
+      title: "Producers",
+      groupedRows: [
+        {
+          personId: "crew-1",
+          personName: "Casey Allan",
+          roleLines: [{ creditId: "line-1", role: "producer", episodesLabel: "12 episodes", yearsLabel: null }],
+        },
+      ],
+    },
+  ],
+  archiveFootageCast: [
+    {
+      id: "archive-1",
+      person_id: "person-archive-1",
+      full_name: "Legacy Cast",
+      cast_member_name: null,
+      photo_url: "https://example.com/archive.jpg",
+      cover_photo_url: null,
+      thumbnail_focus_x: null,
+      thumbnail_focus_y: null,
+      thumbnail_zoom: null,
+      thumbnail_crop_mode: "auto",
+      archive_episode_count: 4,
+    },
+  ],
+  getPersonOverviewHref: ({ personId }) => `/admin/trr-shows/show-1/people/${personId}/overview`,
+  ...overrides,
+});
+
+describe("ShowCastTab", () => {
+  it("preserves wrapper compatibility for child-only usage", () => {
+    render(
+      <ShowCastTab>
+        <div>Child content</div>
+      </ShowCastTab>
+    );
+
+    const tabpanel = screen.getByRole("tabpanel");
+    expect(tabpanel).toHaveAttribute("id", "show-tabpanel-cast");
+    expect(tabpanel).toHaveAttribute("aria-labelledby", "show-tab-cast");
+    expect(screen.getByText("Child content")).toBeInTheDocument();
+  });
+
+  it("renders the extracted cast tab UI and dispatches actions and filter callbacks", () => {
+    const props = createProps();
+    render(<ShowCastTab {...props} />);
+
+    expect(screen.getByText("Credits")).toBeInTheDocument();
+    expect(screen.getByText("2/3/4 cast · 1/2/3 crew · 3/5/7 visible")).toBeInTheDocument();
+    expect(screen.getByText("1. Syncing Credits...")).toBeInTheDocument();
+    expect(screen.getByText("IMDb credits in progress")).toBeInTheDocument();
+    expect(screen.getByText("Rendering 2 of 3 cast members")).toBeInTheDocument();
+    expect(screen.getByText("Heather Gay")).toBeInTheDocument();
+    expect(screen.getByText("Meredith Marks")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Casey Allan" })).toHaveAttribute(
+      "href",
+      "/admin/trr-shows/show-1/people/crew-1/overview"
+    );
+    expect(screen.getByRole("link", { name: /Legacy Cast/i })).toHaveAttribute(
+      "href",
+      "/admin/trr-shows/show-1/people/person-archive-1/overview"
+    );
+    expect(screen.getByText("4 archive footage episodes")).toBeInTheDocument();
+    expect(screen.getByText("Crew source:")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Enrich Media" }));
+    fireEvent.click(screen.getByRole("button", { name: "Enrich Missing Cast Photos (2)" }));
+    fireEvent.click(screen.getByRole("button", { name: "Refresh Credits" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel Run" }));
+    fireEvent.click(screen.getByRole("button", { name: "Show" }));
+    fireEvent.click(screen.getByRole("button", { name: "Retry failed only" }));
+    fireEvent.click(screen.getByRole("button", { name: "Sync Cast Roles (Wiki/Fandom)" }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear Filters" }));
+    fireEvent.click(screen.getByRole("button", { name: "S6" }));
+    fireEvent.click(screen.getByRole("button", { name: "Housewife" }));
+    fireEvent.click(screen.getByRole("button", { name: "List View" }));
+    fireEvent.click(screen.getByRole("button", { name: "5 per row" }));
+
+    fireEvent.change(screen.getByLabelText("Search Name"), { target: { value: "Heather" } });
+    fireEvent.change(screen.getByLabelText("Sort By"), { target: { value: "name" } });
+    fireEvent.change(screen.getByLabelText("Order"), { target: { value: "asc" } });
+    fireEvent.change(screen.getByLabelText("Has Image"), { target: { value: "yes" } });
+    fireEvent.change(screen.getByLabelText("Episode Exact"), { target: { value: "4" } });
+    fireEvent.change(screen.getByLabelText("Episode Min"), { target: { value: "2" } });
+    fireEvent.change(screen.getByLabelText("Episode Max"), { target: { value: "9" } });
+
+    expect(props.onEnrichCastMedia).toHaveBeenCalledTimes(1);
+    expect(props.onEnrichMissingCastPhotos).toHaveBeenCalledTimes(1);
+    expect(props.onRefreshShowCast).toHaveBeenCalledTimes(1);
+    expect(props.onCancelShowCastWorkflow).toHaveBeenCalledTimes(1);
+    expect(props.onToggleCastFailedMembersOpen).toHaveBeenCalledTimes(1);
+    expect(props.onRetryFailedCastMediaEnrich).toHaveBeenCalledTimes(1);
+    expect(props.onSyncCastMatrixRoles).toHaveBeenCalledTimes(1);
+    expect(props.onClearCastFilters).toHaveBeenCalledTimes(1);
+    expect(props.onToggleCastSeasonFilter).toHaveBeenCalledWith(6);
+    expect(props.onToggleCastRoleAndCreditFilter).toHaveBeenCalledWith("role:housewife");
+    expect(props.onSetCastViewMode).toHaveBeenCalledWith("list");
+    expect(props.onSetCastGalleryColumns).toHaveBeenCalledWith(5);
+    expect(props.onSetCastSearchQuery).toHaveBeenCalledWith("Heather");
+    expect(props.onSetCastSortBy).toHaveBeenCalledWith("name");
+    expect(props.onSetCastSortOrder).toHaveBeenCalledWith("asc");
+    expect(props.onSetCastHasImageFilter).toHaveBeenCalledWith("yes");
+    expect(props.onSetCastExactEpisodeCount).toHaveBeenCalledWith(4);
+    expect(props.onSetCastMinEpisodeCount).toHaveBeenCalledWith(2);
+    expect(props.onSetCastMaxEpisodeCount).toHaveBeenCalledWith(9);
+  });
+
+  it("renders loading, retry, unavailable-intelligence, and empty-state branches", () => {
+    const props = createProps({
+      castCreditsRefreshError: "Credits refresh failed",
+      castLoadWarning: "Showing last successful cast snapshot.",
+      castLoadError: "Cast endpoint failed",
+      showCreditsError: "Crew fetch failed",
+      showCreditsLoading: true,
+      showCreditsLoadedOnce: false,
+      castRoleMembersWarningWithSnapshotAge: "Showing last successful cast intelligence snapshot.",
+      rolesWarningWithSnapshotAge: "Showing last successful roles snapshot.",
+      showCastIntelligenceUnavailable: true,
+      castRoleMembersError: "Cast intelligence timeout",
+      rolesError: "Roles timeout",
+      castRoleEditorDeepLinkWarning: "Role editor deep-link is waiting for cast intelligence.",
+      castEligibilityWarning: "Links fallback is active.",
+      castRoleMembersLoading: true,
+      castLoading: true,
+      castLoadedOnce: false,
+      castGalleryMembers: [],
+      visibleCastMembers: [],
+      crewDisplaySections: [],
+      visibleCrewSections: [],
+      archiveFootageCast: [],
+      archiveFootageCount: 0,
+      castCount: 0,
+      castRosterReady: false,
+      castUiTerminalReady: false,
+      shouldShowRoleCreditEmptyState: false,
+    });
+    const { rerender } = render(<ShowCastTab {...props} />);
+
+    expect(screen.getByText("Credits refresh failed")).toHaveClass("text-red-600");
+    expect(screen.getByText("Showing last successful cast snapshot.")).toBeInTheDocument();
+    expect(screen.getByText("Cast endpoint failed")).toBeInTheDocument();
+    expect(screen.getByText("Crew fetch failed")).toBeInTheDocument();
+    expect(screen.getByText("Loading crew credits...")).toBeInTheDocument();
+    expect(screen.getByText("Refreshing cast intelligence...")).toBeInTheDocument();
+    expect(screen.getByText("Loading cast members...")).toBeInTheDocument();
+    expect(screen.getByText("Cast intelligence unavailable; showing base cast snapshot.")).toBeInTheDocument();
+    expect(screen.getByText("Cast intelligence timeout · Roles timeout")).toBeInTheDocument();
+    expect(screen.getByText("Role editor deep-link is waiting for cast intelligence.")).toBeInTheDocument();
+    expect(screen.getByText("Links fallback is active.")).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("button", { name: "Retry Cast" })[0]);
+    fireEvent.click(screen.getByRole("button", { name: "Retry Crew" }));
+    fireEvent.click(screen.getAllByRole("button", { name: "Retry" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Retry Roles" })[0]);
+    fireEvent.click(screen.getByRole("button", { name: "Retry Cast Intelligence" }));
+
+    expect(props.onRetryCast).toHaveBeenCalledTimes(1);
+    expect(props.onRetryCrew).toHaveBeenCalledTimes(1);
+    expect(props.onRetryCastRoleMembers).toHaveBeenCalledTimes(2);
+    expect(props.onRetryRoles).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <ShowCastTab
+        {...props}
+        castCreditsRefreshError={null}
+        castLoadWarning={null}
+        castLoadError={null}
+        showCreditsError={null}
+        showCreditsLoading={false}
+        showCreditsLoadedOnce={true}
+        castRoleMembersWarningWithSnapshotAge={null}
+        rolesWarningWithSnapshotAge={null}
+        showCastIntelligenceUnavailable={false}
+        castRoleMembersError={null}
+        rolesError={null}
+        castRoleMembersLoading={false}
+        castLoading={false}
+        castLoadedOnce={true}
+        castRosterReady={true}
+        castUiTerminalReady={true}
+        shouldShowRoleCreditEmptyState={true}
+      />
+    );
+    expect(screen.getByText("No cast members found for this show.")).toBeInTheDocument();
+    expect(screen.getByText("No role or credit filters available.")).toBeInTheDocument();
+
+    rerender(
+      <ShowCastTab
+        {...props}
+        castCreditsRefreshError={null}
+        castLoadWarning={null}
+        castLoadError={null}
+        showCreditsError={null}
+        showCreditsLoading={false}
+        showCreditsLoadedOnce={true}
+        castRoleMembersWarningWithSnapshotAge={null}
+        rolesWarningWithSnapshotAge={null}
+        showCastIntelligenceUnavailable={false}
+        castRoleMembersError={null}
+        rolesError={null}
+        castRoleMembersLoading={false}
+        castLoading={false}
+        castLoadedOnce={true}
+        castRosterReady={true}
+        castUiTerminalReady={true}
+        shouldShowRoleCreditEmptyState={false}
+        castCount={2}
+      />
+    );
+    expect(screen.getByText("No cast members match the selected filters.")).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/show-detail-utilities.test.ts
+++ b/apps/web/tests/show-detail-utilities.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  GalleryAssetSourceError,
+  type GalleryAssetSourceRequest,
+} from "@/lib/admin/show-page/workspace-model";
+import {
+  areNumberArraysEqual,
+  areStringArraysEqual,
+  buildAssetAutoCropPayload,
+  buildAssetAutoCropPayloadWithFallback,
+  buildProgressMessage,
+  extractBravoSocialHandle,
+  formatBravoSocialLabel,
+  formatFixed1,
+  formatGallerySourceFailure,
+  formatIsoAgeLabel,
+  formatSnapshotAgeLabel,
+  getFeaturedShowImageKind,
+  inferBravoImportImageKind,
+  inferBravoPersonUrl,
+  inferBravoShowUrl,
+  isAbortError,
+  isBravoNetworkName,
+  isCastRefreshPhaseId,
+  isHttpUrlValue,
+  isRetryableGalleryStatus,
+  looksLikeUuid,
+  normalizeBravoSocialKey,
+  normalizeGallerySourceFailure,
+  normalizeRefreshLogMessage,
+  parseGalleryAssetErrorPayload,
+  parseProgressNumber,
+  resolveStageLabel,
+  toFiniteNumber,
+  withSnapshotAgeSuffix,
+} from "@/lib/admin/show-page/show-detail-utilities";
+import type { SeasonAsset } from "@/lib/server/trr-api/trr-shows-repository";
+
+const GALLERY_SOURCE: GalleryAssetSourceRequest = {
+  id: "show",
+  label: "Show images",
+  baseUrl: "/api/admin/show-images",
+};
+
+const buildAsset = (overrides: Partial<SeasonAsset> = {}): SeasonAsset =>
+  ({
+    id: "asset-1",
+    type: "show",
+    source: "tmdb",
+    kind: "poster",
+    hosted_url: "https://cdn.example.com/asset-1.jpg",
+    width: null,
+    height: null,
+    caption: null,
+    ...overrides,
+  }) as SeasonAsset;
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("show detail utilities", () => {
+  it("preserves numeric parsing differences used by progress and display values", () => {
+    expect(parseProgressNumber(2.75)).toBe(2.75);
+    expect(parseProgressNumber(" 12.9 items")).toBe(12);
+    expect(parseProgressNumber(" ")).toBeNull();
+    expect(parseProgressNumber(Number.POSITIVE_INFINITY)).toBeNull();
+
+    expect(toFiniteNumber(" 12.9 ")).toBe(12.9);
+    expect(toFiniteNumber("12 items")).toBeNull();
+    expect(formatFixed1("12.94")).toBe("12.9");
+  });
+
+  it("keeps gallery error precedence and explicit retryability", async () => {
+    const response = new Response(
+      JSON.stringify({
+        detail: {
+          message: " upstream unavailable ",
+          code: "UPSTREAM_TIMEOUT",
+          reason: "provider_timeout",
+          retryable: false,
+        },
+      }),
+      {
+        status: 503,
+        statusText: "Service Unavailable",
+        headers: { "content-type": "application/json" },
+      }
+    );
+
+    await expect(parseGalleryAssetErrorPayload(response)).resolves.toEqual({
+      message: "upstream unavailable",
+      code: "UPSTREAM_TIMEOUT",
+      reason: "provider_timeout",
+      retryable: false,
+      detail: {
+        message: " upstream unavailable ",
+        code: "UPSTREAM_TIMEOUT",
+        reason: "provider_timeout",
+        retryable: false,
+      },
+    });
+
+    await expect(
+      parseGalleryAssetErrorPayload(
+        new Response("not json", { status: 425, statusText: "Too Early" })
+      )
+    ).resolves.toEqual({
+      message: "425 Too Early",
+      retryable: true,
+    });
+  });
+
+  it("normalizes typed and unknown gallery source failures without losing metadata", () => {
+    const typedFailure = normalizeGallerySourceFailure(
+      GALLERY_SOURCE,
+      new GalleryAssetSourceError({
+        message: "Timed out",
+        status: 504,
+        retryable: true,
+        code: "TIMEOUT",
+        reason: "upstream",
+        detail: { attempt: 2 },
+      })
+    );
+
+    expect(typedFailure).toEqual({
+      sourceId: "show",
+      label: "Show images",
+      message: "Timed out",
+      status: 504,
+      retryable: true,
+      code: "TIMEOUT",
+      reason: "upstream",
+      detail: { attempt: 2 },
+    });
+    expect(formatGallerySourceFailure(typedFailure)).toBe(
+      "Show images: Timed out (TIMEOUT), retryable"
+    );
+    expect(normalizeGallerySourceFailure(GALLERY_SOURCE, "unknown")).toEqual({
+      sourceId: "show",
+      label: "Show images",
+      message: "Failed to load gallery assets",
+      status: 500,
+      retryable: false,
+    });
+  });
+
+  it("classifies aborts and retryable statuses exactly", () => {
+    const abort = new Error("cancelled");
+    abort.name = "AbortError";
+
+    expect(isAbortError(abort)).toBe(true);
+    expect(isAbortError({ name: "AbortError" })).toBe(false);
+    expect([408, 409, 425, 429, 500].every(isRetryableGalleryStatus)).toBe(true);
+    expect(isRetryableGalleryStatus(499)).toBe(false);
+  });
+
+  it("formats ISO and snapshot ages at their boundary values", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-16T12:00:00.000Z"));
+
+    expect(formatIsoAgeLabel("2026-07-16T11:59:58.600Z")).toBe("1s ago");
+    expect(formatIsoAgeLabel("not-a-date")).toBeNull();
+    expect(formatSnapshotAgeLabel(Date.now() - 59_999)).toBe("just now");
+    expect(formatSnapshotAgeLabel(Date.now() - 60 * 60_000)).toBe("1h ago");
+    expect(formatSnapshotAgeLabel(Date.now() + 60_000)).toBe("just now");
+    expect(withSnapshotAgeSuffix("Using cached data.", Date.now() - 2 * 60_000)).toBe(
+      "Using cached data. Last successful snapshot: 2m ago."
+    );
+    expect(withSnapshotAgeSuffix(null, Date.now())).toBeNull();
+  });
+
+  it("normalizes Bravo URLs, social labels, handles, networks, and image kinds", () => {
+    expect(inferBravoShowUrl(" Watch What Happens & Live! ")).toBe(
+      "https://www.bravotv.com/watch-what-happens-and-live"
+    );
+    expect(inferBravoPersonUrl(" Andy Cohen ")).toBe(
+      "https://www.bravotv.com/people/andy-cohen"
+    );
+    expect(inferBravoPersonUrl("---")).toBeNull();
+    expect(isBravoNetworkName("Bravo TV (US)")).toBe(true);
+    expect(isBravoNetworkName("NBC")).toBe(false);
+    expect(normalizeBravoSocialKey("Twitter / X")).toBe("x");
+    expect(normalizeBravoSocialKey(" ")).toBe("link");
+    expect(formatBravoSocialLabel("fan_club")).toBe("Fan Club");
+    expect(extractBravoSocialHandle("https://instagram.com/andy/?hl=en")).toBe("@andy");
+    expect(
+      inferBravoImportImageKind({ url: "/images/key-art.jpg", alt: "Key art" })
+    ).toBe("poster");
+    expect(inferBravoImportImageKind({ url: "/images/unknown.jpg", alt: "Cast photo" })).toBe(
+      "cast"
+    );
+  });
+
+  it("normalizes stage and refresh-log messages without changing fallbacks", () => {
+    expect(resolveStageLabel("sync_cast_photos", { sync_cast_photos: "Cast Media" })).toBe(
+      "Cast Media"
+    );
+    expect(resolveStageLabel("custom_stage-name", {})).toBe("Custom Stage Name");
+    expect(resolveStageLabel(3, {})).toBeNull();
+    expect(buildProgressMessage("Cast Media", "  Fetching  ", "Working...")).toBe(
+      "Cast Media: Fetching"
+    );
+    expect(buildProgressMessage("Cast Media", "", "Working...")).toBe(
+      "Working on Cast Media..."
+    );
+    expect(
+      normalizeRefreshLogMessage(
+        "  Synced  4c0f0df0-7e69-4d39-8d22-11011752d30f   successfully  "
+      )
+    ).toBe("Synced person successfully");
+  });
+
+  it("preserves featured-kind and crop precedence with clamping and fallback", () => {
+    expect(getFeaturedShowImageKind(buildAsset({ kind: " BACKDROP " }))).toBe("backdrop");
+    expect(getFeaturedShowImageKind(buildAsset({ kind: "logo" }))).toBeNull();
+
+    expect(
+      buildAssetAutoCropPayload(
+        buildAsset({
+          thumbnail_focus_x: 120,
+          thumbnail_focus_y: -5,
+          thumbnail_zoom: 10,
+          thumbnail_crop_mode: "manual",
+          metadata: {
+            thumbnail_crop: { x: 20, y: 30, zoom: 1.5, mode: "auto" },
+          },
+        })
+      )
+    ).toEqual({ x: 100, y: 0, zoom: 4, mode: "manual" });
+    expect(
+      buildAssetAutoCropPayload(
+        buildAsset({
+          metadata: {
+            thumbnail_crop: { x: 20, y: 30, zoom: 1.5, mode: "auto" },
+          },
+        })
+      )
+    ).toEqual({ x: 20, y: 30, zoom: 1.5, mode: "auto" });
+    expect(buildAssetAutoCropPayloadWithFallback(buildAsset())).toEqual({
+      x: 50,
+      y: 32,
+      zoom: 1,
+      mode: "auto",
+      strategy: "resize_center_fallback_v1",
+    });
+  });
+
+  it("keeps array equality order-sensitive and validates stable identifiers", () => {
+    const strings = ["one", "two"];
+    expect(areStringArraysEqual(strings, strings)).toBe(true);
+    expect(areStringArraysEqual(strings, ["one", "two"])).toBe(true);
+    expect(areStringArraysEqual(strings, ["two", "one"])).toBe(false);
+    expect(areNumberArraysEqual([1, 2], [1, 2])).toBe(true);
+    expect(areNumberArraysEqual([Number.NaN], [Number.NaN])).toBe(false);
+
+    expect(looksLikeUuid("4c0f0df0-7e69-4d39-8d22-11011752d30f")).toBe(true);
+    expect(looksLikeUuid("prefix-4c0f0df0-7e69-4d39-8d22-11011752d30f")).toBe(false);
+    expect(isCastRefreshPhaseId("network_augmentation")).toBe(true);
+    expect(isCastRefreshPhaseId("unknown")).toBe(false);
+    expect(isHttpUrlValue("https://example.com/path")).toBe(true);
+    expect(isHttpUrlValue("mailto:test@example.com")).toBe(false);
+  });
+});

--- a/apps/web/tests/show-gallery-batch-preflight.test.ts
+++ b/apps/web/tests/show-gallery-batch-preflight.test.ts
@@ -4,15 +4,21 @@ import path from "node:path";
 
 describe("show gallery batch jobs preflight wiring", () => {
   it("reuses the same computed target plan for summary and submit", () => {
-    const filePath = path.resolve(
+    const routePath = path.resolve(
       __dirname,
       "../src/app/admin/trr-shows/[showId]/page.tsx"
     );
-    const contents = fs.readFileSync(filePath, "utf8");
+    const modalPath = path.resolve(
+      __dirname,
+      "../src/components/admin/ShowBatchRoleModals.tsx"
+    );
+    const route = fs.readFileSync(routePath, "utf8");
+    const modal = fs.readFileSync(modalPath, "utf8");
 
-    expect(contents).toContain("const showBatchTargetPlan = useMemo(() => {");
-    expect(contents).toContain("const showBatchPreflightSummary = useMemo(() => {");
-    expect(contents).toContain("const { targets } = showBatchTargetPlan;");
-    expect(contents).toContain("{showBatchPreflightSummary}");
+    expect(route).toContain("const showBatchTargetPlan = useMemo(() => {");
+    expect(route).toContain("const showBatchPreflightSummary = useMemo(() => {");
+    expect(route).toContain("const { targets } = showBatchTargetPlan;");
+    expect(route).toContain("preflightSummary: showBatchPreflightSummary");
+    expect(modal).toContain("{batchJobs.preflightSummary}");
   });
 });

--- a/apps/web/tests/show-gallery-section-visibility.test.ts
+++ b/apps/web/tests/show-gallery-section-visibility.test.ts
@@ -9,6 +9,12 @@ describe("show media gallery section visibility", () => {
       "../src/app/admin/trr-shows/[showId]/page.tsx"
     );
     const contents = fs.readFileSync(filePath, "utf8");
+    const assetsTabPath = path.resolve(
+      __dirname,
+      "../src/components/admin/show-tabs/ShowAssetsTab.tsx"
+    );
+    const assetsTabContents = fs.readFileSync(assetsTabPath, "utf8");
+    const renderedContents = `${contents}\n${assetsTabContents}`;
 
     expect(contents).toContain("const SHOW_GALLERY_ALLOWED_SECTIONS: AssetSectionKey[] = [");
     expect(contents).toContain("\"cast_photos\"");
@@ -16,9 +22,9 @@ describe("show media gallery section visibility", () => {
     expect(contents).toContain("\"banners\"");
     expect(contents).toContain("\"posters\"");
     expect(contents).toContain("\"backdrops\"");
-    expect(contents).not.toMatch(/<h4[^>]*>\s*Episode Stills\s*<\/h4>/);
-    expect(contents).not.toMatch(/<h4[^>]*>\s*Confessionals\s*<\/h4>/);
-    expect(contents).not.toMatch(/<h4[^>]*>\s*Reunion\s*<\/h4>/);
-    expect(contents).not.toMatch(/<h4[^>]*>\s*Intro Card\s*<\/h4>/);
+    expect(renderedContents).not.toMatch(/<h4[^>]*>\s*Episode Stills\s*<\/h4>/);
+    expect(renderedContents).not.toMatch(/<h4[^>]*>\s*Confessionals\s*<\/h4>/);
+    expect(renderedContents).not.toMatch(/<h4[^>]*>\s*Reunion\s*<\/h4>/);
+    expect(renderedContents).not.toMatch(/<h4[^>]*>\s*Intro Card\s*<\/h4>/);
   });
 });

--- a/apps/web/tests/show-health-center-modal.test.tsx
+++ b/apps/web/tests/show-health-center-modal.test.tsx
@@ -1,0 +1,198 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import ShowHealthCenterModal, {
+  type ShowHealthCenterModalProps,
+} from "@/components/admin/ShowHealthCenterModal";
+
+vi.mock("@/components/admin/AdminModal", () => ({
+  default: ({
+    ariaLabel,
+    children,
+    isOpen,
+  }: {
+    ariaLabel?: string;
+    children: ReactNode;
+    isOpen: boolean;
+  }) => (isOpen ? <div role="dialog" aria-label={ariaLabel}>{children}</div> : null),
+}));
+
+type ShowHealthCenterModalOverrides = {
+  dialog?: Partial<ShowHealthCenterModalProps["dialog"]>;
+  contentHealthItems?: ShowHealthCenterModalProps["contentHealthItems"];
+  pipeline?: Partial<ShowHealthCenterModalProps["pipeline"]>;
+  operationsInboxItems?: ShowHealthCenterModalProps["operationsInboxItems"];
+  refreshLog?: Partial<ShowHealthCenterModalProps["refreshLog"]>;
+};
+
+const createProps = (
+  overrides: ShowHealthCenterModalOverrides = {}
+): ShowHealthCenterModalProps => {
+  const props: ShowHealthCenterModalProps = {
+    dialog: {
+      open: true,
+      onClose: vi.fn(),
+      onRun: vi.fn(),
+      runDisabled: false,
+      runButtonLabel: "Run",
+      notice: "Refresh ready",
+      error: null,
+      progressContent: <div data-testid="refresh-progress">Refreshing details</div>,
+    },
+    contentHealthItems: [
+      {
+        key: "show",
+        label: "Show",
+        countLabel: "Info set",
+        status: "ready",
+        onClick: vi.fn(),
+      },
+      {
+        key: "cast",
+        label: "Credits",
+        countLabel: "0",
+        status: "missing",
+        onClick: vi.fn(),
+      },
+    ],
+    pipeline: {
+      steps: [
+        {
+          topic: {
+            key: "show_core",
+            label: "SHOW CORE",
+            description: "Details and setup",
+          },
+          status: "failed",
+          latest: {
+            id: "entry-1",
+            at: "2026-07-16T03:30:00.000Z",
+            category: "Refresh",
+            message: "Catalog Sync: waiting on upstream",
+            current: 1,
+            total: 2,
+          },
+          executionOwner: "remote_worker",
+          parentOperationId: "op-1",
+        },
+      ],
+      onRetryStep: vi.fn(),
+    },
+    operationsInboxItems: [
+      {
+        id: "op-1",
+        title: "Sync prerequisites missing",
+        detail: "Run Show Info first.",
+        onClick: vi.fn(),
+      },
+    ],
+    refreshLog: {
+      hasEntries: true,
+      topicGroups: [
+        {
+          topic: {
+            key: "show_core",
+            label: "SHOW CORE",
+            description: "Details and setup",
+          },
+          entries: [
+            {
+              id: "entry-1",
+              at: "2026-07-16T03:30:00.000Z",
+              category: "Refresh",
+              message: "Catalog Sync: waiting on upstream",
+              current: 1,
+              total: 2,
+            },
+          ],
+          entriesForView: [
+            {
+              id: "entry-1",
+              at: "2026-07-16T03:30:00.000Z",
+              category: "Refresh",
+              message: "Catalog Sync: waiting on upstream",
+              current: 1,
+              total: 2,
+            },
+          ],
+          latest: {
+            id: "entry-1",
+            at: "2026-07-16T03:30:00.000Z",
+            category: "Refresh",
+            message: "Catalog Sync: waiting on upstream",
+            current: 1,
+            total: 2,
+          },
+          status: "failed",
+        },
+        {
+          topic: {
+            key: "bravo",
+            label: "BRAVO",
+            description: "Bravo sync",
+          },
+          entries: [],
+          entriesForView: [],
+          latest: null,
+          status: "done",
+        },
+      ],
+    },
+  };
+
+  return {
+    ...props,
+    ...overrides,
+    dialog: { ...props.dialog, ...overrides.dialog },
+    pipeline: { ...props.pipeline, ...overrides.pipeline },
+    refreshLog: { ...props.refreshLog, ...overrides.refreshLog },
+    contentHealthItems: overrides.contentHealthItems ?? props.contentHealthItems,
+    operationsInboxItems: overrides.operationsInboxItems ?? props.operationsInboxItems,
+  };
+};
+
+describe("ShowHealthCenterModal", () => {
+  it("renders the health center sections and dispatches route-owned callbacks", () => {
+    const props = createProps();
+
+    render(<ShowHealthCenterModal {...props} />);
+
+    expect(screen.getByRole("dialog", { name: "Health Center" })).toBeInTheDocument();
+    expect(screen.getByTestId("refresh-progress")).toHaveTextContent("Refreshing details");
+    expect(screen.getByText("Content Health")).toBeInTheDocument();
+    expect(screen.getByText("Sync Pipeline")).toBeInTheDocument();
+    expect(screen.getByText("Operations Inbox")).toBeInTheDocument();
+    expect(screen.getByText("Refresh Log")).toBeInTheDocument();
+    expect(screen.getByText("BRAVO: Done ✔️")).toBeInTheDocument();
+    expect(screen.getByText("(Modal)")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    fireEvent.click(screen.getByRole("button", { name: "Show Ready Info set" }));
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    fireEvent.click(screen.getByRole("button", { name: "Sync prerequisites missing Run Show Info first." }));
+
+    expect(props.dialog.onRun).toHaveBeenCalledOnce();
+    expect(props.dialog.onClose).toHaveBeenCalledOnce();
+    expect(props.contentHealthItems[0]?.onClick).toHaveBeenCalledOnce();
+    expect(props.pipeline.onRetryStep).toHaveBeenCalledWith("show_core", "op-1");
+    expect(props.operationsInboxItems[0]?.onClick).toHaveBeenCalledOnce();
+  });
+
+  it("preserves the empty inbox and refresh-log branches", () => {
+    render(
+      <ShowHealthCenterModal
+        {...createProps({
+          dialog: { notice: null },
+          operationsInboxItems: [],
+          refreshLog: { hasEntries: false },
+        })}
+      />
+    );
+
+    expect(screen.getByText("No blocking tasks.")).toBeInTheDocument();
+    expect(screen.getByText("No refresh activity yet.")).toBeInTheDocument();
+    expect(screen.queryByText("BRAVO: Done ✔️")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/show-link-badges.test.tsx
+++ b/apps/web/tests/show-link-badges.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  PersonSourceLogo,
+  SocialHandlePill,
+  SourceBadge,
+} from "@/components/admin/ShowLinkBadges";
+import type { EntityLink, ShowSocialLinkPill } from "@/lib/admin/show-page/workspace-model";
+
+const socialLink: EntityLink = {
+  id: "social-1",
+  show_id: "show-1",
+  entity_type: "show",
+  entity_id: "show-1",
+  season_number: 0,
+  link_group: "social",
+  link_kind: "instagram",
+  label: "@rhoslc",
+  url: "https://instagram.com/rhoslc",
+  status: "approved",
+  confidence: null,
+  source: null,
+  metadata: null,
+  created_at: null,
+  updated_at: null,
+};
+
+describe("show link badges", () => {
+  it("keeps a text alternative alongside a decorative social icon", () => {
+    render(<SourceBadge kind="instagram" label="Instagram" />);
+
+    expect(screen.getByText("Instagram")).toHaveClass("sr-only");
+  });
+
+  it("renders branded source tokens without changing their visible labels", () => {
+    const { rerender } = render(<PersonSourceLogo sourceKey="imdb" />);
+    expect(screen.getByText("IMDb")).toBeInTheDocument();
+
+    rerender(<SourceBadge kind="google_news" label="Google News" />);
+    expect(screen.getByText("News")).toBeInTheDocument();
+  });
+
+  it("preserves the external-link and accessible-name contract for social pills", () => {
+    const pill: ShowSocialLinkPill = {
+      id: socialLink.id,
+      sourceKind: "instagram",
+      sourceLabel: "Instagram",
+      text: "@rhoslc",
+      url: socialLink.url,
+      link: socialLink,
+    };
+
+    render(<SocialHandlePill pill={pill} />);
+
+    const anchor = screen.getByRole("link", { name: "@rhoslc" });
+    expect(anchor).toHaveAttribute("href", "https://instagram.com/rhoslc");
+    expect(anchor).toHaveAttribute("target", "_blank");
+    expect(anchor).toHaveAttribute("rel", "noopener noreferrer");
+    expect(anchor).toHaveAttribute("title", "https://instagram.com/rhoslc");
+  });
+});

--- a/apps/web/tests/show-link-display-model.test.ts
+++ b/apps/web/tests/show-link-display-model.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyPersonLinkSource,
+  extractSocialHandleFromUrl,
+  getApprovedLinkText,
+  getCastMemberLinkText,
+  getLinkSourceBadgeKind,
+  getLinkSourceLabel,
+  getShowPageLinkTitle,
+  getSourceBadgeOrder,
+  isRenderableSeasonPageLink,
+  isRenderableShowPageLink,
+  normalizeEntityLinkStatus,
+  normalizeSocialHandleValue,
+  pickPreferredPersonSourceLink,
+  resolveCastMemberNameFromLinks,
+  toSocialPlatformIconKey,
+  usesBrandIconOnly,
+} from "@/lib/admin/show-page/show-link-display-model";
+import type { EntityLink } from "@/lib/admin/show-page/workspace-model";
+
+const makeLink = (overrides: Partial<EntityLink> = {}): EntityLink => ({
+  id: "link-1",
+  show_id: "show-1",
+  entity_type: "show",
+  entity_id: "show-1",
+  season_number: 0,
+  link_group: "official",
+  link_kind: "official_page",
+  label: null,
+  url: "https://example.com/shows/test-show",
+  status: "approved",
+  confidence: null,
+  source: null,
+  metadata: null,
+  created_at: null,
+  updated_at: null,
+  ...overrides,
+});
+
+describe("show link display model", () => {
+  it("normalizes statuses and classifies person-link source aliases", () => {
+    expect(normalizeEntityLinkStatus(" APPROVED ")).toBe("approved");
+    expect(normalizeEntityLinkStatus("rejected")).toBe("rejected");
+    expect(normalizeEntityLinkStatus("unexpected")).toBe("pending");
+
+    expect(classifyPersonLinkSource("bravo_profile")).toBe("bravo");
+    expect(classifyPersonLinkSource("imdb_name")).toBe("imdb");
+    expect(classifyPersonLinkSource("wikia")).toBe("fandom");
+    expect(classifyPersonLinkSource("instagram")).toBeNull();
+  });
+
+  it("selects person sources by status, canonical kind, then stable label order", () => {
+    const rejected = makeLink({
+      id: "rejected",
+      link_kind: "wikipedia",
+      label: "A",
+      status: "rejected",
+    });
+    const approvedAlias = makeLink({
+      id: "approved-alias",
+      link_kind: "wikipedia_mirror",
+      label: "A",
+    });
+    const approvedCanonical = makeLink({
+      id: "approved-canonical",
+      link_kind: "wikipedia",
+      label: "Z",
+    });
+    const links = [rejected, approvedAlias, approvedCanonical];
+
+    expect(pickPreferredPersonSourceLink("wikipedia", links)?.id).toBe("approved-canonical");
+    expect(links.map((link) => link.id)).toEqual([
+      "rejected",
+      "approved-alias",
+      "approved-canonical",
+    ]);
+    expect(pickPreferredPersonSourceLink("wikipedia", [])).toBeNull();
+  });
+
+  it("maps source badges, labels, and ordering without losing site metadata", () => {
+    const bravo = makeLink({
+      url: "https://www.bravotv.com/the-real-housewives-of-salt-lake-city",
+    });
+    const fandom = makeLink({
+      link_kind: "wikia",
+      url: "https://real-housewives.fandom.com/wiki/The_Real_Housewives_of_Salt_Lake_City",
+      metadata: { site_title: "The Real Housewives Wiki" },
+    });
+    const twitter = makeLink({ link_group: "social", link_kind: "twitter" });
+    const googleNews = makeLink({ link_kind: "google_news_url" });
+
+    expect(getLinkSourceBadgeKind(bravo)).toBe("bravo");
+    expect(getLinkSourceLabel(bravo)).toBe("Bravo TV");
+    expect(getLinkSourceBadgeKind(fandom)).toBe("fandom");
+    expect(getLinkSourceLabel(fandom)).toBe("The Real Housewives Wiki");
+    expect(getLinkSourceBadgeKind(twitter)).toBe("x");
+    expect(getLinkSourceBadgeKind(googleNews)).toBe("google_news");
+    expect(getSourceBadgeOrder("official")).toBeLessThan(getSourceBadgeOrder("instagram"));
+  });
+
+  it("normalizes encoded social handles and uses them as approved-link text", () => {
+    const instagram = makeLink({
+      link_group: "social",
+      link_kind: "instagram",
+      label: "Instagram profile",
+      url: "https://instagram.com/%40andy.cohen/",
+    });
+
+    expect(normalizeSocialHandleValue(" profile: @andy.cohen ")).toBe("@andy.cohen");
+    expect(normalizeSocialHandleValue("%40bravotv")).toBe("@bravotv");
+    expect(extractSocialHandleFromUrl(instagram.url)).toBe("@andy.cohen");
+    expect(extractSocialHandleFromUrl("not a url")).toBeNull();
+    expect(getApprovedLinkText(instagram, "Andy Cohen")).toBe("@andy.cohen");
+    expect(getCastMemberLinkText(instagram, "Andy Cohen")).toBe("@andy.cohen");
+  });
+
+  it("keeps canonical show titles while using fandom page titles for cast links", () => {
+    const fandom = makeLink({
+      entity_type: "person",
+      entity_id: "person-1",
+      link_kind: "fandom",
+      label: "Angie Katsanevas/Gallery",
+      url: "https://real-housewives.fandom.com/wiki/Angie_Katsanevas/Gallery",
+      metadata: { page_title: "Angie Katsanevas" },
+    });
+    const official = makeLink({
+      label: "Legacy label",
+      url: "https://example.com/shows/rhoslc",
+    });
+
+    expect(getShowPageLinkTitle(official, "The Real Housewives of Salt Lake City")).toBe(
+      "The Real Housewives of Salt Lake City"
+    );
+    expect(getCastMemberLinkText(fandom, "Angie K.")).toBe("Angie Katsanevas");
+  });
+
+  it("resolves cast names by roster override, approval, and source priority", () => {
+    const pendingBravo = makeLink({
+      id: "bravo",
+      entity_type: "person",
+      entity_id: "person-1",
+      link_kind: "bravo_profile",
+      label: "Bravo Name",
+      status: "pending",
+    });
+    const approvedWikipedia = makeLink({
+      id: "wikipedia",
+      entity_type: "person",
+      entity_id: "person-1",
+      link_kind: "wikipedia",
+      label: "Wikipedia Name",
+    });
+
+    expect(resolveCastMemberNameFromLinks([pendingBravo, approvedWikipedia], null)).toBe(
+      "Wikipedia Name"
+    );
+    expect(resolveCastMemberNameFromLinks([approvedWikipedia], " Roster Name ")).toBe(
+      "Roster Name"
+    );
+    expect(resolveCastMemberNameFromLinks([], null)).toBe("Unknown Person");
+  });
+
+  it("only renders approved, page-shaped show and season links in their intended sections", () => {
+    const showPage = makeLink();
+    const seasonPage = makeLink({
+      entity_type: "season",
+      entity_id: "season-2",
+      season_number: 2,
+      link_kind: "fandom",
+      url: "https://real-housewives.fandom.com/wiki/The_Real_Housewives_of_Salt_Lake_City/Season_2",
+    });
+
+    expect(isRenderableShowPageLink(showPage)).toBe(true);
+    expect(isRenderableShowPageLink(makeLink({ status: "pending" }))).toBe(false);
+    expect(
+      isRenderableShowPageLink(
+        makeLink({ link_group: "social", link_kind: "instagram", url: "https://instagram.com/rhoslc" })
+      )
+    ).toBe(false);
+    expect(isRenderableShowPageLink(makeLink({ url: "https://example.com/" }))).toBe(false);
+
+    expect(isRenderableSeasonPageLink(seasonPage)).toBe(true);
+    expect(
+      isRenderableSeasonPageLink(
+        makeLink({
+          entity_type: "season",
+          season_number: 2,
+          link_kind: "network_blog",
+        })
+      )
+    ).toBe(false);
+    expect(
+      isRenderableSeasonPageLink(
+        makeLink({
+          entity_type: "season",
+          season_number: 2,
+          link_kind: "fandom",
+          url: "https://real-housewives.fandom.com/",
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("maps social brands to shared icon keys and brand-only presentation", () => {
+    expect(toSocialPlatformIconKey("x")).toBe("twitter");
+    expect(toSocialPlatformIconKey("instagram")).toBe("instagram");
+    expect(toSocialPlatformIconKey("official")).toBeNull();
+    expect(usesBrandIconOnly("imdb")).toBe(true);
+    expect(usesBrandIconOnly("instagram")).toBe(true);
+    expect(usesBrandIconOnly("fandom")).toBe(false);
+  });
+});

--- a/apps/web/tests/show-links-discovery-modal-wiring.test.ts
+++ b/apps/web/tests/show-links-discovery-modal-wiring.test.ts
@@ -1,0 +1,37 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) =>
+  fs.readFileSync(path.resolve(__dirname, relativePath), "utf8");
+
+describe("show links discovery modal wiring", () => {
+  const route = readSource("../src/app/admin/trr-shows/[showId]/page.tsx");
+  const modal = readSource("../src/components/admin/ShowLinksDiscoveryModal.tsx");
+
+  it("keeps links discovery orchestration in the route", () => {
+    expect(route).toMatch(/<ShowLinksDiscoveryModal/);
+    expect(route).toMatch(/const refreshShowLinks = useCallback/);
+    expect(route).toMatch(/const cancelShowLinksRefresh = useCallback/);
+    expect(route).toMatch(/await adminStream\(targetPath/);
+    expect(route).toMatch(/upsertAdminOperationSession/);
+    expect(route).toMatch(/getAutoResumableAdminOperationSession/);
+    expect(route).toMatch(/void refreshShowLinks\(\{ resumeOnly: true \}\)/);
+    expect(route).toMatch(/onRefresh: refreshShowLinks/);
+    expect(route).toMatch(/linksRefreshTimeoutMessage/);
+    expect(route).not.toMatch(/ariaLabel="Links discovery progress"/);
+    expect(modal).toMatch(/ariaLabel="Links discovery progress"/);
+  });
+
+  it("keeps the extracted modal presentational and preserves neighboring packets", () => {
+    expect(modal).not.toMatch(/\bfetch\s*\(/);
+    expect(modal).not.toMatch(/adminStream|upsertAdminOperationSession/);
+    expect(modal).not.toMatch(/useEffect|useLayoutEffect|useState|useReducer|useMemo/);
+    expect(modal).not.toMatch(/["'`]\/api\//);
+    expect(route).toMatch(/<ShowHealthCenterModal/);
+    expect(route).toMatch(/<ShowBravoSyncModal/);
+    expect(modal).toMatch(/dialog\.error \|\| dialog\.completionNotice \|\| dialog\.notice/);
+    expect(modal).toMatch(/execution\.owner === "remote_worker"/);
+    expect(modal).toMatch(/progress\.hasResult/);
+  });
+});

--- a/apps/web/tests/show-links-discovery-modal.test.tsx
+++ b/apps/web/tests/show-links-discovery-modal.test.tsx
@@ -1,0 +1,189 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import ShowLinksDiscoveryModal, {
+  type ShowLinksDiscoveryModalProps,
+} from "@/components/admin/ShowLinksDiscoveryModal";
+
+vi.mock("@/components/admin/AdminModal", () => ({
+  default: ({
+    ariaLabel,
+    children,
+    isOpen,
+  }: {
+    ariaLabel?: string;
+    children: ReactNode;
+    isOpen: boolean;
+  }) => (isOpen ? <div role="dialog" aria-label={ariaLabel}>{children}</div> : null),
+}));
+
+type ModalOverrides = {
+  dialog?: Partial<ShowLinksDiscoveryModalProps["dialog"]>;
+  cancellation?: Partial<ShowLinksDiscoveryModalProps["cancellation"]>;
+  execution?: Partial<ShowLinksDiscoveryModalProps["execution"]>;
+  progress?: Partial<ShowLinksDiscoveryModalProps["progress"]>;
+};
+
+const createProps = (overrides: ModalOverrides = {}): ShowLinksDiscoveryModalProps => {
+  const props: ShowLinksDiscoveryModalProps = {
+    dialog: {
+      open: true,
+      onClose: vi.fn(),
+      status: "running",
+      error: null,
+      notice: "Discovery is running",
+      completionNotice: "Links refresh complete. 3 discovered.",
+    },
+    cancellation: {
+      visible: true,
+      pending: false,
+      buttonLabel: "Cancel job",
+      onCancel: vi.fn(),
+    },
+    execution: {
+      runLabel: "Run abcdef12",
+      operationLabel: "Op fedcba98",
+      owner: "remote_worker",
+      backend: "modal",
+      mode: "remote",
+    },
+    progress: {
+      summary: {
+        currentStage: "people",
+        stageLabel: "Cast Member Pages",
+        headline: "Checking cast links",
+        detail: "Discovery still running...",
+        budgetLabel: "Budget exhausted: candidate limit",
+        elapsedLabel: "12s elapsed",
+        stageElapsedLabel: "4s in this stage",
+        targetSummary: "1/2 Cast Members",
+        stageProgressLabel: "1/2 processed · 3 links found",
+        currentTargetLabel: "Lisa Vanderpump",
+        metrics: [{ label: "Discovered", value: "3" }],
+        heartbeat: false,
+        terminal: false,
+        stalled: true,
+        stalledReason: "worker heartbeat overdue",
+        lastProgressAt: "2026-07-16T03:30:00.000Z",
+        lastStageTransitionAt: "2026-07-16T03:29:00.000Z",
+      },
+      refreshing: true,
+      timeoutMessage: "Cast discovery reached its time budget.",
+      stalled: true,
+      stalledReason: "worker heartbeat overdue",
+      lastUpdateLabel: "2s ago",
+      lastStageChangeLabel: "8s ago",
+      validatedSourceCounts: [{ key: "bravotv", label: "BravoTV", count: 3 }],
+      deletedSourceCounts: [{ key: "fandom", label: "Fandom", count: 1 }],
+      hasResult: true,
+    },
+  };
+
+  return {
+    dialog: { ...props.dialog, ...overrides.dialog },
+    cancellation: { ...props.cancellation, ...overrides.cancellation },
+    execution: { ...props.execution, ...overrides.execution },
+    progress: { ...props.progress, ...overrides.progress },
+  };
+};
+
+describe("ShowLinksDiscoveryModal", () => {
+  it("renders progress details and dispatches route-owned callbacks", () => {
+    const props = createProps();
+
+    render(<ShowLinksDiscoveryModal {...props} />);
+
+    expect(screen.getByRole("dialog", { name: "Links discovery progress" })).toBeInTheDocument();
+    expect(screen.getByText("Links Discovery")).toBeInTheDocument();
+    expect(screen.getByText("running")).toHaveClass("border-blue-200");
+    expect(screen.getByText("Run abcdef12")).toBeInTheDocument();
+    expect(screen.getByText("Op fedcba98")).toBeInTheDocument();
+    expect(screen.getByText("remote worker")).toBeInTheDocument();
+    expect(screen.getByText("modal · mode remote")).toBeInTheDocument();
+    expect(screen.getByText("Cast Member Pages")).toBeInTheDocument();
+    expect(screen.getByText("Checking cast links")).toBeInTheDocument();
+    expect(screen.getByText("Checking:")).toHaveTextContent("Lisa Vanderpump");
+    expect(screen.getByText("Discovered: 3")).toBeInTheDocument();
+    expect(screen.getByText("Cast discovery reached its time budget.")).toBeInTheDocument();
+    expect(screen.getByText("Stalled")).toHaveClass("text-amber-700");
+    expect(screen.getByText("Last stream update: 2s ago")).toBeInTheDocument();
+    expect(screen.getByText("Last stage change: 8s ago")).toBeInTheDocument();
+    expect(screen.getByText("BravoTV: 3")).toBeInTheDocument();
+    expect(screen.getByText("Fandom: 1")).toBeInTheDocument();
+    expect(screen.getByText("BravoTV: 3 live")).toBeInTheDocument();
+    expect(screen.getByText("Fandom: 1 invalid deleted")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel job" }));
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(props.cancellation.onCancel).toHaveBeenCalledOnce();
+    expect(props.dialog.onClose).toHaveBeenCalledOnce();
+  });
+
+  it("preserves message precedence, terminal status styling, and pending cancellation", () => {
+    const props = createProps({
+      dialog: {
+        status: "failed",
+        error: "Discovery failed",
+        completionNotice: "Completion should be hidden",
+        notice: "Notice should be hidden",
+      },
+      cancellation: { pending: true, buttonLabel: "Cancelling..." },
+      progress: { hasResult: false },
+    });
+
+    render(<ShowLinksDiscoveryModal {...props} />);
+
+    expect(screen.getByText("Discovery failed")).toHaveClass("text-red-600");
+    expect(screen.queryByText("Completion should be hidden")).not.toBeInTheDocument();
+    expect(screen.queryByText("Notice should be hidden")).not.toBeInTheDocument();
+    expect(screen.getByText("failed")).toHaveClass("border-rose-200");
+    expect(screen.getByRole("button", { name: "Cancelling..." })).toBeDisabled();
+  });
+
+  it("preserves the queued empty state and hides cancellation when unavailable", () => {
+    render(
+      <ShowLinksDiscoveryModal
+        {...createProps({
+          dialog: { status: null, error: null, completionNotice: null, notice: null },
+          cancellation: { visible: false },
+          execution: {
+            runLabel: "Pending",
+            operationLabel: "Pending",
+            owner: null,
+            backend: null,
+            mode: null,
+          },
+          progress: {
+            summary: null,
+            refreshing: false,
+            timeoutMessage: null,
+            stalled: false,
+            stalledReason: null,
+            lastUpdateLabel: null,
+            lastStageChangeLabel: null,
+            validatedSourceCounts: [],
+            deletedSourceCounts: [],
+            hasResult: false,
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByText("queued")).toHaveClass("border-zinc-200");
+    expect(screen.getByText("Awaiting worker")).toBeInTheDocument();
+    expect(screen.getByText("Start a links refresh to see live updates here.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /cancel/i })).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ["completed", "border-emerald-200"],
+    ["cancelled", "border-rose-200"],
+    ["cancelling", "border-zinc-200"],
+  ] as const)("preserves the %s status badge", (status, className) => {
+    render(<ShowLinksDiscoveryModal {...createProps({ dialog: { status } })} />);
+
+    expect(screen.getByText(status)).toHaveClass(className);
+  });
+});

--- a/apps/web/tests/show-news-tab-google-wiring.test.ts
+++ b/apps/web/tests/show-news-tab-google-wiring.test.ts
@@ -35,7 +35,17 @@ describe("show news tab google wiring", () => {
 
   it("routes Google News configuration through the normal show-links UI", () => {
     const filePath = path.resolve(__dirname, "../src/app/admin/trr-shows/[showId]/page.tsx");
-    const contents = fs.readFileSync(filePath, "utf8");
+    const settingsPath = path.resolve(
+      __dirname,
+      "../src/components/admin/show-tabs/ShowSettingsTab.tsx",
+    );
+    const linkModelPath = path.resolve(
+      __dirname,
+      "../src/lib/admin/show-page/show-link-display-model.ts",
+    );
+    const contents = [filePath, settingsPath, linkModelPath]
+      .map((sourcePath) => fs.readFileSync(sourcePath, "utf8"))
+      .join("\n");
 
     expect(contents).toMatch(/Google News topic URLs/);
     expect(contents).toMatch(/news\.google\.com\/topics/);

--- a/apps/web/tests/show-overview-tab.test.tsx
+++ b/apps/web/tests/show-overview-tab.test.tsx
@@ -1,0 +1,262 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import ShowOverviewTab, {
+  type ShowOverviewTabProps,
+} from "@/components/admin/show-tabs/ShowOverviewTab";
+import type { OverviewSeasonCoverageRow } from "@/lib/admin/show-page/overview-display";
+
+type TestExternalLink = {
+  id: string;
+  url: string;
+  title: string;
+};
+
+type TestSocialHandle = {
+  id: string;
+  label: string;
+};
+
+type TestProps = ShowOverviewTabProps<
+  TestExternalLink,
+  TestSocialHandle,
+  OverviewSeasonCoverageRow
+>;
+
+const createProps = (overrides: Partial<TestProps> = {}): TestProps => ({
+  show: {
+    id: "show-1",
+    name: "The Real Housewives of Salt Lake City",
+    description: "A representative show description.",
+    premiere_date: "2020-11-11",
+    external_ids: { wikidata_id: "Q104833725" },
+    tmdb_id: 110381,
+    imdb_id: "tt11363282",
+    derived_external_links: {
+      justwatch_url: "https://www.themoviedb.org/tv/110381/watch?locale=US",
+    },
+    genres: ["Reality"],
+    tags: ["Bravo"],
+  },
+  nickname: "RHOSLC",
+  alternativeNamesText: "RHOSLC\nSalt Lake City Housewives",
+  refreshCenterButtonLabel: "Open Refresh Center",
+  refreshNotice: null,
+  refreshError: null,
+  refreshing: true,
+  refreshProgress: {
+    stage: "show_core",
+    message: "Refreshing details",
+    current: 1,
+    total: 2,
+  },
+  renderRefreshProgress: ({ show, message }) =>
+    show ? <div data-testid="refresh-progress">{message}</div> : null,
+  detailsNotice: null,
+  detailsError: null,
+  externalIdLinks: [
+    {
+      id: "external-1",
+      url: "https://example.com/show",
+      title: "Official show page",
+    },
+  ],
+  getExternalIdLinkTitle: (link) => link.title,
+  renderExternalIdLinkBadge: (link) => <span>{`badge:${link.id}`}</span>,
+  socialHandleLinks: [{ id: "social-1", label: "@rhoslc" }],
+  renderSocialHandlePill: (pill) => <span>{pill.label}</span>,
+  redditLoading: false,
+  redditError: null,
+  redditGroups: [
+    {
+      key: "SHOW",
+      label: "SHOW",
+      communities: [
+        {
+          id: "community-1",
+          subreddit: "RHOSLC",
+          displayName: "RHOSLC Community",
+          assignedFlairs: ["Episode Discussion"],
+          postFlairs: [],
+        },
+      ],
+    },
+  ],
+  getRedditCommunityHref: (community) => `/admin/social/reddit/${community.subreddit}`,
+  seasonUrlCoverageRows: [
+    {
+      seasonNumber: 6,
+      links: [
+        {
+          id: "season-link-1",
+          url: "https://example.com/season-6",
+          sourceKind: "fandom",
+          sourceLabel: "Fandom",
+          iconUrl: null,
+          linkTitle: "Season Six",
+        },
+      ],
+    },
+  ],
+  renderSeasonCoverageBadge: (link) => <span>{`season-badge:${link.id}`}</span>,
+  networks: ["Bravo"],
+  watchProviderRegions: [
+    {
+      regionCode: "US",
+      regionLabel: "United States",
+      stream: ["Peacock"],
+      free: ["Bravo TV"],
+      buyRent: ["Apple TV"],
+    },
+    {
+      regionCode: "GB",
+      regionLabel: "United Kingdom",
+      stream: ["Hayu"],
+      free: [],
+      buyRent: [],
+    },
+  ],
+  watchProviderRegionOptions: [
+    { regionCode: "US", regionLabel: "United States" },
+    { regionCode: "GB", regionLabel: "United Kingdom" },
+  ],
+  selectedAvailabilityRegion: {
+    regionCode: "US",
+    regionLabel: "United States",
+    stream: ["Peacock"],
+    free: ["Bravo TV"],
+    buyRent: ["Apple TV"],
+  },
+  fallbackWatchProviders: [],
+  isCovered: true,
+  coverageLoading: false,
+  coverageError: null,
+  onOpenSettings: vi.fn(),
+  onOpenRefreshLog: vi.fn(),
+  onSelectAvailabilityRegion: vi.fn(),
+  onAddToCoveredShows: vi.fn(),
+  onRemoveFromCoveredShows: vi.fn(),
+  ...overrides,
+});
+
+describe("ShowOverviewTab", () => {
+  it("keeps the details tabpanel semantics and renders representative overview data", () => {
+    render(<ShowOverviewTab {...createProps()} />);
+
+    const tabpanel = screen.getByRole("tabpanel");
+    expect(tabpanel).toHaveAttribute("id", "show-tabpanel-details");
+    expect(tabpanel).toHaveAttribute("aria-labelledby", "show-tab-details");
+    expect(screen.getByText("Details and Metadata")).toBeInTheDocument();
+    expect(screen.getByText("The Real Housewives of Salt Lake City")).toBeInTheDocument();
+    expect(screen.getByText("RHOSLC", { exact: true })).toBeInTheDocument();
+    expect(screen.getByText("Salt Lake City Housewives", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("A representative show description.")).toBeInTheDocument();
+    expect(screen.getByText("Official show page")).toBeInTheDocument();
+    expect(screen.getByText("badge:external-1")).toBeInTheDocument();
+    expect(screen.getByText("@rhoslc")).toBeInTheDocument();
+    expect(screen.getByText("RHOSLC Community")).toBeInTheDocument();
+    expect(screen.getByText("Episode Discussion")).toBeInTheDocument();
+    expect(screen.getByText("season-badge:season-link-1")).toBeInTheDocument();
+    expect(screen.getByText("Peacock")).toBeInTheDocument();
+    expect(screen.getByText("Bravo TV")).toBeInTheDocument();
+    expect(screen.getByText("Apple TV")).toBeInTheDocument();
+    expect(screen.getByText("show-1")).toBeInTheDocument();
+    expect(screen.getByTestId("refresh-progress")).toHaveTextContent("Refreshing details");
+  });
+
+  it("dispatches settings, refresh, region, and coverage callbacks and preserves disabled coverage state", () => {
+    const onOpenSettings = vi.fn();
+    const onOpenRefreshLog = vi.fn();
+    const onSelectAvailabilityRegion = vi.fn();
+    const onRemoveFromCoveredShows = vi.fn();
+    const onAddToCoveredShows = vi.fn();
+    const props = createProps({
+      onOpenSettings,
+      onOpenRefreshLog,
+      onSelectAvailabilityRegion,
+      onRemoveFromCoveredShows,
+      onAddToCoveredShows,
+    });
+    const { rerender } = render(<ShowOverviewTab {...props} />);
+
+    for (const button of screen.getAllByRole("button", { name: "Open Settings" })) {
+      fireEvent.click(button);
+    }
+    expect(onOpenSettings).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Refresh Center" }));
+    expect(onOpenRefreshLog).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Availability region" }), {
+      target: { value: "GB" },
+    });
+    expect(onSelectAvailabilityRegion).toHaveBeenCalledWith("GB");
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove from Shows" }));
+    expect(onRemoveFromCoveredShows).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <ShowOverviewTab
+        {...props}
+        isCovered={false}
+        coverageLoading={true}
+      />
+    );
+    const disabledCoverageButton = screen.getByRole("button", { name: "..." });
+    expect(disabledCoverageButton).toBeDisabled();
+    fireEvent.click(disabledCoverageButton);
+    expect(onAddToCoveredShows).not.toHaveBeenCalled();
+  });
+
+  it("renders Reddit loading, error, and empty branches", () => {
+    const props = createProps({ redditLoading: true, redditGroups: [] });
+    const { rerender } = render(<ShowOverviewTab {...props} />);
+
+    expect(screen.getByText("Loading Reddit communities...")).toBeInTheDocument();
+
+    rerender(
+      <ShowOverviewTab
+        {...props}
+        redditLoading={false}
+        redditError="Reddit is unavailable"
+      />
+    );
+    expect(screen.getByText("Reddit is unavailable")).toHaveClass("text-red-600");
+
+    rerender(
+      <ShowOverviewTab
+        {...props}
+        redditLoading={false}
+        redditError={null}
+      />
+    );
+    expect(
+      screen.getByText("No relevant Reddit communities configured for this show.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders season and watch empty and fallback branches", () => {
+    const props = createProps({
+      seasonUrlCoverageRows: [],
+      watchProviderRegions: [],
+      watchProviderRegionOptions: [],
+      selectedAvailabilityRegion: null,
+      fallbackWatchProviders: [],
+    });
+    const { rerender } = render(<ShowOverviewTab {...props} />);
+
+    expect(screen.getByText("No seasons available for URL coverage yet.")).toBeInTheDocument();
+    expect(screen.getByText("No streaming providers on this record.")).toBeInTheDocument();
+    expect(screen.getByText("Typed TMDb availability is unavailable for this show.")).toBeInTheDocument();
+
+    rerender(
+      <ShowOverviewTab
+        {...props}
+        seasonUrlCoverageRows={[{ seasonNumber: 6, links: [] }]}
+        fallbackWatchProviders={["Hayu"]}
+      />
+    );
+    expect(screen.getByText("No validated season-scoped URLs discovered.")).toBeInTheDocument();
+    expect(screen.getByText("Hayu")).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/show-refresh-health-center-wiring.test.ts
+++ b/apps/web/tests/show-refresh-health-center-wiring.test.ts
@@ -4,11 +4,13 @@ import path from "node:path";
 
 describe("show refresh health center wiring", () => {
   const showPagePath = path.resolve(__dirname, "../src/app/admin/trr-shows/[showId]/page.tsx");
+  const modalPath = path.resolve(__dirname, "../src/components/admin/ShowHealthCenterModal.tsx");
   const seasonPagePath = path.resolve(
     __dirname,
     "../src/app/admin/trr-shows/[showId]/seasons/[seasonNumber]/page.tsx"
   );
   const showPage = fs.readFileSync(showPagePath, "utf8");
+  const modal = fs.readFileSync(modalPath, "utf8");
   const seasonPage = fs.readFileSync(seasonPagePath, "utf8");
 
   it("routes show refresh through the health center modal with unified backend stages", () => {
@@ -25,10 +27,30 @@ describe("show refresh health center wiring", () => {
     expect(showPage).toMatch(/"Open Refresh Center"/);
     expect(showPage).toMatch(/"View Refresh Center"/);
     expect(showPage).toMatch(/onRefresh=\{\(\) => setRefreshLogOpen\(true\)\}/);
-    expect(showPage).toMatch(/preserveScrollPosition=\{true\}/);
-    expect(showPage).not.toMatch(/onClick=\{\(\) => void refreshAllShowData\(\)\}/);
-    expect(showPage).toMatch(/Refresh Links/);
+    expect(showPage).toMatch(/<ShowHealthCenterModal/);
+    expect(showPage).toMatch(/onRun: \(\) => \{/);
+    expect(showPage).toMatch(/captureHealthCenterScrollPosition\(\);/);
+    expect(showPage).toMatch(/void refreshAllShowData\(\);/);
+    expect(showPage).not.toMatch(/ariaLabel="Health Center"/);
+    expect(modal).toMatch(/ariaLabel="Health Center"/);
+    expect(modal).toMatch(/preserveScrollPosition=\{true\}/);
+    expect(modal).toMatch(/Content Health, Sync Pipeline, Operations Inbox, and Refresh Log\./);
+    expect(modal).toMatch(/Sync Pipeline/);
     expect(showPage).not.toMatch(/Show Gallery/);
+  });
+
+  it("keeps the health center component presentational and leaves retry plus operations callbacks in the route", () => {
+    expect(showPage).toMatch(/pipeline=\{\{\s*steps: pipelineSteps,\s*onRetryStep: retryRefreshTarget,/s);
+    expect(showPage).toMatch(/operationsInboxItems=\{operationsInboxItems\}/);
+    expect(showPage).toMatch(
+      /refreshLog=\{\{\s*hasEntries: refreshLogEntries\.length > 0,\s*topicGroups: refreshLogTopicGroups,\s*\}\}/s
+    );
+    expect(showPage).toMatch(/progressContent: \(\s*<RefreshProgressBar/s);
+    expect(modal).not.toMatch(/\bfetch\s*\(/);
+    expect(modal).not.toMatch(/useEffect|useLayoutEffect|useState|useReducer/);
+    expect(modal).not.toMatch(/["'`]\/api\//);
+    expect(modal).toMatch(/pipeline\.onRetryStep\(step\.topic\.key, step\.parentOperationId!\)/);
+    expect(modal).toMatch(/operationsInboxItems\.map/);
   });
 
   it("surfaces remote worker events and refetches credits payload after cast refresh", () => {

--- a/apps/web/tests/show-settings-tab-wiring.test.ts
+++ b/apps/web/tests/show-settings-tab-wiring.test.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("show detail settings tab extraction wiring", () => {
+  const routePath = path.resolve(__dirname, "../src/app/admin/trr-shows/[showId]/page.tsx");
+  const tabPath = path.resolve(__dirname, "../src/components/admin/show-tabs/ShowSettingsTab.tsx");
+  const badgesPath = path.resolve(__dirname, "../src/components/admin/ShowLinkBadges.tsx");
+  const linkModelPath = path.resolve(
+    __dirname,
+    "../src/lib/admin/show-page/show-link-display-model.ts"
+  );
+  const routeContents = fs.readFileSync(routePath, "utf8");
+  const tabContents = fs.readFileSync(tabPath, "utf8");
+  const badgesContents = fs.readFileSync(badgesPath, "utf8");
+  const linkModelContents = fs.readFileSync(linkModelPath, "utf8");
+
+  it("keeps the settings UI in the lazy tab module", () => {
+    expect(routeContents).toMatch(
+      /dynamic\(\(\) => import\("@\/components\/admin\/show-tabs\/ShowSettingsTab"\)/
+    );
+    expect(routeContents).toMatch(/<ShowSettingsTab[\s\S]*header=\{\{/);
+    expect(tabContents).toMatch(/Editable Metadata/);
+    expect(tabContents).toMatch(/Role Catalog/);
+    expect(tabContents).toMatch(/Paste one or more URLs or handles/);
+    expect(tabContents).toMatch(/Loading Reddit communities/);
+    expect(routeContents).not.toMatch(/Editable Metadata/);
+    expect(routeContents).not.toMatch(/Role Catalog/);
+    expect(routeContents).not.toMatch(/Paste one or more URLs or handles/);
+  });
+
+  it("keeps route-owned state and mutations outside the tab implementation", () => {
+    expect(routeContents).toMatch(/const syncShowScopedBrandLogos = useCallback/);
+    expect(routeContents).toMatch(/const fetchShowLinks = useCallback/);
+    expect(routeContents).toMatch(/const createShowRole = useCallback/);
+    expect(routeContents).toMatch(/from "@\/components\/admin\/ShowLinkBadges"/);
+    expect(routeContents).toMatch(/from "@\/lib\/admin\/show-page\/show-link-display-model"/);
+    expect(badgesContents).toMatch(/export function SourceBadge/);
+    expect(linkModelContents).toMatch(/export const getLinkSourceBadgeKind/);
+    expect(routeContents).not.toMatch(/function InlineEditableLinkUrl/);
+    expect(routeContents).not.toMatch(/const settingsLinkSections = useMemo/);
+    expect(tabContents).toMatch(/function InlineEditableLinkUrl/);
+    expect(tabContents).not.toMatch(/ShowBrandLogosSection|FeaturedLogoDrawer|\/api\/admin/);
+  });
+
+  it("preserves the settings tabpanel contract", () => {
+    expect(tabContents).toMatch(/id="show-tabpanel-settings"/);
+    expect(tabContents).toMatch(/role="tabpanel"/);
+    expect(tabContents).toMatch(/aria-labelledby="show-tab-settings"/);
+  });
+});

--- a/apps/web/tests/show-settings-tab.test.tsx
+++ b/apps/web/tests/show-settings-tab.test.tsx
@@ -1,0 +1,318 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import ShowSettingsTab, {
+  type ShowSettingsTabProps,
+} from "@/components/admin/show-tabs/ShowSettingsTab";
+
+type TestRole = {
+  id: string;
+  name: string;
+  is_active: boolean;
+};
+
+type TestLink = {
+  id: string;
+  url: string;
+};
+
+type TestSourceKind = "instagram" | "fandom" | "imdb";
+
+type PresentationalProps = Exclude<
+  ShowSettingsTabProps<TestRole, TestLink, TestSourceKind>,
+  { children: ReactNode }
+>;
+
+const createProps = (overrides: Partial<PresentationalProps> = {}): PresentationalProps => ({
+  header: {
+    showLogoSyncing: false,
+    refreshCenterButtonLabel: "Open Refresh Center",
+    onSyncShowLogoTargets: vi.fn(),
+    onOpenRefreshLog: vi.fn(),
+  },
+  status: {
+    linksError: null,
+    linksNotice: null,
+    linksLoadTimedOut: false,
+    rolesError: null,
+    rolesWarning: null,
+    rolesLoadTimedOut: false,
+    showLogoSyncError: null,
+    showLogoSyncNotice: null,
+    onRetryLinks: vi.fn(),
+    onRetryRoles: vi.fn(),
+  },
+  metadata: {
+    form: {
+      displayName: "Test Show",
+      nickname: "Test Show",
+      altNamesText: "TS",
+      description: "A test show.",
+      premiereDate: "2025-01-02",
+      imdbId: "tt123",
+      tmdbId: "456",
+      tvdbId: "tvdb-7",
+      wikidataId: "Q8",
+      tvRageId: "rage-9",
+      genresText: "Reality",
+      networksText: "Bravo",
+      streamingProvidersText: "Peacock",
+      tagsText: "competition",
+    },
+    editing: true,
+    saving: false,
+    notice: null,
+    error: null,
+    onChangeField: vi.fn(),
+    onStartEdit: vi.fn(),
+    onCancelEdit: vi.fn(),
+    onSave: vi.fn(),
+  },
+  roles: {
+    newRoleName: "Friend",
+    loading: false,
+    rows: [{ id: "role-1", name: "Housewife", is_active: true }],
+    onNewRoleNameChange: vi.fn(),
+    onCreate: vi.fn(),
+    onRename: vi.fn(),
+    onToggleActive: vi.fn(),
+  },
+  links: {
+    showIsBravo: true,
+    refreshing: false,
+    bulkInput: "https://example.com/new",
+    bulkSaving: false,
+    loading: false,
+    totalCount: 4,
+    eligibleCastLoading: false,
+    eligibleCastLoadedOnce: true,
+    savingLinkIds: {},
+    socialLinks: [
+      {
+        id: "social-1",
+        sourceKind: "instagram",
+        sourceLabel: "Instagram",
+        text: "@testshow",
+        url: "https://instagram.com/testshow",
+        link: { id: "social-link-1", url: "https://instagram.com/testshow" },
+      },
+    ],
+    showPageLinks: [{ id: "page-1", url: "https://example.com/show" }],
+    seasonUrlCoverageRows: [
+      {
+        seasonNumber: 2,
+        links: [
+          {
+            id: "season-link-1",
+            url: "https://example.com/season-2",
+            sourceKind: "fandom",
+            sourceLabel: "Fandom",
+            iconUrl: null,
+            linkTitle: "Season Two",
+          },
+        ],
+      },
+    ],
+    castMemberLinkCoverageCards: [
+      {
+        personId: "person-1",
+        personName: "Jane Doe",
+        avatarUrl: null,
+        seasons: [2],
+        approvedLinkCount: 1,
+        approvedLinks: [
+          {
+            id: "person-link-1",
+            sourceKind: "imdb",
+            sourceLabel: "IMDb",
+            text: "Jane Doe",
+            label: "IMDb",
+            url: "https://imdb.com/name/nm1",
+            iconUrl: null,
+            link: { id: "person-link-1", url: "https://imdb.com/name/nm1" },
+          },
+        ],
+        missingSources: [
+          {
+            key: "fandom",
+            label: "Fandom",
+            state: "missing",
+            url: null,
+            link: null,
+          },
+        ],
+      },
+    ],
+    onRefresh: vi.fn(),
+    onBulkInputChange: vi.fn(),
+    onAdd: vi.fn(),
+    onUpdateUrl: vi.fn(async () => undefined),
+    onDelete: vi.fn(),
+  },
+  reddit: {
+    loading: false,
+    error: null,
+    groups: [
+      {
+        key: "SHOW",
+        label: "SHOW",
+        communities: [
+          {
+            id: "reddit-1",
+            subreddit: "TestShow",
+            displayName: "Test Show Community",
+            assignedFlairs: ["Episode Discussion"],
+            postFlairs: ["News"],
+          },
+        ],
+      },
+    ],
+    getCommunityHref: (community) => `/admin/social/reddit/${community.subreddit}`,
+  },
+  getShowPageLinkTitle: () => "Official show page",
+  renderShowPageLinkBadge: (link) => <span>{`page-badge:${link.id}`}</span>,
+  renderSourceBadge: ({ kind }) => <span>{`badge:${kind}`}</span>,
+  usesBrandIconOnly: () => true,
+  ...overrides,
+});
+
+describe("ShowSettingsTab", () => {
+  it("preserves child-wrapper tabpanel compatibility", () => {
+    render(
+      <ShowSettingsTab>
+        <div>Child content</div>
+      </ShowSettingsTab>
+    );
+
+    const tabpanel = screen.getByRole("tabpanel");
+    expect(tabpanel).toHaveAttribute("id", "show-tabpanel-settings");
+    expect(tabpanel).toHaveAttribute("aria-labelledby", "show-tab-settings");
+    expect(screen.getByText("Child content")).toBeInTheDocument();
+  });
+
+  it("renders settings data and dispatches metadata, role, link, and header actions", () => {
+    const props = createProps();
+    render(<ShowSettingsTab {...props} />);
+
+    expect(screen.getByRole("heading", { name: "Settings" })).toBeInTheDocument();
+    expect(screen.getAllByDisplayValue("Test Show")[0]).not.toBeDisabled();
+    expect(screen.getByText("test-show")).toBeInTheDocument();
+    expect(screen.getByText("Housewife")).toBeInTheDocument();
+    expect(screen.getByText("@testshow")).toBeInTheDocument();
+    expect(screen.getByText("Official show page")).toBeInTheDocument();
+    expect(screen.getByText("Season 2")).toBeInTheDocument();
+    expect(screen.getAllByText("Jane Doe")).toHaveLength(2);
+    expect(screen.getByText("Test Show Community")).toBeInTheDocument();
+    expect(screen.getByText("Cast Member Pages")).toBeInTheDocument();
+    expect(screen.getByText(/BravoTV, Fandom/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Sync Show Logo Targets" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open Refresh Center" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    fireEvent.change(screen.getByDisplayValue("A test show."), {
+      target: { value: "Updated description" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Housewife"), {
+      target: { value: "Guest" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add Role" }));
+    fireEvent.click(screen.getByRole("button", { name: "Rename" }));
+    fireEvent.click(screen.getByRole("button", { name: "Deactivate" }));
+    fireEvent.click(screen.getByRole("button", { name: "Refresh Links" }));
+    fireEvent.change(screen.getByPlaceholderText(/thetraitors\.fandom\.com/), {
+      target: { value: "https://example.com/updated" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add Link(s)" }));
+    fireEvent.click(screen.getAllByRole("button", { name: "Delete" })[0]);
+
+    expect(props.header.onSyncShowLogoTargets).toHaveBeenCalledTimes(1);
+    expect(props.header.onOpenRefreshLog).toHaveBeenCalledTimes(1);
+    expect(props.metadata.onCancelEdit).toHaveBeenCalledTimes(1);
+    expect(props.metadata.onSave).toHaveBeenCalledTimes(1);
+    expect(props.metadata.onChangeField).toHaveBeenCalledWith("description", "Updated description");
+    expect(props.roles.onNewRoleNameChange).toHaveBeenCalledWith("Guest");
+    expect(props.roles.onCreate).toHaveBeenCalledTimes(1);
+    expect(props.roles.onRename).toHaveBeenCalledWith(props.roles.rows[0]);
+    expect(props.roles.onToggleActive).toHaveBeenCalledWith(props.roles.rows[0]);
+    expect(props.links.onRefresh).toHaveBeenCalledTimes(1);
+    expect(props.links.onBulkInputChange).toHaveBeenCalledWith("https://example.com/updated");
+    expect(props.links.onAdd).toHaveBeenCalledTimes(1);
+    expect(props.links.onDelete).toHaveBeenCalledWith("social-link-1");
+    expect(screen.getByRole("link", { name: "Open Community" })).toHaveAttribute(
+      "href",
+      "/admin/social/reddit/TestShow"
+    );
+  });
+
+  it("preserves timeout retries and loading, error, and empty branches", () => {
+    const props = createProps({
+      status: {
+        ...createProps().status,
+        linksError: "Links timed out",
+        linksLoadTimedOut: true,
+        rolesError: "Roles timed out",
+        rolesLoadTimedOut: true,
+      },
+      metadata: {
+        ...createProps().metadata,
+        editing: false,
+        error: "Metadata save failed",
+      },
+      roles: {
+        ...createProps().roles,
+        rows: [],
+      },
+      links: {
+        ...createProps().links,
+        loading: true,
+        totalCount: 0,
+        socialLinks: [],
+        showPageLinks: [],
+        seasonUrlCoverageRows: [],
+        castMemberLinkCoverageCards: [],
+      },
+      reddit: {
+        ...createProps().reddit,
+        loading: true,
+        groups: [],
+      },
+    });
+    const { rerender } = render(<ShowSettingsTab {...props} />);
+
+    expect(screen.getByText("Links timed out")).toHaveClass("text-amber-700");
+    expect(screen.getByText("Metadata save failed")).toHaveClass("text-red-600");
+    expect(screen.getByText("No roles configured yet.")).toBeInTheDocument();
+    expect(screen.getByText("Loading links...")).toBeInTheDocument();
+    expect(screen.getByText("Loading Reddit communities...")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry links" }));
+    fireEvent.click(screen.getByRole("button", { name: "Retry roles" }));
+    expect(props.status.onRetryLinks).toHaveBeenCalledTimes(1);
+    expect(props.status.onRetryRoles).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <ShowSettingsTab
+        {...props}
+        status={{ ...props.status, linksError: null, rolesError: null }}
+        links={{ ...props.links, loading: false }}
+        reddit={{ ...props.reddit, loading: false, error: "Reddit unavailable" }}
+      />
+    );
+
+    expect(screen.getByText("No links yet. Run discovery to populate this list.")).toBeInTheDocument();
+    expect(screen.getByText("Reddit unavailable")).toHaveClass("text-red-600");
+
+    rerender(
+      <ShowSettingsTab
+        {...props}
+        status={{ ...props.status, linksError: null, rolesError: null }}
+        links={{ ...props.links, loading: false }}
+        reddit={{ ...props.reddit, loading: false, error: null }}
+      />
+    );
+    expect(
+      screen.getByText("No relevant Reddit communities configured for this show.")
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/show-workspace-model.test.ts
+++ b/apps/web/tests/show-workspace-model.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GalleryAssetSourceError,
+  buildSeasonEpisodeSummary,
+  buildSeasonEpisodeSummaryMap,
+  getMeaningfulShowCreditsRoles,
+  groupShowCrewRows,
+  normalizeErrorMessage,
+  normalizeShowCreditsCastRoster,
+  type ShowCrewCreditRow,
+  type TrrSeason,
+} from "@/lib/admin/show-page/workspace-model";
+
+const buildSeason = (overrides: Partial<TrrSeason> = {}): TrrSeason => ({
+  id: "season-1",
+  show_id: "show-1",
+  season_number: 1,
+  name: "Season 1",
+  title: null,
+  overview: null,
+  air_date: null,
+  url_original_poster: null,
+  tmdb_season_id: null,
+  ...overrides,
+});
+
+const buildCrewRow = (
+  overrides: Partial<ShowCrewCreditRow> = {}
+): ShowCrewCreditRow => ({
+  credit_id: "credit-1",
+  person_id: "person-1",
+  person_name: "Alex Example",
+  role: "Producer",
+  billing_order: null,
+  source_type: null,
+  episode_count: null,
+  episodes_label: null,
+  years_label: null,
+  imdb_name_id: null,
+  display_order: null,
+  ...overrides,
+});
+
+describe("show workspace model", () => {
+  it("preserves the season summary precedence and null behavior", () => {
+    expect(buildSeasonEpisodeSummary(buildSeason())).toBeNull();
+
+    expect(
+      buildSeasonEpisodeSummary(
+        buildSeason({
+          episode_count: 10,
+          episode_airdate_count: 8,
+          premiere_date: "2025-01-02",
+          air_date: "2025-01-03",
+          first_episode_air_date: "2025-01-01",
+          last_episode_air_date: "2025-03-01",
+        })
+      )
+    ).toEqual({
+      count: 10,
+      premiereDate: "2025-01-01",
+      finaleDate: "2025-03-01",
+    });
+  });
+
+  it("maps only seasons with summary data", () => {
+    expect(
+      buildSeasonEpisodeSummaryMap([
+        buildSeason(),
+        buildSeason({ id: "season-2", season_number: 2, episode_airdate_count: 7 }),
+      ])
+    ).toEqual({
+      "season-2": {
+        count: 7,
+        premiereDate: null,
+        finaleDate: null,
+      },
+    });
+  });
+
+  it("normalizes nested and list error payloads without changing precedence", () => {
+    expect(normalizeErrorMessage([" first ", { detail: "second" }, null])).toBe(
+      "first; second"
+    );
+    expect(
+      normalizeErrorMessage({ error: "preferred", detail: "fallback", message: "last" })
+    ).toBe("preferred");
+    expect(normalizeErrorMessage("   ")).toBeNull();
+  });
+
+  it("normalizes credits cast rows and drops rows without a person id", () => {
+    expect(
+      normalizeShowCreditsCastRoster([
+        null,
+        { person_name: "Missing id" },
+        {
+          person_id: " person-1 ",
+          person_name: "Alex Example",
+          roles: ["Host", "", 5],
+          photo_url: "https://example.com/photo.jpg",
+          total_episodes: 12,
+          archive_episodes: 3,
+          latest_season: 4,
+          season_numbers: [1, 2, Number.NaN, "3"],
+        },
+      ])
+    ).toEqual([
+      expect.objectContaining({
+        id: "person-1",
+        person_id: "person-1",
+        full_name: "Alex Example",
+        cast_member_name: "Alex Example",
+        role: "Host",
+        roles: ["Host"],
+        total_episodes: 12,
+        archive_episode_count: 3,
+        latest_season: 4,
+        seasons_appeared: [1, 2],
+      }),
+    ]);
+  });
+
+  it("filters generic self roles but keeps meaningful credits", () => {
+    expect(
+      getMeaningfulShowCreditsRoles([
+        " Cast ",
+        "Self",
+        "Self - Guest",
+        "Self/Host",
+        " Executive Producer ",
+        "",
+      ])
+    ).toEqual(["Executive Producer"]);
+  });
+
+  it("groups crew rows in first-seen order and falls back to credit ids", () => {
+    const grouped = groupShowCrewRows([
+      buildCrewRow(),
+      buildCrewRow({ credit_id: "credit-2", role: "Writer" }),
+      buildCrewRow({ credit_id: "credit-3", person_id: "", person_name: "Unknown" }),
+    ]);
+
+    expect(grouped.map((row) => row.person_id)).toEqual(["person-1", "credit-3"]);
+    expect(grouped[0]?.role_lines.map((row) => row.role)).toEqual(["Producer", "Writer"]);
+  });
+
+  it("retains gallery source error metadata", () => {
+    const error = new GalleryAssetSourceError({
+      message: "source unavailable",
+      status: 503,
+      retryable: true,
+      code: "UPSTREAM_TIMEOUT",
+      reason: "timeout",
+      detail: { source: "bravo" },
+    });
+
+    expect(error).toMatchObject({
+      name: "GalleryAssetSourceError",
+      message: "source unavailable",
+      status: 503,
+      retryable: true,
+      code: "UPSTREAM_TIMEOUT",
+      reason: "timeout",
+      detail: { source: "bravo" },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- extract the admin show workspace into focused tabs, modals, display models, and utilities
- preserve the complete import/behavior/test closure across all 47 audited paths
- add focused UI, wiring, model, and utility coverage

## Validation passing

- exact 47-path audited scope with canonical source-byte parity
- 30 focused Vitest files / 116 tests
- focused ESLint without errors
- full Web CI
- CodeRabbit and Vercel preview checks
- `git diff --check`
- staged Gitleaks scan

## Draft blocker

Browser acceptance at `https://admin.trr.localhost` remains required for this user-visible refactor.

No backend, API-v2 consumer, package, lockfile, Graphify, Vercel-guard, or font paths are included.
